### PR TITLE
Add Head and Tail operations

### DIFF
--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3196,7 +3196,69 @@ const OperationConfig = {
         outputType: "html",
         args: [
         ]
-    }
+    },
+    "Head": {
+        description: [
+            "Like the UNIX head utility.",
+            "<br>",
+            "Gets the first $Number of lines.",
+            "<br>",
+            "Optionally you can select all but the last $Number of lines.",
+            "<br>",
+            "The delimiter can be changed so that instead of lines, fields (i.e. commas) are selected instead.",
+        ].join("\n"),
+        run: StrUtils.runHead,
+        inputType: "string",
+        outputType: "string",
+        args: [
+            {
+                name: "Delimiter",
+                type: "option",
+                value: StrUtils.DELIMITER_OPTIONS
+            },
+            {
+                name: "Number",
+                type: "number",
+                value: 10,
+            },
+            {
+                name: "All but last $Number of lines",
+                type: "boolean",
+                value: false,
+            },
+        ]
+    },
+    "Tail": {
+        description: [
+            "Like the UNIX tail utility.",
+            "<br>",
+            "Gets the last $Number of lines.",
+            "<br>",
+            "Optionally you can select all lines after line $Number.",
+            "<br>",
+            "The delimiter can be changed so that instead of lines, fields (i.e. commas) are selected instead.",
+        ].join("\n"),
+        run: StrUtils.runTail,
+        inputType: "string",
+        outputType: "string",
+        args: [
+            {
+                name: "Delimiter",
+                type: "option",
+                value: StrUtils.DELIMITER_OPTIONS
+            },
+            {
+                name: "Number",
+                type: "number",
+                value: 10,
+            },
+            {
+                name: "Start from line $Number",
+                type: "boolean",
+                value: false,
+            },
+        ]
+    },
 };
 
 export default OperationConfig;

--- a/src/core/operations/StrUtils.js
+++ b/src/core/operations/StrUtils.js
@@ -537,6 +537,61 @@ const StrUtils = {
         return output;
     },
 
+    /**
+     * Head lines operation.
+     *
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    runHead: function(input, args) {
+        let delimiter = args[0],
+            number = args[1],
+            allBut = args[2];
+
+        delimiter = Utils.charRep[delimiter];
+        let splitInput = input.split(delimiter);
+
+        return splitInput
+        .filter((line, lineIndex) => {
+            lineIndex += 1;
+
+            if (allBut) {
+                return lineIndex <= splitInput.length - number;
+            } else {
+                return lineIndex <= number;
+            }
+        })
+        .join(delimiter);
+    },
+
+    /**
+     * Tail lines operation.
+     *
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    runTail: function(input, args) {
+        let delimiter = args[0],
+            number = args[1],
+            allBut = args[2];
+
+        delimiter = Utils.charRep[delimiter];
+        let splitInput = input.split(delimiter);
+
+        return splitInput
+        .filter((line, lineIndex) => {
+            lineIndex += 1;
+
+            if (allBut) {
+                return lineIndex >= number;
+            } else {
+                return lineIndex > splitInput.length - number;
+            }
+        })
+        .join(delimiter);
+    },
 };
 
 export default StrUtils;

--- a/test/tests/operations/StrUtils.js
+++ b/test/tests/operations/StrUtils.js
@@ -34,4 +34,224 @@ TestRegister.addTests([
             }
         ],
     },
+    {
+        name: "Head 0",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 0, false]
+            }
+        ],
+    },
+    {
+        name: "Head 1",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 1, false]
+            }
+        ],
+    },
+    {
+        name: "Head 2",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 2, false]
+            }
+        ],
+    },
+    {
+        name: "Head 6",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4, 5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 6, false]
+            }
+        ],
+    },
+    {
+        name: "Head big",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4, 5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 100, false]
+            }
+        ],
+    },
+    {
+        name: "Head all but 0",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4, 5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 0, true]
+            }
+        ],
+    },
+    {
+        name: "Head all but 1",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4, 5].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 1, true]
+            }
+        ],
+    },
+    {
+        name: "Head all but 2",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 2, true]
+            }
+        ],
+    },
+    {
+        name: "Head all but 6",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 6, true]
+            }
+        ],
+    },
+    {
+        name: "Head all but big",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Head",
+                "args": ["Line feed", 100, true]
+            }
+        ],
+    },
+    {
+        name: "Tail 0",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 0, false]
+            }
+        ],
+    },
+    {
+        name: "Tail 1",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 1, false]
+            }
+        ],
+    },
+    {
+        name: "Tail 2",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 2, false]
+            }
+        ],
+    },
+    {
+        name: "Tail 6",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4, 5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 6, false]
+            }
+        ],
+    },
+    {
+        name: "Tail big",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4, 5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 100, false]
+            }
+        ],
+    },
+    {
+        name: "Tail all but 0",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4, 5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 0, true]
+            }
+        ],
+    },
+    {
+        name: "Tail all but 1",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [1, 2, 3, 4, 5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 1, true]
+            }
+        ],
+    },
+    {
+        name: "Tail all but 2",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [2, 3, 4, 5, 6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 2, true]
+            }
+        ],
+    },
+    {
+        name: "Tail all but 6",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [6].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 6, true]
+            }
+        ],
+    },
+    {
+        name: "Tail all but big",
+        input: [1, 2, 3, 4, 5, 6].join("\n"),
+        expectedOutput: [].join("\n"),
+        recipeConfig: [
+            {
+                "op": "Tail",
+                "args": ["Line feed", 100, true]
+            }
+        ],
+    },
 ]);


### PR DESCRIPTION
My most common reason to switch out of CyberChef into a terminal is to use `head` or `tail`. The basic functionality of `head` and `tail` is implemented here:

Head operation
+ `head -n 10` => first 10 lines (Number = 10, box = unchecked)
+ `head -n -10` => all lines except the last 10 (Number = 10, box = checked)
+ `tail -n 10` => last 10 lines (Number = 10, box = unchecked)
+ `tail -n +10` => all lines starting from line 10 (Number = 10, box = checked)

You can change the delimiter as needed, so this can even work as a very primitive `cut`:
![image](https://cloud.githubusercontent.com/assets/1482692/25300955/4ddc986c-26e9-11e7-949d-656bc9a5e84b.png)
(I don't recommend this though)

Relevant tests also included.