### PR TITLE
Add repo option to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ deploy:
     local_dir: build/prod/
     target_branch: gh-pages
     on:
+      repo: gchq/CyberChef
       branch: master
   - provider: releases
     skip_cleaup: true


### PR DESCRIPTION
This stops Travis from trying to build GH pages for other repos.

I.e. solves [this](https://travis-ci.org/tlwr/CyberChef/builds/234148384) problem.