### PR TITLE
Adds support to build/run CyberChef in a Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.4
+
+RUN addgroup cyberchef -S && \
+    adduser cyberchef -G cyberchef -S && \
+    apk update && \
+    apk add git nodejs && \
+    rm -rf /var/cache/apk/* && \
+    npm install -g grunt-cli && \
+    npm install -g http-server
+
+COPY . /srv/CyberChef
+
+RUN cd /srv/CyberChef && \
+    rm -rf .git && \
+    npm install && \
+    npm cache rm && \
+    apk del git && \
+    chown -R cyberchef:cyberchef /srv/CyberChef && \
+    grunt prod
+
+WORKDIR /srv/CyberChef/build/prod
+USER cyberchef
+ENTRYPOINT ["http-server", "-p", "8000"]


### PR DESCRIPTION
Build and/or run CyberChef in a Docker container. Eases development and integration of CyberChef and can even be used to serve production deployments.

This example will build a CyberChef container-image and sart an container instance serving op 8000/tcp:

```
docker build -t CyberChef .
docker run -d -p 8000:8000 CyberChef
```
