### PR TITLE
[Feature] HTTP Gzip payload decryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "lodash": "^4.17.4",
     "moment": "^2.17.1",
     "moment-timezone": "^0.5.11",
+    "pako": "^1.0.5",
     "sladex-blowfish": "^0.8.1",
     "sortablejs": "^1.5.1",
     "split.js": "^1.2.0",

--- a/src/core/config/Categories.js
+++ b/src/core/config/Categories.js
@@ -130,6 +130,7 @@ const Categories = [
         ops: [
             "HTTP request",
             "Strip HTTP headers",
+            "HTTP gzip decrypt",
             "Parse User Agent",
             "Parse IP range",
             "Parse IPv6 address",

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -1678,6 +1678,13 @@ const OperationConfig = {
         outputType: "string",
         args: []
     },
+    "HTTP gzip decrypt": {
+        description: "Decrypts Gzip payload from a request or response and returning plaintext of the header and decrypted payload.",
+        run: Compress.runHttpGzip,
+        inputType: "byteArray",
+        outputType: "byteArray",
+        args: []
+    },
     "Parse User Agent": {
         description: "Attempts to identify and categorise information contained in a user-agent string.",
         run: HTTP.runParseUserAgent,

--- a/src/core/operations/Compress.js
+++ b/src/core/operations/Compress.js
@@ -5,6 +5,7 @@ import zlibAndGzip from "zlibjs/bin/zlib_and_gzip.min";
 import zip from "zlibjs/bin/zip.min";
 import unzip from "zlibjs/bin/unzip.min";
 import bzip2 from "exports-loader?bzip2!../lib/bzip2.js";
+import pako from "pako/index.js";
 
 const Zlib = {
     RawDeflate: rawdeflate.Zlib.RawDeflate,
@@ -251,6 +252,26 @@ const Compress = {
         input = Utils.strToByteArray(Utils.byteArrayToUtf8(input));
         const gunzip = new Zlib.Gunzip(input);
         return Array.prototype.slice.call(gunzip.decompress());
+    },
+
+
+    /**
+     * HTTP Gzip operation.
+     *
+     * @param {byteArray} input
+     * @param {Object[]} args
+     * @returns {byteArray}
+     */
+    runHttpGzip: function(input, args) {
+        input = Utils.byteArrayToHex(input, "");
+
+        let regexStr = /1f8b080[0-8][0-9a-f]{12}/;
+        let gzipPos = input.search(regexStr);
+        let plainData = input.substr(0, gzipPos);
+        let gzipData = input.substr(gzipPos);
+
+        gzipData = Utils.hexToByteArray(gzipData);
+        return Utils.hexToByteArray(plainData).concat(Array.prototype.slice.call(pako.ungzip(gzipData)));
     },
 
 


### PR DESCRIPTION
[ADD] Library Pako (https://github.com/nodeca/pako)
[ADD] Operation: HTTP Gzip Decrypt - Decrypts gzip payload in HTTP request/response and keeps the HTTP header in the result


As the original library CyberChef using (zlib.js - https://github.com/imaya/zlib.js) has different bugs that cause failing decrypting gzip. I worked out that Pako can provide better/faster/stable way to decrypt gzip. The operation I added utilize this library for gzip payload. Although there is still a minor bug when the payload is too long, the overall result is pretty good.

**I do not own/participate on this Pako library.**