### PR TITLE
Add crypt base64 format

### DIFF
--- a/src/js/operations/Base64.js
+++ b/src/js/operations/Base64.js
@@ -31,6 +31,7 @@ var Base64 = {
         {name: "Xxencoding: +-0-9A-Za-z", value: "+\\-0-9A-Za-z"},
         {name: "BinHex: !-,-0-689@A-NP-VX-Z[`a-fh-mp-r", value: "!-,-0-689@A-NP-VX-Z[`a-fh-mp-r"},
         {name: "ROT13: N-ZA-Mn-za-m0-9+/=", value: "N-ZA-Mn-za-m0-9+/="},
+        {name: "UNIX crypt: ./0-9A-Za-z", value: "./0-9A-Za-z"},
     ],
 
     /**


### PR DESCRIPTION
This is used by `crypt()` (e.g. in `/etc/shadow`).


(Would be nice to have a `crypt()` ingredient too, since the crypt algorithm is based on applying hashes many times over and is not simple)

http://www.vidarholen.net/contents/blog/?p=32