### PR TITLE
Add string escape/unescape operations

### DIFF
--- a/src/js/config/Categories.js
+++ b/src/js/config/Categories.js
@@ -167,6 +167,8 @@ var Categories = [
             "Parse UNIX file permissions",
             "Swap endianness",
             "Parse colour code",
+            "Escape String",
+            "Unescape String",
         ]
     },
     {

--- a/src/js/config/OperationConfig.js
+++ b/src/js/config/OperationConfig.js
@@ -2952,5 +2952,19 @@ var OperationConfig = {
                 value: Cipher.SUBS_CIPHERTEXT
             }
         ]
-    }
+    },
+    "Escape String": {
+        description: "Escapes a string so that it can be embedded in another. For example, <code>Don't stop me now</code> becomes <code>Don\\'t stop me now</code>.",
+        run: String_.run_escape,
+        input_type: "string",
+        output_type: "string",
+        args: []
+    },
+    "Unescape String": {
+        description: "Unescapes a string that was embedded inside another so that it can be used in it's own right. For example, <code>Don\\'t stop me now</code> becomes <code>Don't stop me now</code>.",
+        run: String_.run_unescape,
+        input_type: "string",
+        output_type: "string",
+        args: []
+    },
 };

--- a/src/js/operations/String.js
+++ b/src/js/operations/String.js
@@ -1,0 +1,67 @@
+/**
+ * String operations.
+ * Namespace is appended with an underscore to prevent overwriting the global String object.
+ *
+ * @author Vel0x
+ * @namespace
+ */
+var String_ = {
+
+    /**
+     * @constant
+     * @default
+     */
+    REPLACEMENTS: [
+        {"escaped": "\\\\", "unescaped":"\\"}, // Must be first
+        {"escaped": "\\'", "unescaped":"'"},
+        {"escaped": "\\\"", "unescaped":"\""},
+        {"escaped": "\\n", "unescaped":"\n"},
+        {"escaped": "\\r", "unescaped":"\r"},
+    ],
+    
+    /**
+     * Escapes a string for embedding in another string.
+     *
+     * Example: "Don't do that" -> "Don\'t do that"
+     *
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run_escape: function(input, args) {
+        return String_._replace_by_keys(input, "unescaped", "escaped")
+    },
+    
+    /**
+     * Unescapes a string that was part of another string
+     *
+     * Example: "Don\'t do that" -> "Don't do that"
+     *
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run_unescape: function(input, args) {
+        return String_._replace_by_keys(input, "escaped", "unescaped")
+    },
+    
+    /**
+     * Replaces all matching tokens in REPLACEMENTS with the correction. The 
+     * ordering is determined by the pattern_key and the replacement_key.
+     *
+     * @param {string} input
+     * @param {string} pattern_key
+     * @param {string} replacement_key
+     * @returns {string}
+     */
+    _replace_by_keys: function(input, pattern_key, replacement_key) {
+        var output = input;
+        var replacementsLength = String_.REPLACEMENTS.length;
+        for (var i = 0; i < replacementsLength; i++) {
+            var replacement = String_.REPLACEMENTS[i];
+            output = output.split(replacement[pattern_key]).join(replacement[replacement_key]);
+        }
+        return output
+    },
+    
+};


### PR DESCRIPTION
These operations are useful for taking the contents of a string, and making it
suitable for use as a stand alone string. For example, in an IDE you might see
a string which is represented as: `"Say \"Hello\""`. The escaped double quotes
are shown to make it clear that they do not end the string, despite the fact
that they are not truly part of the string. In order to get the raw string, you
would need to copy this, then manually remove the backslashes. The new
String_.run_unescape operation does this automatically.

The String_.run_escape is the inverse. It allows you to take a string such as 
`Say "Hello"`, and paste it between two quotes without having to manually 
escape it.

The "Parse escaped string" operation is similar, but only operates on new line 
characters. This works on newlines, backslashes, single and double quotes. 