### PR TITLE
[Fix] Removing the restriction to UNIX only.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,7 @@
             "ArrayExpression": "first",
             "SwitchCase": 1
         }],
-        "linebreak-style": ["error", "unix"],
+        // "linebreak-style": ["error", "unix"], // Disabling this to let Windows run
         "quotes": ["error", "double", {
             "avoidEscape": true
         }],


### PR DESCRIPTION
It is a small fix to delete the line for compiling the project in UNIX only.
I have tested it on Windows 7 and it works perfectly.