### PR TITLE
Fix "Fork, Conditional Jump, Encodings" test and fix the "Return" operation.

### DIFF
--- a/src/js/core/FlowControl.js
+++ b/src/js/core/FlowControl.js
@@ -201,7 +201,7 @@ var FlowControl = {
      * @returns {Object} The updated state of the recipe.
      */
     runReturn: function(state) {
-        state.progress = state.opList.length;
+        state.progress = state.opList.length - 1;
         return state;
     },
 

--- a/test/tests/operations/FlowControl.js
+++ b/test/tests/operations/FlowControl.js
@@ -54,7 +54,7 @@ TestRegister.addTests([
     },
     {
         name: "Fork, Conditional Jump, Encodings",
-        input: "Some data with a 1 in it\nSome data with a 2 in it",
+        input: "Some data with a 1 in it\nSome data with a 2 in it\n",
         expectedOutput: "U29tZSBkYXRhIHdpdGggYSAxIGluIGl0\n53 6f 6d 65 20 64 61 74 61 20 77 69 74 68 20 61 20 32 20 69 6e 20 69 74\n",
         recipeConfig: [
             {"op":"Fork", "args":["\\n", "\\n", false]},


### PR DESCRIPTION
The return operation was setting `state.progress` to the length of the recipe.

Under async this is incorrect behaviour because after any flow control operation the Recipe executes `state.progress + 1`, and then at the beginning of the recursed `Recipe.execute` checks the length and returns if `currentStep === recipe.opList.length`

Return now sets `state.progress` equal to `state.opList.length - 1`.

This bug could instead have been fixed by changing finish condition from `currentStep === recipe.opList.length` to `currentStep >= recipe.opList.length` to prevent this class of bugs in the future. I'll leave that decision to @n1474335.

Additionally there was a type in the test "Fork, Conditional Jump, Encodings" which was just a missing newline in the input which was required to match the output.

Screenshot of tests passing
![image](https://cloud.githubusercontent.com/assets/1482692/23580280/29010fb6-00cc-11e7-8d60-7045d17bb18b.png)


