### PR TITLE
Fixing issues of image error when building dev

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -206,14 +206,14 @@ module.exports = function (grunt) {
                                 limit: 10000
                             }
                         },
-                        { // First party images are saved as files to be cached
-                            test: /\.(png|jpg|gif|svg)$/,
-                            exclude: /node_modules/,
-                            loader: "file-loader",
-                            options: {
-                                name: "images/[name].[ext]"
-                            }
-                        },
+                        // { // First party images are saved as files to be cached
+                            // test: /\.(png|jpg|gif|svg)$/,
+                            // exclude: /node_modules/,
+                            // loader: "file-loader",
+                            // options: {
+                                // name: "images/[name].[ext]"
+                            // }
+                        // },
                         { // Third party images are inlined
                             test: /\.(png|jpg|gif|svg)$/,
                             exclude: /web\/static/,
@@ -321,7 +321,7 @@ module.exports = function (grunt) {
                 },
                 src: "build/prod/index.html",
                 dest: "build/prod/index.html"
-            }
+            },
         },
         chmod: {
             build: {


### PR DESCRIPTION
Fixing issues on packing images into build #webpack #base64 #loader

The problem now is that:
When you do `grunt dev`, all the images are double encoded with base64 and saved as files. By default, HTML do not load up data base64 images in this way, so I removed the loader part and images are now converted into data URI base64 inline in the HTML.

I didn't try on build prod, but I assume it has the same issue. I can see that the Webpack part is still under development, this should temp fix for people who want to use the tool at the moment.