### PR TITLE
add a grunt plugin to check accessibility

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-chmod");
     grunt.loadNpmTasks("grunt-exec");
     grunt.loadNpmTasks("grunt-execute");
+    grunt.loadNpmTasks("grunt-accessibility");
 
 
     // Project configuration
@@ -131,6 +132,14 @@ module.exports = function (grunt) {
                     "src/**/*.js",
                     "!src/core/lib/**/*",
                 ],
+            }
+        },
+        accessibility: {
+            options: {
+                accessibilityLevel: "WCAG2A"
+            },
+            test: {
+                src: ["build/**/*.html"]
             }
         },
         webpack: {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.10.1",
     "grunt": ">=0.4.5",
+    "grunt-accessibility": "~5.0.0",
     "grunt-chmod": "~1.1.1",
     "grunt-contrib-clean": "~1.0.0",
     "grunt-contrib-copy": "~1.0.0",


### PR DESCRIPTION
Added: https://github.com/yargalot/grunt-accessibility

Runs checks over all HTML files in the build folder, thus if you have a dev and a prod build it will report everything twice.

This pull doesn't actually fix any of the accessibility errors/warnings (of which there are about 50).

Once you have something in your "build" folder you can run ```grunt accessibility```

I considered adding the accessibility task as part of the prod build but thought it might be a bit verbose, as a lot of the messages it pumps out are warnings and hints rather than actual errors.