### PR TITLE
WIP: Charts module

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "bootstrap-switch": "^3.3.4",
     "crypto-api": "^0.6.2",
     "crypto-js": "^3.1.9-1",
+    "d3": "^4.9.1",
+    "d3-hexbin": "^0.2.2",
     "diff": "^3.2.0",
     "escodegen": "^1.8.1",
     "esmangle": "^1.0.1",

--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -1021,6 +1021,7 @@ const Utils = {
         "Comma":         ",",
         "Semi-colon":    ";",
         "Colon":         ":",
+        "Tab":           "\t",
         "Line feed":     "\n",
         "CRLF":          "\r\n",
         "Forward slash": "/",

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -5,6 +5,7 @@ import Base64 from "../operations/Base64.js";
 import BitwiseOp from "../operations/BitwiseOp.js";
 import ByteRepr from "../operations/ByteRepr.js";
 import CharEnc from "../operations/CharEnc.js";
+import Charts from "../operations/Charts.js";
 import Checksum from "../operations/Checksum.js";
 import Cipher from "../operations/Cipher.js";
 import Code from "../operations/Code.js";
@@ -3388,6 +3389,44 @@ const OperationConfig = {
             }
         ]
     },
+    "Hex Density chart": {
+        description: [].join("\n"),
+        run: Charts.runHexDensityChart,
+        inputType: "string",
+        outputType: "html",
+        args: [
+            {
+                name: "Record delimiter",
+                type: "option",
+                value: Charts.RECORD_DELIMITER_OPTIONS,
+            },
+            {
+                name: "Field delimiter",
+                type: "option",
+                value: Charts.FIELD_DELIMITER_OPTIONS,
+            },
+            {
+                name: "Radius",
+                type: "number",
+                value: 25,
+            },
+            {
+                name: "Use column headers as labels",
+                type: "boolean",
+                value: true,
+            },
+            {
+                name: "X label",
+                type: "string",
+                value: "",
+            },
+            {
+                name: "Y label",
+                type: "string",
+                value: "",
+            },
+        ]
+    }
 };
 
 export default OperationConfig;

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3510,6 +3510,54 @@ const OperationConfig = {
             },
         ]
     },
+    "Scatter chart": {
+        description: [].join("\n"),
+        run: Charts.runScatterChart,
+        inputType: "string",
+        outputType: "html",
+        args: [
+            {
+                name: "Record delimiter",
+                type: "option",
+                value: Charts.RECORD_DELIMITER_OPTIONS,
+            },
+            {
+                name: "Field delimiter",
+                type: "option",
+                value: Charts.FIELD_DELIMITER_OPTIONS,
+            },
+            {
+                name: "Use column headers as labels",
+                type: "boolean",
+                value: true,
+            },
+            {
+                name: "X label",
+                type: "string",
+                value: "",
+            },
+            {
+                name: "Y label",
+                type: "string",
+                value: "",
+            },
+            {
+                name: "Colour",
+                type: "string",
+                value: Charts.COLOURS.max,
+            },
+            {
+                name: "Point radius",
+                type: "number",
+                value: 10,
+            },
+            {
+                name: "Use colour from third column",
+                type: "boolean",
+                value: false,
+            },
+        ]
+    },
     "HTML to Text": {
         description: [].join("\n"),
         run: HTML.runHTMLToText,

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3445,6 +3445,11 @@ const OperationConfig = {
                 type: "string",
                 value: Charts.COLOURS.max,
             },
+            {
+                name: "Draw empty hexagons within data boundaries",
+                type: "boolean",
+                value: false,
+            },
         ]
     }
 };

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3430,6 +3430,21 @@ const OperationConfig = {
                 type: "string",
                 value: "",
             },
+            {
+                name: "Draw hexagon edges",
+                type: "boolean",
+                value: false,
+            },
+            {
+                name: "Min colour value",
+                type: "string",
+                value: Charts.COLOURS.min,
+            },
+            {
+                name: "Max colour value",
+                type: "string",
+                value: Charts.COLOURS.max,
+            },
         ]
     }
 };

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3406,9 +3406,14 @@ const OperationConfig = {
                 value: Charts.FIELD_DELIMITER_OPTIONS,
             },
             {
-                name: "Radius",
+                name: "Pack radius",
                 type: "number",
                 value: 25,
+            },
+            {
+                name: "Draw radius",
+                type: "number",
+                value: 15,
             },
             {
                 name: "Use column headers as labels",

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3558,6 +3558,39 @@ const OperationConfig = {
             },
         ]
     },
+    "Series chart": {
+        description: [].join("\n"),
+        run: Charts.runSeriesChart,
+        inputType: "string",
+        outputType: "html",
+        args: [
+            {
+                name: "Record delimiter",
+                type: "option",
+                value: Charts.RECORD_DELIMITER_OPTIONS,
+            },
+            {
+                name: "Field delimiter",
+                type: "option",
+                value: Charts.FIELD_DELIMITER_OPTIONS,
+            },
+            {
+                name: "X label",
+                type: "string",
+                value: "",
+            },
+            {
+                name: "Point radius",
+                type: "number",
+                value: 1,
+            },
+            {
+                name: "Series colours",
+                type: "string",
+                value: "mediumseagreen, dodgerblue, tomato",
+            },
+        ]
+    },
     "HTML to Text": {
         description: [].join("\n"),
         run: HTML.runHTMLToText,

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3509,6 +3509,14 @@ const OperationConfig = {
                 value: Charts.COLOURS.max,
             },
         ]
+    },
+    "HTML to Text": {
+        description: [].join("\n"),
+        run: HTML.runHTMLToText,
+        inputType: "html",
+        outputType: "string",
+        args: [
+        ]
     }
 };
 

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3451,6 +3451,64 @@ const OperationConfig = {
                 value: false,
             },
         ]
+    },
+    "Heatmap chart": {
+        description: [].join("\n"),
+        run: Charts.runHeatmapChart,
+        inputType: "string",
+        outputType: "html",
+        args: [
+            {
+                name: "Record delimiter",
+                type: "option",
+                value: Charts.RECORD_DELIMITER_OPTIONS,
+            },
+            {
+                name: "Field delimiter",
+                type: "option",
+                value: Charts.FIELD_DELIMITER_OPTIONS,
+            },
+            {
+                name: "Number of vertical bins",
+                type: "number",
+                value: 25,
+            },
+            {
+                name: "Number of horizontal bins",
+                type: "number",
+                value: 25,
+            },
+            {
+                name: "Use column headers as labels",
+                type: "boolean",
+                value: true,
+            },
+            {
+                name: "X label",
+                type: "string",
+                value: "",
+            },
+            {
+                name: "Y label",
+                type: "string",
+                value: "",
+            },
+            {
+                name: "Draw bin edges",
+                type: "boolean",
+                value: false,
+            },
+            {
+                name: "Min colour value",
+                type: "string",
+                value: Charts.COLOURS.min,
+            },
+            {
+                name: "Max colour value",
+                type: "string",
+                value: Charts.COLOURS.max,
+            },
+        ]
     }
 };
 

--- a/src/core/operations/Charts.js
+++ b/src/core/operations/Charts.js
@@ -103,7 +103,7 @@ const Charts = {
         return { headings, values };
     },
 
-    
+
     /**
      * Gets values from input for a scatter plot with colour from the third column.
      *
@@ -137,6 +137,50 @@ const Charts = {
         });
 
         return { headings, values };
+    },
+
+
+    /**
+     * Gets values from input for a time series plot.
+     *
+     * @param {string} input
+     * @param {string} recordDelimiter
+     * @param {string} fieldDelimiter
+     * @param {boolean} columnHeadingsAreIncluded - whether we should skip the first record
+     * @returns {Object[]}
+     */
+    _getSeriesValues(input, recordDelimiter, fieldDelimiter, columnHeadingsAreIncluded) {
+        let { headings, values } = Charts._getValues(
+            input,
+            recordDelimiter, fieldDelimiter,
+            false,
+            3
+        );
+
+        let xValues = new Set(),
+            series = {};
+
+        values = values.forEach(row => {
+            let serie = row[0],
+                xVal = row[1],
+                val = parseFloat(row[2], 10);
+
+            if (Number.isNaN(val)) throw "Values must be numbers in base 10.";
+
+            xValues.add(xVal);
+            if (typeof series[serie] === "undefined") series[serie] = {};
+            series[serie][xVal] = val;
+        });
+
+        xValues = new Array(...xValues);
+
+        const seriesList = [];
+        for (let seriesName in series) {
+            let serie = series[seriesName];
+            seriesList.push({name: seriesName, data: serie});
+        }
+
+        return { xValues, series: seriesList };
     },
 
 
@@ -627,6 +671,168 @@ const Charts = {
             .attr("y", dimension)
             .style("text-anchor", "middle")
             .text(xLabel);
+
+        return svg._groups[0][0].outerHTML;
+    },
+
+
+    /**
+     * Series chart operation.
+     *
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {html}
+     */
+    runSeriesChart(input, args) {
+        const recordDelimiter = Utils.charRep[args[0]],
+            fieldDelimiter = Utils.charRep[args[1]],
+            xLabel = args[2],
+            pipRadius = args[3],
+            seriesColours = args[4].split(","),
+            svgWidth = 500,
+            interSeriesPadding = 20,
+            xAxisHeight = 50,
+            seriesLabelWidth = 50,
+            seriesHeight = 100,
+            seriesWidth = svgWidth - seriesLabelWidth - interSeriesPadding;
+
+        let { xValues, series } = Charts._getSeriesValues(input, recordDelimiter, fieldDelimiter),
+            allSeriesHeight = Object.keys(series).length * (interSeriesPadding + seriesHeight),
+            svgHeight = allSeriesHeight + xAxisHeight + interSeriesPadding;
+
+        let svg = document.createElement("svg");
+        svg = d3.select(svg)
+            .attr("width", "100%")
+            .attr("height", "100%")
+            .attr("viewBox", `0 0 ${svgWidth} ${svgHeight}`);
+
+        let xAxis = d3.scalePoint()
+            .domain(xValues)
+            .range([0, seriesWidth]);
+
+        svg.append("g")
+            .attr("class", "axis axis--x")
+            .attr("transform", `translate(${seriesLabelWidth}, ${xAxisHeight})`)
+            .call(
+                d3.axisTop(xAxis).tickValues(xValues.filter((x, i) => {
+                    return [0, Math.round(xValues.length / 2), xValues.length -1].indexOf(i) >= 0;
+                }))
+            );
+
+        svg.append("text")
+            .attr("x", svgWidth / 2)
+            .attr("y", xAxisHeight / 2)
+            .style("text-anchor", "middle")
+            .text(xLabel);
+
+        let tooltipText = {},
+            tooltipAreaWidth = seriesWidth / xValues.length;
+
+        xValues.forEach(x => {
+            let tooltip = [];
+
+            series.forEach(serie => {
+                let y = serie.data[x];
+                if (typeof y === "undefined") return;
+
+                tooltip.push(`${serie.name}: ${y}`);
+            });
+
+            tooltipText[x] = tooltip.join("\n");
+        });
+
+        let chartArea = svg.append("g")
+            .attr("transform", `translate(${seriesLabelWidth}, ${xAxisHeight})`);
+
+        chartArea
+            .append("g")
+            .selectAll("rect")
+            .data(xValues)
+            .enter()
+            .append("rect")
+            .attr("x", x => {
+                return xAxis(x) - (tooltipAreaWidth / 2);
+            })
+            .attr("y", 0)
+            .attr("width", tooltipAreaWidth)
+            .attr("height", allSeriesHeight)
+            .attr("stroke", "none")
+            .attr("fill", "transparent")
+            .append("title")
+            .text(x => {
+                return `${x}\n
+                    --\n
+                    ${tooltipText[x]}\n
+                `.replace(/\s{2,}/g, "\n");
+            });
+
+        let yAxesArea = svg.append("g")
+            .attr("transform", `translate(0, ${xAxisHeight})`);
+
+        series.forEach((serie, seriesIndex) => {
+            let yExtent = d3.extent(Object.values(serie.data)),
+                yAxis = d3.scaleLinear()
+                    .domain(yExtent)
+                    .range([seriesHeight, 0]);
+
+            let seriesGroup = chartArea
+                .append("g")
+                .attr("transform", `translate(0, ${seriesHeight * seriesIndex + interSeriesPadding * (seriesIndex + 1)})`);
+
+            let path = "";
+            xValues.forEach((x, xIndex) => {
+                let nextX = xValues[xIndex + 1],
+                    y = serie.data[x],
+                    nextY= serie.data[nextX];
+
+                if (typeof y === "undefined" || typeof nextY === "undefined") return;
+
+                x = xAxis(x); nextX = xAxis(nextX);
+                y = yAxis(y); nextY = yAxis(nextY);
+
+                path += `M ${x} ${y} L ${nextX} ${nextY} z `;
+            });
+
+            seriesGroup
+                .append("path")
+                .attr("d", path)
+                .attr("fill", "none")
+                .attr("stroke", seriesColours[seriesIndex % seriesColours.length])
+                .attr("stroke-width", "1");
+
+            xValues.forEach(x => {
+                let y = serie.data[x];
+                if (typeof y === "undefined") return;
+
+                seriesGroup
+                    .append("circle")
+                    .attr("cx", xAxis(x))
+                    .attr("cy", yAxis(y))
+                    .attr("r", pipRadius)
+                    .attr("fill", seriesColours[seriesIndex % seriesColours.length])
+                    .append("title")
+                    .text(d => {
+                        return `${x}\n
+                            --\n
+                            ${tooltipText[x]}\n
+                        `.replace(/\s{2,}/g, "\n");
+                    });
+            });
+
+            yAxesArea
+                .append("g")
+                .attr("transform", `translate(${seriesLabelWidth - interSeriesPadding}, ${seriesHeight * seriesIndex + interSeriesPadding * (seriesIndex + 1)})`)
+                .attr("class", "axis axis--y")
+                .call(d3.axisLeft(yAxis).ticks(5));
+
+            yAxesArea
+                .append("g")
+                .attr("transform", `translate(0, ${seriesHeight / 2 + seriesHeight * seriesIndex + interSeriesPadding * (seriesIndex + 1)})`)
+                .append("text")
+                .style("text-anchor", "middle")
+                .attr("transform", "rotate(-90)")
+                .text(serie.name);
+        });
 
         return svg._groups[0][0].outerHTML;
     },

--- a/src/core/operations/Charts.js
+++ b/src/core/operations/Charts.js
@@ -151,9 +151,9 @@ const Charts = {
             .attr("viewBox", `0 0 ${dimension} ${dimension}`);
 
         let margin = {
-                top: 0,
+                top: 10,
                 right: 0,
-                bottom: 30,
+                bottom: 40,
                 left: 30,
             },
             width = dimension - margin.left - margin.right,

--- a/src/core/operations/Charts.js
+++ b/src/core/operations/Charts.js
@@ -171,7 +171,7 @@ const Charts = {
         let xExtent = d3.extent(hexPoints, d => d.x),
             yExtent = d3.extent(hexPoints, d => d.y);
         xExtent[0] -= 2 * packRadius;
-        xExtent[1] += 2 * packRadius;
+        xExtent[1] += 3 * packRadius;
         yExtent[0] -= 2 * packRadius;
         yExtent[1] += 2 * packRadius;
 

--- a/src/core/operations/Charts.js
+++ b/src/core/operations/Charts.js
@@ -78,12 +78,13 @@ const Charts = {
     runHexDensityChart: function (input, args) {
         const recordDelimiter = Utils.charRep[args[0]],
             fieldDelimiter = Utils.charRep[args[1]],
-            radius = args[2],
-            columnHeadingsAreIncluded = args[3],
+            packRadius = args[2],
+            drawRadius = args[3],
+            columnHeadingsAreIncluded = args[4],
             dimension = 500;
 
-        let xLabel = args[4],
-            yLabel = args[5],
+        let xLabel = args[5],
+            yLabel = args[6],
             { headings, values } = Charts._getScatterValues(
                 input,
                 recordDelimiter,
@@ -114,7 +115,7 @@ const Charts = {
                 .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
         let hexbin = d3hexbin()
-            .radius(radius)
+            .radius(packRadius)
             .extent([0, 0], [width, height]);
 
         let hexPoints = hexbin(values),
@@ -122,10 +123,10 @@ const Charts = {
 
         let xExtent = d3.extent(hexPoints, d => d.x),
             yExtent = d3.extent(hexPoints, d => d.y);
-        xExtent[0] -= 2 * radius;
-        xExtent[1] += 2 * radius;
-        yExtent[0] -= 2 * radius;
-        yExtent[1] += 2 * radius;
+        xExtent[0] -= 2 * packRadius;
+        xExtent[1] += 2 * packRadius;
+        yExtent[0] -= 2 * packRadius;
+        yExtent[1] += 2 * packRadius;
 
         let xAxis = d3.scaleLinear()
             .domain(xExtent)
@@ -151,7 +152,7 @@ const Charts = {
             .enter()
             .append("path")
             .attr("d", d => {
-                return `M${xAxis(d.x)},${yAxis(d.y)} ${hexbin.hexagon(radius * 0.75)}`;
+                return `M${xAxis(d.x)},${yAxis(d.y)} ${hexbin.hexagon(drawRadius)}`;
             })
             .attr("fill", (d) => color(d.length))
             .append("title")

--- a/src/core/operations/Charts.js
+++ b/src/core/operations/Charts.js
@@ -1,0 +1,205 @@
+import * as d3 from "d3";
+import {hexbin as d3hexbin} from "d3-hexbin";
+import Utils from "../Utils.js";
+
+/**
+ * Charting operations.
+ *
+ * @author tlwr [toby@toby.com]
+ * @copyright Crown Copyright 2016
+ * @license Apache-2.0
+ *
+ * @namespace
+ */
+const Charts = {
+    /**
+     * @constant
+     * @default
+     */
+    RECORD_DELIMITER_OPTIONS: ["Line feed", "CRLF"],
+
+
+    /**
+     * @constant
+     * @default
+     */
+    FIELD_DELIMITER_OPTIONS: ["Space", "Comma", "Semi-colon", "Colon", "Tab"],
+
+
+    /**
+     * Gets values from input for a scatter plot.
+     *
+     * @param {string} input
+     * @param {string} recordDelimiter
+     * @param {string} fieldDelimiter
+     * @param {boolean} columnHeadingsAreIncluded - whether we should skip the first record
+     * @returns {Object[]}
+     */
+    _getScatterValues(input, recordDelimiter, fieldDelimiter, columnHeadingsAreIncluded) {
+        let headings;
+        const values = [];
+
+        input
+            .split(recordDelimiter)
+            .forEach((row, rowIndex) => {
+                let split = row.split(fieldDelimiter);
+
+                if (split.length !== 2) throw "Each row must have length 2.";
+
+                if (columnHeadingsAreIncluded && rowIndex === 0) {
+                    headings = {};
+                    headings.x = split[0];
+                    headings.y = split[1];
+                } else {
+                    let x = split[0],
+                        y = split[1];
+
+                    x = parseFloat(x, 10);
+                    if (Number.isNaN(x)) throw "Values must be numbers in base 10.";
+
+                    y = parseFloat(y, 10);
+                    if (Number.isNaN(y)) throw "Values must be numbers in base 10.";
+
+                    values.push([x, y]);
+                }
+            });
+
+        return { headings, values};
+    },
+
+
+    /**
+     * Hex Bin chart operation.
+     *
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {html}
+     */
+    runHexDensityChart: function (input, args) {
+        const recordDelimiter = Utils.charRep[args[0]],
+            fieldDelimiter = Utils.charRep[args[1]],
+            radius = args[2],
+            columnHeadingsAreIncluded = args[3],
+            dimension = 500;
+
+        let xLabel = args[4],
+            yLabel = args[5],
+            { headings, values } = Charts._getScatterValues(
+                input,
+                recordDelimiter,
+                fieldDelimiter,
+                columnHeadingsAreIncluded
+            );
+
+        if (headings) {
+            xLabel = headings.x;
+            yLabel = headings.y;
+        }
+
+        let svg = document.createElement("svg");
+        svg = d3.select(svg)
+            .attr("width", "100%")
+            .attr("height", "100%")
+            .attr("viewBox", `0 0 ${dimension} ${dimension}`);
+
+        let margin = {
+                top: 0,
+                right: 0,
+                bottom: 30,
+                left: 30,
+            },
+            width = dimension - margin.left - margin.right,
+            height = dimension - margin.top - margin.bottom,
+            marginedSpace = svg.append("g")
+                .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+        let hexbin = d3hexbin()
+            .radius(radius)
+            .extent([0, 0], [width, height]);
+
+        let hexPoints = hexbin(values),
+            maxCount = Math.max(...hexPoints.map(b => b.length));
+
+        let xExtent = d3.extent(hexPoints, d => d.x),
+            yExtent = d3.extent(hexPoints, d => d.y);
+        xExtent[0] -= 2 * radius;
+        xExtent[1] += 2 * radius;
+        yExtent[0] -= 2 * radius;
+        yExtent[1] += 2 * radius;
+
+        let xAxis = d3.scaleLinear()
+            .domain(xExtent)
+            .range([0, width]);
+        let yAxis = d3.scaleLinear()
+            .domain(yExtent)
+            .range([height, 0]);
+
+        let color = d3.scaleSequential(d3.interpolateLab("white", "steelblue"))
+            .domain([0, maxCount]);
+
+        marginedSpace.append("clipPath")
+            .attr("id", "clip")
+            .append("rect")
+            .attr("width", width)
+            .attr("height", height);
+
+        marginedSpace.append("g")
+            .attr("class", "hexagon")
+            .attr("clip-path", "url(#clip)")
+            .selectAll("path")
+            .data(hexPoints)
+            .enter()
+            .append("path")
+            .attr("d", d => {
+                return `M${xAxis(d.x)},${yAxis(d.y)} ${hexbin.hexagon(radius * 0.75)}`;
+            })
+            .attr("fill", (d) => color(d.length))
+            .append("title")
+            .text(d => {
+                let count = d.length,
+                    perc = 100.0 * d.length / values.length,
+                    CX = d.x,
+                    CY = d.y,
+                    xMin = Math.min(...d.map(d => d[0])),
+                    xMax = Math.max(...d.map(d => d[0])),
+                    yMin = Math.min(...d.map(d => d[1])),
+                    yMax = Math.max(...d.map(d => d[1])),
+                    tooltip = `Count: ${count}\n
+                               Percentage: ${perc.toFixed(2)}%\n
+                               Center: ${CX.toFixed(2)}, ${CY.toFixed(2)}\n
+                               Min X: ${xMin.toFixed(2)}\n
+                               Max X: ${xMax.toFixed(2)}\n
+                               Min Y: ${yMin.toFixed(2)}\n
+                               Max Y: ${yMax.toFixed(2)}
+                    `.replace(/\s{2,}/g, "\n");
+                return tooltip;
+            });
+
+        marginedSpace.append("g")
+            .attr("class", "axis axis--y")
+            .call(d3.axisLeft(yAxis).tickSizeOuter(-width));
+
+        svg.append("text")
+            .attr("transform", "rotate(-90)")
+            .attr("y", -margin.left)
+            .attr("x", -(height / 2))
+            .attr("dy", "1em")
+            .style("text-anchor", "middle")
+            .text(yLabel);
+
+        marginedSpace.append("g")
+            .attr("class", "axis axis--x")
+            .attr("transform", "translate(0," + height + ")")
+            .call(d3.axisBottom(xAxis).tickSizeOuter(-height));
+
+        svg.append("text")
+            .attr("x", width / 2)
+            .attr("y", dimension)
+            .style("text-anchor", "middle")
+            .text(xLabel);
+
+        return svg._groups[0][0].outerHTML;
+    },
+};
+
+export default Charts;

--- a/src/core/operations/Charts.js
+++ b/src/core/operations/Charts.js
@@ -69,6 +69,19 @@ const Charts = {
 
 
     /**
+     * Default from colour
+     *
+     * @constant
+     * @default
+     */
+    COLOURS: {
+        min: "white",
+        max: "black",
+    },
+
+
+
+    /**
      * Hex Bin chart operation.
      *
      * @param {string} input
@@ -81,6 +94,9 @@ const Charts = {
             packRadius = args[2],
             drawRadius = args[3],
             columnHeadingsAreIncluded = args[4],
+            drawEdges = args[7],
+            minColour = args[8],
+            maxColour = args[9],
             dimension = 500;
 
         let xLabel = args[5],
@@ -135,7 +151,7 @@ const Charts = {
             .domain(yExtent)
             .range([height, 0]);
 
-        let color = d3.scaleSequential(d3.interpolateLab("white", "steelblue"))
+        let colour = d3.scaleSequential(d3.interpolateLab(minColour, maxColour))
             .domain([0, maxCount]);
 
         marginedSpace.append("clipPath")
@@ -154,7 +170,9 @@ const Charts = {
             .attr("d", d => {
                 return `M${xAxis(d.x)},${yAxis(d.y)} ${hexbin.hexagon(drawRadius)}`;
             })
-            .attr("fill", (d) => color(d.length))
+            .attr("fill", (d) => colour(d.length))
+            .attr("stroke", drawEdges ? "black" : "none")
+            .attr("stroke-width", drawEdges ? "0.5" : "none")
             .append("title")
             .text(d => {
                 let count = d.length,

--- a/src/core/operations/HTML.js
+++ b/src/core/operations/HTML.js
@@ -851,6 +851,16 @@ const HTML = {
         "diams" : 9830,
     },
 
+    /**
+     * HTML to text operation
+     *
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    runHTMLToText(input, args) {
+        return input;
+    },
 };
 
 export default HTML;


### PR DESCRIPTION
CyberChef is very useful for slicing and dicing and some analysis, but I often find myself dumping CyberChef output into GNUPlot or a spreadsheet to do some analysis. With a module system in the works I thought charting be a good candidate for an initial module.

Currently I'm using D3 to generate SVGs, this method allows us to just save the generated SVG for embedding elsewhere.

Currently I have implemented:
+ Hexagon density charts

I would love to see in the comments what visualisations or charts would be useful: links to blog posts, pictures, and d3 blocks would be highly appreciated.

Here is the Hexagon density chart (heavily influenced by [this block](https://bl.ocks.org/mbostock/4248145)):
![image](https://cloud.githubusercontent.com/assets/1482692/26600125/da32848e-4548-11e7-93b1-78861422445f.png)
