### PR TITLE
Feature: 'Comment' operation

### DIFF
--- a/src/core/FlowControl.js
+++ b/src/core/FlowControl.js
@@ -196,7 +196,7 @@ const FlowControl = {
 
     /**
      * Comment operation.
-     * 
+     *
      * @param {Object} state - The current state of the recipe.
      * @param {number} state.progress - The current position in the recipe.
      * @param {Dish} state.dish - The Dish being operated on.

--- a/src/core/FlowControl.js
+++ b/src/core/FlowControl.js
@@ -193,6 +193,20 @@ const FlowControl = {
         return state;
     },
 
+
+    /**
+     * Comment operation.
+     * 
+     * @param {Object} state - The current state of the recipe.
+     * @param {number} state.progress - The current position in the recipe.
+     * @param {Dish} state.dish - The Dish being operated on.
+     * @param {Operation[]} state.opList - The list of operations in the recipe.
+     * @returns {Object} The updated state of the recipe.
+     */
+    runComment: function(state) {
+        return state;
+    },
+
 };
 
 export default FlowControl;

--- a/src/core/config/Categories.js
+++ b/src/core/config/Categories.js
@@ -292,6 +292,7 @@ const Categories = [
             "Jump",
             "Conditional Jump",
             "Return",
+            "Comment"
         ]
     },
 ];

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -162,6 +162,20 @@ const OperationConfig = {
         flowControl: true,
         args: []
     },
+    "Comment": {
+        description: "Provides a place to write comments within the flow of the recipe. This operation has no computational effect.",
+        run: FlowControl.runComment,
+        inputType: "string",
+        outputType: "string",
+        flowControl: true,
+        args: [
+            {
+                name: "",
+                type: "text",
+                value: ""
+            }
+        ]
+    },
     "From Base64": {
         description: "Base64 is a notation for encoding arbitrary byte data using a restricted set of symbols that can be conveniently used by humans and processed by computers.<br><br>This operation decodes data from an ASCII Base64 string back into its raw format.<br><br>e.g. <code>aGVsbG8=</code> becomes <code>hello</code>",
         run: Base64.runFrom,

--- a/test/tests/operations/FlowControl.js
+++ b/test/tests/operations/FlowControl.js
@@ -111,4 +111,34 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "Comment: nothing",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                "op": "Comment",
+                "args": [""]
+            }
+        ]
+    },
+    {
+        name: "Fork, Comment, Base64",
+        input: "cat\nsat\nmat",
+        expectedOutput: "Y2F0\nc2F0\nbWF0\n",
+        recipeConfig: [
+            {
+                "op": "Fork",
+                "args": ["\\n","\\n",false]
+            },
+            {
+                "op": "Comment",
+                "args": ["Testing 123"]
+            },
+            {
+                "op": "To Base64",
+                "args": ["A-Za-z0-9+/="]
+            }
+        ]
+    },
 ]);

--- a/test/tests/operations/FlowControl.js
+++ b/test/tests/operations/FlowControl.js
@@ -129,7 +129,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "Fork",
-                "args": ["\\n","\\n",false]
+                "args": ["\\n", "\\n", false]
             },
             {
                 "op": "Comment",


### PR DESCRIPTION
Added 'Comment' operation for annotating the recipe.

In response to #34.

This seemed like the easiest way of adding comments. Another option would be to add an icon to each operation as suggested in #34, however this would require a lot more code.