### PR TITLE
Add download button for displayFilesAsHTML files

### DIFF
--- a/src/js/core/Utils.js
+++ b/src/js/core/Utils.js
@@ -1028,20 +1028,43 @@ var Utils = {
         };
 
         var formatFile = function(file, i) {
+            var blob = new Blob(
+                [new Uint8Array(file.bytes)],
+                {type: "octet/stream"}
+            );
+            var blobUrl = window.URL.createObjectURL(blob);
+
+            var downloadAnchorElem = $("<a></a>")
+                .html("\u21B4")
+                .attr("href", blobUrl)
+                .attr("title", "Download '" + file.fileName + "'")
+                .attr("download", file.fileName);
+
+            var expandFileContentsElem = $("<a></a>")
+                .html("&#x1F50D")
+                .addClass("collapsed")
+                .attr("data-toggle", "collapse")
+                .attr("aria-expanded", "true")
+                .attr("aria-controls", "collapse" + i)
+                .attr("href", "#collapse" + i)
+                .attr("title", "Show/hide contents of '" + file.fileName + "'");
+
             var html = "<div class='panel panel-default'>" +
                        "<div class='panel-heading' role='tab' id='heading" + i + "'>" +
                        "<h4 class='panel-title'>" +
-                       "<a class='collapsed' role='button' data-toggle='collapse' " +
-                       "href='#collapse" + i + "' " +
-                       "aria-expanded='true' aria-controls='collapse" + i +"'>" +
+                       "<div>" +
                        file.fileName +
+                       " " +
+                       $(expandFileContentsElem).prop("outerHTML") +
+                       " " +
+                       $(downloadAnchorElem).prop("outerHTML") +
                        "<span class='pull-right'>" +
                        // These are for formatting when stripping HTML
                        "<span style='display: none'>\n</span>" +
                        file.size.toLocaleString() + " bytes" +
                        "<span style='display: none'>\n</span>" +
                        "</span>" +
-                       "</a>" +
+                       "</div>" +
                        "</h4>" +
                        "</div>" +
                        "<div id='collapse" + i + "' class='panel-collapse collapse' " +

--- a/src/js/operations/Compress.js
+++ b/src/js/operations/Compress.js
@@ -309,9 +309,8 @@ var Compress = {
             files = [];
 
         filenames.forEach(function(fileName) {
-            var contents = unzip.decompress(fileName);
-
-            contents = Utils.byteArrayToUtf8(contents);
+            var bytes = unzip.decompress(fileName);
+            var contents = Utils.byteArrayToUtf8(bytes);
 
             var file = {
                 fileName: fileName,
@@ -320,6 +319,7 @@ var Compress = {
 
             var isDir = contents.length === 0 && fileName.endsWith("/");
             if (!isDir) {
+                file.bytes = bytes;
                 file.contents = contents;
             }
 
@@ -477,6 +477,13 @@ var Compress = {
             this.position = 0;
         };
 
+        Stream.prototype.getBytes = function(bytesToGet) {
+            var newPosition = this.position + bytesToGet;
+            var bytes = this.bytes.slice(this.position, newPosition);
+            this.position = newPosition;
+            return bytes;
+        };
+
         Stream.prototype.readString = function(numBytes) {
             var result = "";
             for (var i = this.position; i < this.position + numBytes; i++) {
@@ -535,11 +542,9 @@ var Compress = {
                     endPosition += 512 - (file.size % 512);
                 }
 
-                file.contents = "";
-
-                while (stream.position < endPosition) {
-                    file.contents += stream.readString(512);
-                }
+                file.bytes = stream.getBytes(file.size);
+                file.contents = Utils.byteArrayToUtf8(file.bytes);
+                stream.position = endPosition;
             } else if (file.type === "5") {
                 // Directory
                 files.push(file);


### PR DESCRIPTION
# Summary
+ Added bytes attribute for "file objects" in untar and unzip
+ Added download button on files displayed by displayFilesAsHTML
+ Fixes bug in "Untar" for binary files.

# Reasoning
I was looking to implement PGP detached signatures which outputs a message, an ASCII-armored signature, and a binary file signature.

Looking into the matter further I found there was a bug in the "Untar" operation when reading binary files. The bug caused binary files to get cut off when being read (if they contained a`0` byte). See below
![image](https://cloud.githubusercontent.com/assets/1482692/23833904/6a1fe42e-0723-11e7-87c4-0cc59fedaebd.png)
The file displayed is clearly not 218 bytes, it should be:
![image](https://cloud.githubusercontent.com/assets/1482692/23833907/7f9e02b8-0723-11e7-89bd-ec0cfed1653a.png)

Also if you wanted to download the contents of that file you would not be able to (some bytes not displayed).

# Result
Overall file display now has two buttons
+  `🔍` to show/hide the contents
+ `↴` to download the file

![image](https://cloud.githubusercontent.com/assets/1482692/23833920/b6ed6204-0723-11e7-9c45-a04170b8d9c0.png)

Previously the show/hide functionality was achieved by clicking on the name. This was "hidden" and confusing (directory vs file). Now functionality is more obvious and is explicit.

Clicking on the download button now downloads the file with the correct file name. This works for binary and non-binary files (as it just uses the bytes rather than the string contents), and it saves the user from having to copy/paste.

![image](https://cloud.githubusercontent.com/assets/1482692/23833962/787f0c6a-0724-11e7-8bd0-f50321dc79dd.png)

