### PR TITLE
Hash URLs

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -982,6 +982,37 @@ const Utils = {
 
 
     /**
+     * Parses URI parameters into a JSON object.
+     *
+     * @param {string} paramStr - The serialised query or hash section of a URI
+     * @returns {object}
+     *
+     * @example
+     * // returns {a: 'abc', b: '123'}
+     * Utils.parseURIParams("?a=abc&b=123")
+     * Utils.parseURIParams("#a=abc&b=123")
+     */
+    parseURIParams: function(paramStr) {
+        if (paramStr === "") return {};
+
+        // Cut off ? or # and split on &
+        const params = paramStr.substr(1).split("&");
+
+        const result = {};
+        for (let i = 0; i < params.length; i++) {
+            const param = params[i].split("=");
+            if (param.length !== 2) {
+                result[params[i]] = true;
+            } else {
+                result[param[0]] = decodeURIComponent(param[1].replace(/\+/g, " "));
+            }
+        }
+
+        return result;
+    },
+
+
+    /**
      * Actual modulo function, since % is actually the remainder function in JS.
      *
      * @author Matt C [matt@artemisbot.pw]

--- a/src/web/ControlsWaiter.js
+++ b/src/web/ControlsWaiter.js
@@ -174,20 +174,21 @@ ControlsWaiter.prototype.generateStateUrl = function(includeRecipe, includeInput
     const inputStr = Utils.toBase64(this.app.getInput(), "A-Za-z0-9+/"); // B64 alphabet with no padding
 
     includeRecipe = includeRecipe && (recipeConfig.length > 0);
-    includeInput = includeInput && (inputStr.length > 0) && (inputStr.length < 8000);
+    // Only inlcude input if it is less than 50KB (51200 * 4/3 as it is Base64 encoded)
+    includeInput = includeInput && (inputStr.length > 0) && (inputStr.length <= 68267);
 
     const params = [
         includeRecipe ? ["recipe", recipeStr] : undefined,
         includeInput ? ["input", inputStr] : undefined,
     ];
 
-    const query = params
+    const hash = params
        .filter(v => v)
        .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
        .join("&");
 
-    if (query) {
-        return `${link}?${query}`;
+    if (hash) {
+        return `${link}#${hash}`;
     }
 
     return link;

--- a/src/web/static/ga.html
+++ b/src/web/static/ga.html
@@ -9,7 +9,7 @@
 
   ga('create', 'UA-85682716-2', 'auto');
 
-  // Specifying location.pathname here overrides the default URL which would include arguments.
+  // Specifying location.pathname here overrides the default URL which could include arguments.
   // This method prevents Google Analytics from logging any recipe or input data in the URL.
   ga('send', 'pageview', location.pathname);
 


### PR DESCRIPTION
The recipe and input are now stored in the hash (#) part of the URL instead of the query/search (?) part. This has a number of benefits:

- The hash is never sent to the server, so it is not limited by HTTP request length rules.
- This also means the server cannot see what recipe and input you are using (Google Analytics was already deliberately prevented from seeing these but this is a further privacy safeguard).
- Logically it makes more sense to store these details in the hash, as they are not required by the server.

CyberChef will only include the input in the URL if it is less than 50KB. This is a rather arbitrary size and can be changed if anyone has any particular feelings on the matter.

This seems like a good time to remind people that there is an option to turn off URL updating in the 'Options' pane.

Old style query (?) URLs will still load correctly.