### PR TITLE
Implement support for async ops.

### DIFF
--- a/docs/jsdoc.conf.json
+++ b/docs/jsdoc.conf.json
@@ -2,7 +2,10 @@
     "tags": {
         "allowUnknownTags": true
     },
-    "plugins": ["plugins/markdown"],
+    "plugins": [
+        "plugins/markdown",
+        "node_modules/jsdoc-babel"
+    ],
     "templates": {
         "systemName": "CyberChef",
         "footer": "",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "html-webpack-plugin": "^2.28.0",
     "imports-loader": "^0.7.1",
     "ink-docstrap": "^1.1.4",
+    "jsdoc-babel": "^0.3.0",
     "less": "^2.7.2",
     "less-loader": "^4.0.2",
     "style-loader": "^0.15.0",

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "parserOptions": {
-        "ecmaVersion": 6,
+        "ecmaVersion": 8,
         "ecmaFeatures": {
             "impliedStrict": true
         },

--- a/src/core/Chef.js
+++ b/src/core/Chef.js
@@ -34,7 +34,7 @@ var Chef = function() {
  * @returns {number} response.duration - The number of ms it took to execute the recipe
  * @returns {number} response.error - The error object thrown by a failed operation (false if no error)
 */
-Chef.prototype.bake = function(inputText, recipeConfig, options, progress, step) {
+Chef.prototype.bake = async function(inputText, recipeConfig, options, progress, step) {
     var startTime  = new Date().getTime(),
         recipe     = new Recipe(recipeConfig),
         containsFc = recipe.containsFlowControl(),
@@ -72,7 +72,7 @@ Chef.prototype.bake = function(inputText, recipeConfig, options, progress, step)
     }
 
     try {
-        progress = recipe.execute(this.dish, progress);
+        progress = await recipe.execute(this.dish, progress);
     } catch (err) {
         // Return the error in the result so that everything else gets correctly updated
         // rather than throwing it here and losing state info.

--- a/src/core/FlowControl.js
+++ b/src/core/FlowControl.js
@@ -38,7 +38,7 @@ const FlowControl = {
      * @param {Operation[]} state.opList - The list of operations in the recipe.
      * @returns {Object} The updated state of the recipe.
      */
-    runFork: function(state) {
+    runFork: async function(state) {
         var opList       = state.opList,
             inputType    = opList[state.progress].inputType,
             outputType   = opList[state.progress].outputType,
@@ -73,7 +73,7 @@ const FlowControl = {
         for (i = 0; i < inputs.length; i++) {
             var dish = new Dish(inputs[i], inputType);
             try {
-                progress = recipe.execute(dish, 0);
+                progress = await recipe.execute(dish, 0);
             } catch (err) {
                 if (!ignoreErrors) {
                     throw err;

--- a/src/core/Recipe.js
+++ b/src/core/Recipe.js
@@ -145,7 +145,7 @@ Recipe.prototype.lastOpIndex = function(startIndex) {
  * @param {number} [startFrom=0] - The index of the Operation to start executing from
  * @returns {number} - The final progress through the recipe
  */
-Recipe.prototype.execute = function(dish, startFrom) {
+Recipe.prototype.execute = async function(dish, startFrom) {
     startFrom = startFrom || 0;
     var op, input, output, numJumps = 0;
 
@@ -170,11 +170,11 @@ Recipe.prototype.execute = function(dish, startFrom) {
                     "numJumps" : numJumps
                 };
 
-                state = op.run(state);
+                state = await op.run(state);
                 i = state.progress;
                 numJumps = state.numJumps;
             } else {
-                output = op.run(input, op.getIngValues());
+                output = await op.run(input, op.getIngValues());
                 dish.set(output, op.outputType);
             }
         } catch (err) {

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -1185,33 +1185,6 @@ const Utils = {
         "Latin1":  CryptoJS.enc.Latin1,
     },
 
-
-    /**
-     * A utility for "debouncing" functions.
-     * Debouncing is when you want to ensure events triggered by an event are rate-limited.
-     * @constant
-     */
-    debounce(fn, delay) {
-        let timeout;
-
-        return function() {
-            /**
-             * later calls the debounced function with arguments.
-             * If the debounced function is called again, then the timeout
-             * which calls later is cancelled.
-             */
-            let later = () => {
-                fn.apply(this, arguments);
-            };
-
-            if (timeout) {
-                clearTimeout(timeout);
-            }
-
-            timeout = setTimeout(later, delay);
-        };
-    },
-
 };
 
 export default Utils;

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -1185,6 +1185,33 @@ const Utils = {
         "Latin1":  CryptoJS.enc.Latin1,
     },
 
+
+    /**
+     * A utility for "debouncing" functions.
+     * Debouncing is when you want to ensure events triggered by an event are rate-limited.
+     * @constant
+     */
+    debounce(fn, delay) {
+        let timeout;
+
+        return function() {
+            /**
+             * later calls the debounced function with arguments.
+             * If the debounced function is called again, then the timeout
+             * which calls later is cancelled.
+             */
+            let later = () => {
+                fn.apply(this, arguments);
+            };
+
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+
+            timeout = setTimeout(later, delay);
+        };
+    },
+
 };
 
 export default Utils;

--- a/src/web/App.js
+++ b/src/web/App.js
@@ -124,13 +124,13 @@ App.prototype.bake = async function(step) {
         this.handleError(err);
     }
 
+    this.setBakingStatus(false);
+
     if (!response) return;
 
     if (response.error) {
         this.handleError(response.error);
     }
-
-    this.setBakingStatus(false);
 
     this.options  = response.options;
     this.dishStr  = response.type === "html" ? Utils.stripHtmlTags(response.result, true) : response.result;

--- a/src/web/App.js
+++ b/src/web/App.js
@@ -36,6 +36,8 @@ var App = function(categories, operations, defaultFavourites, defaultOptions) {
     this.ingId       = 0;
 
     window.chef      = this.chef;
+
+    this.autoBake = Utils.debounce(this.autoBake, 300);
 };
 
 

--- a/src/web/App.js
+++ b/src/web/App.js
@@ -73,11 +73,11 @@ App.prototype.handleError = function(err) {
  * @param {boolean} [step] - Set to true if we should only execute one operation instead of the
  *   whole recipe.
  */
-App.prototype.bake = function(step) {
+App.prototype.bake = async function(step) {
     var response;
 
     try {
-        response = this.chef.bake(
+        response = await this.chef.bake(
             this.getInput(),         // The user's input
             this.getRecipeConfig(), // The configuration of the recipe
             this.options,             // Options set by the user

--- a/src/web/App.js
+++ b/src/web/App.js
@@ -36,8 +36,6 @@ var App = function(categories, operations, defaultFavourites, defaultOptions) {
     this.ingId       = 0;
 
     window.chef      = this.chef;
-
-    this.autoBake = Utils.debounce(this.autoBake, 300);
 };
 
 
@@ -80,22 +78,17 @@ App.prototype.setBakingStatus = function(bakingStatus) {
 
     var inputLoadingIcon = document.querySelector("#input .title .loading-icon"),
         outputLoadingIcon = document.querySelector("#output .title .loading-icon"),
-        inputElement = document.querySelector("#input-text"),
         outputElement = document.querySelector("#output-text");
 
     if (bakingStatus) {
         inputLoadingIcon.style.display = "inline-block";
         outputLoadingIcon.style.display = "inline-block";
-        inputElement.classList.add("disabled");
         outputElement.classList.add("disabled");
-        inputElement.disabled = true;
         outputElement.disabled = true;
     } else {
         inputLoadingIcon.style.display = "none";
         outputLoadingIcon.style.display = "none";
-        inputElement.classList.remove("disabled");
         outputElement.classList.remove("disabled");
-        inputElement.disabled = false;
         outputElement.disabled = false;
     }
 };

--- a/src/web/App.js
+++ b/src/web/App.js
@@ -30,6 +30,7 @@ var App = function(categories, operations, defaultFavourites, defaultOptions) {
     this.chef        = new Chef();
     this.manager     = new Manager(this);
 
+    this.baking      = false;
     this.autoBake_   = false;
     this.progress    = 0;
     this.ingId       = 0;
@@ -68,6 +69,37 @@ App.prototype.handleError = function(err) {
 
 
 /**
+ * Updates the UI to show if baking is in process or not.
+ *
+ * @param {bakingStatus}
+ */
+App.prototype.setBakingStatus = function(bakingStatus) {
+    this.baking = bakingStatus;
+
+    var inputLoadingIcon = document.querySelector("#input .title .loading-icon"),
+        outputLoadingIcon = document.querySelector("#output .title .loading-icon"),
+        inputElement = document.querySelector("#input-text"),
+        outputElement = document.querySelector("#output-text");
+
+    if (bakingStatus) {
+        inputLoadingIcon.style.display = "inline-block";
+        outputLoadingIcon.style.display = "inline-block";
+        inputElement.classList.add("disabled");
+        outputElement.classList.add("disabled");
+        inputElement.disabled = true;
+        outputElement.disabled = true;
+    } else {
+        inputLoadingIcon.style.display = "none";
+        outputLoadingIcon.style.display = "none";
+        inputElement.classList.remove("disabled");
+        outputElement.classList.remove("disabled");
+        inputElement.disabled = false;
+        outputElement.disabled = false;
+    }
+};
+
+
+/**
  * Calls the Chef to bake the current input using the current recipe.
  *
  * @param {boolean} [step] - Set to true if we should only execute one operation instead of the
@@ -75,6 +107,10 @@ App.prototype.handleError = function(err) {
  */
 App.prototype.bake = async function(step) {
     var response;
+
+    if (this.baking) return;
+
+    this.setBakingStatus(true);
 
     try {
         response = await this.chef.bake(
@@ -93,6 +129,8 @@ App.prototype.bake = async function(step) {
     if (response.error) {
         this.handleError(response.error);
     }
+
+    this.setBakingStatus(false);
 
     this.options  = response.options;
     this.dishStr  = response.type === "html" ? Utils.stripHtmlTags(response.result, true) : response.result;

--- a/src/web/css/structure/layout.css
+++ b/src/web/css/structure/layout.css
@@ -430,3 +430,36 @@ span.btn img {
     border-top: none;
     margin-top: 0;
 }
+
+
+@-moz-keyframes spinner {
+    from { -moz-transform: rotate(0deg); }
+    to { -moz-transform: rotate(359deg); }
+}
+@-webkit-keyframes spinner {
+    from { -webkit-transform: rotate(0deg); }
+    to { -webkit-transform: rotate(359deg); }
+}
+@keyframes spinner {
+    from {transform:rotate(0deg);}
+    to {transform:rotate(359deg);}
+}
+
+.loading-icon::before {
+    content: "\21bb";
+}
+
+.loading-icon {
+    -webkit-animation-name: spinner;
+    -webkit-animation-duration: 1000ms;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-timing-function: linear;
+    -moz-animation-name: spinner;
+    -moz-animation-duration: 1000ms;
+    -moz-animation-iteration-count: infinite;
+    -moz-animation-timing-function: linear;
+    -ms-animation-name: spinner;
+    -ms-animation-duration: 1000ms;
+    -ms-animation-iteration-count: infinite;
+    -ms-animation-timing-function: linear;
+}

--- a/src/web/html/index.html
+++ b/src/web/html/index.html
@@ -100,6 +100,7 @@
                     <div id="input" class="split no-select">
                         <div class="title no-select">
                             <label for="input-text">Input</label>
+                            <div class="loading-icon" style="display: none"></div>
                             <div class="btn-group io-btn-group">
                                 <button type="button" class="btn btn-default btn-sm" id="clr-io"><img aria-hidden="true" src="<%- require('../static/images/recycle-16x16.png') %>" alt="Recycle Icon"/> Clear I/O</button>
                                 <button type="button" class="btn btn-default btn-sm" id="reset-layout"><img aria-hidden="true" src="<%- require('../static/images/layout-16x16.png') %>" alt="Grid Icon"/> Reset layout</button>
@@ -116,6 +117,7 @@
                     <div id="output" class="split">
                         <div class="title no-select">
                             <label for="output-text">Output</label>
+                            <div class="loading-icon" style="display: none"></div>
                             <div class="btn-group io-btn-group">
                                 <button type="button" class="btn btn-default btn-sm" id="save-to-file" title="Save to file"><img aria-hidden="true" src="<%- require('../static/images/save_as-16x16.png') %>" alt="Save Icon"/> Save to file</button>
                                 <button type="button" class="btn btn-default btn-sm" id="switch" title="Move output to input"><img aria-hidden="true" src="<%- require('../static/images/switch-16x16.png') %>" alt="Switch Icon"/> Move output to input</button>

--- a/test/TestRegister.js
+++ b/test/TestRegister.js
@@ -40,13 +40,13 @@ import Chef from "../src/core/Chef.js";
             this.tests.map(function(test, i) {
                 var chef = new Chef();
 
-                return Promise.resolve(chef.bake(
+                return chef.bake(
                     test.input,
                     test.recipeConfig,
                     {},
                     0,
                     false
-                ))
+                )
                 .then(function(result) {
                     var ret = {
                         test: test,

--- a/test/tests/operations/FlowControl.js
+++ b/test/tests/operations/FlowControl.js
@@ -67,6 +67,62 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Jump: skips 0",
+        input: [
+            "should be changed",
+        ].join("\n"),
+        expectedOutput: [
+            "should be changed was changed",
+        ].join("\n"),
+        recipeConfig: [
+            {
+                op: "Jump",
+                args: [0, 10],
+            },
+            {
+                op: "Find / Replace",
+                args: [
+                    {
+                        "option": "Regex",
+                        "string": "should be changed"
+                    },
+                    "should be changed was changed",
+                    true,
+                    true,
+                    true,
+                ],
+            },
+        ],
+    },
+    {
+        name: "Jump: skips 1",
+        input: [
+            "shouldnt be changed",
+        ].join("\n"),
+        expectedOutput: [
+            "shouldnt be changed",
+        ].join("\n"),
+        recipeConfig: [
+            {
+                op: "Jump",
+                args: [1, 10],
+            },
+            {
+                op: "Find / Replace",
+                args: [
+                    {
+                        "option": "Regex",
+                        "string": "shouldnt be changed"
+                    },
+                    "shouldnt be changed was changed",
+                    true,
+                    true,
+                    true,
+                ],
+            },
+        ],
+    },
+    {
         name: "Conditional Jump: Skips 0",
         input: [
             "match",
@@ -108,6 +164,83 @@ TestRegister.addTests([
                     true,
                     true,
                 ],
+            },
+        ],
+    },
+    {
+        name: "Conditional Jump: Skips 1",
+        input: [
+            "match",
+            "should not be changed",
+            "should be changed",
+        ].join("\n"),
+        expectedOutput: [
+            "match",
+            "should not be changed",
+            "should be changed was changed"
+        ].join("\n"),
+        recipeConfig: [
+            {
+                op: "Conditional Jump",
+                args: ["match", 1, 10],
+            },
+            {
+                op: "Find / Replace",
+                args: [
+                    {
+                        "option": "Regex",
+                        "string": "should not be changed"
+                    },
+                    "should not be changed was changed",
+                    true,
+                    true,
+                    true,
+                ],
+            },
+            {
+                op: "Find / Replace",
+                args: [
+                    {
+                        "option": "Regex",
+                        "string": "should be changed"
+                    },
+                    "should be changed was changed",
+                    true,
+                    true,
+                    true,
+                ],
+            },
+        ],
+    },
+    {
+        name: "Conditional Jump: Skips negatively",
+        input: [
+            "match",
+        ].join("\n"),
+        expectedOutput: [
+            "replaced",
+        ].join("\n"),
+        recipeConfig: [
+            {
+                op: "Jump",
+                args: [1],
+            },
+            {
+                op: "Find / Replace",
+                args: [
+                    {
+                        "option": "Regex",
+                        "string": "match"
+                    },
+                    "replaced",
+                    true,
+                    true,
+                    true,
+                ],
+            },
+            {
+                op: "Conditional Jump",
+                args: ["match", -2, 10],
             },
         ],
     },


### PR DESCRIPTION
This deals with #79 with 11 lines of code changes (and the addition of some tests).

The relevant code changes are exclusively the addition of `async` and `await` where necessary.

This should be able to be dealt with fairly quickly and I can clean up #89 separately.

Summary
+ Async/await to support asynchronous operations
+ Added more tests
+ eslint ecmaVersion changed from 6 to 8
+ Added jsdoc-babel plugin to jsdoc
+ Re-added the UI changes made by n1474335 