### PR TITLE
[WIP] Feature: Google Translate support for UI

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -305,6 +305,11 @@ module.exports = function (grunt) {
                         // Add Google Analytics code to index.html
                         content = content.replace("</body></html>",
                             grunt.file.read("src/web/static/ga.html") + "</body></html>");
+
+                        // Add Google Translate code to index.html
+                        content = content.replace("<!-- Google Translate placeholder -->",
+                            grunt.file.read("src/web/static/gt.html"));
+
                         return grunt.template.process(content);
                     }
                 },

--- a/src/web/html/index.html
+++ b/src/web/html/index.html
@@ -233,6 +233,7 @@
                             <input type="number" option="auto_bake_threshold" id="auto_bake_threshold"/>
                             <label for="auto_bake_threshold"> Auto Bake threshold in ms </label>
                         </div>
+                        <!-- htmlmin:ignore --><!-- Google Translate placeholder --><!-- htmlmin:ignore -->
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" id="reset-options">Reset options to default</button>

--- a/src/web/static/gt.html
+++ b/src/web/static/gt.html
@@ -1,0 +1,13 @@
+
+
+<div class="option-item">
+    <!-- Begin Google Translate -->
+    <div id="google_translate_element"></div>
+    <script type="text/javascript">
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({pageLanguage: 'en', layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL, gaTrack: true, gaId: 'UA-85682716-2'}, 'google_translate_element');
+        }
+    </script><script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <!-- End Google Translate -->
+</div>
+


### PR DESCRIPTION
In response to #102 and #42.

Creating and maintaining native support for multiple languages would be a substantial drain on resources and would slow development of new features and operations. For these reasons, I suggest we don't attempt to do it natively. 

However, it would obviously be useful for non-English speakers to be able to read operation names, descriptions and supporting text. The easiest way to quickly support multiple languages is to offer automated translation using [Google Translate](https://translate.google.com/manager/website/). I accept that this is not a perfect solution, but I think it's the best way of supporting a large number of languages without hampering future development. CyberChef isn't a word-heavy application, so automated translation should be accurate enough for users to work out roughly what is going on, even if it isn't perfect.

This pull request adds a dropdown to the options pane where users can select a language for Google to automatically translate the web page with. This option is only added in GitHub Pages builds (by running `grunt prod` followed by `grunt copy:ghPages`).

It is currently a work in progress. Known bugs include:

- [ ] Baking doesn't work as operation names have changed.
- [ ] The styling of the Google Translate dropdown needs to be tweaked after #113 has been merged.
- [ ] The bootstrap-switch checkboxes break after translation.