### PR TITLE
'Encode NetBIOS Name' and 'Decode NetBIOS Name' operations

### DIFF
--- a/src/js/config/Categories.js
+++ b/src/js/config/Categories.js
@@ -131,6 +131,8 @@ var Categories = [
             "Format MAC addresses",
             "Change IP format",
             "Group IP addresses",
+            "Encode NetBIOS Name",
+            "Decode NetBIOS Name",
         ]
     },
     {

--- a/src/js/config/OperationConfig.js
+++ b/src/js/config/OperationConfig.js
@@ -1536,6 +1536,32 @@ var OperationConfig = {
             }
         ]
     },
+    "Encode NetBIOS Name": {
+        description: "NetBIOS names as seen across the client interface to NetBIOS are exactly 16 bytes long. Within the NetBIOS-over-TCP protocols, a longer representation is used.<br><br>There are two levels of encoding. The first level maps a NetBIOS name into a domain system name.  The second level maps the domain system name into the 'compressed' representation required for interaction with the domain name system.<br><br>This operation carries out the first level of encoding. See RFC 1001 for full details.",
+        run: NetBIOS.runEncodeName,
+        inputType: "byteArray",
+        outputType: "byteArray",
+        args: [
+            {
+                name: "Offset",
+                type: "number",
+                value: NetBIOS.OFFSET
+            }
+        ]
+    },
+    "Decode NetBIOS Name": {
+        description: "NetBIOS names as seen across the client interface to NetBIOS are exactly 16 bytes long. Within the NetBIOS-over-TCP protocols, a longer representation is used.<br><br>There are two levels of encoding. The first level maps a NetBIOS name into a domain system name.  The second level maps the domain system name into the 'compressed' representation required for interaction with the domain name system.<br><br>This operation decodes the first level of encoding. See RFC 1001 for full details.",
+        run: NetBIOS.runDecodeName,
+        inputType: "byteArray",
+        outputType: "byteArray",
+        args: [
+            {
+                name: "Offset",
+                type: "number",
+                value: NetBIOS.OFFSET
+            }
+        ]
+    },
     "Offset checker": {
         description: "Compares multiple inputs (separated by the specified delimiter) and highlights matching characters which appear at the same position in all samples.",
         run: StrUtils.runOffsetChecker,

--- a/src/js/operations/NetBIOS.js
+++ b/src/js/operations/NetBIOS.js
@@ -1,0 +1,57 @@
+/**
+ * NetBIOS operations.
+ *
+ * @author n1474335 [n1474335@gmail.com]
+ * @copyright Crown Copyright 2017
+ * @license Apache-2.0
+ *
+ * @namespace
+ */
+var NetBIOS = {
+
+    /**
+     * @constant
+     * @default
+     */
+    OFFSET: 65,
+
+    /**
+     * Encode NetBIOS Name operation.
+     *
+     * @param {byteArray} input
+     * @param {Object[]} args
+     * @returns {byteArray}
+     */
+    runEncodeName: function(input, args) {
+        var output = [],
+            offset = args[0];
+
+        for (var i = 0; i < input.length; i++) {
+            output.push((input[i] >> 4) + offset);
+            output.push((input[i] & 0xf) + offset);
+        }
+
+        return output;
+    },
+
+
+    /**
+     * Decode NetBIOS Name operation.
+     *
+     * @param {byteArray} input
+     * @param {Object[]} args
+     * @returns {byteArray}
+     */
+    runDecodeName: function(input, args) {
+        var output = [],
+            offset = args[0];
+
+        for (var i = 0; i < input.length; i += 2) {
+            output.push(((input[i] - offset) << 4) |
+                        ((input[i + 1] - offset) & 0xf));
+        }
+
+        return output;
+    },
+
+};


### PR DESCRIPTION
Operations to carry out first level encoding and decoding of NetBIOS names, [as per RFC 1001](https://tools.ietf.org/html/rfc1001#section-14.1). Note that the example in the RFC appears to be incorrect.

Comments welcome.