### PR TITLE
Bug fix: Substitute commas

### DIFF
--- a/src/core/operations/Cipher.js
+++ b/src/core/operations/Cipher.js
@@ -766,8 +766,8 @@ const Cipher = {
      * @returns {string}
      */
     runSubstitute: function (input, args) {
-        let plaintext = Utils.expandAlphRange(args[0]).join(),
-            ciphertext = Utils.expandAlphRange(args[1]).join(),
+        let plaintext = Utils.expandAlphRange(args[0]).join(""),
+            ciphertext = Utils.expandAlphRange(args[1]).join(""),
             output = "",
             index = -1;
 


### PR DESCRIPTION
Fixes a bug in the Substitute operation that was preventing commas from being converted correctly.

Discovered when decoding a question asked in the GCHQ Twitter Q&A: https://twitter.com/GCHQ/status/901026153024106497

Solution here: https://gchq.github.io/CyberChef/#recipe=Substitute('SNVFRGHJOKL:%3CMP%7BWTDYIBECUXsnvfrghjokl;,mp%5Bwtdyibecux','ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz')&input=RWpzeSBvZCB1cGl0IGdzYnBpdG95ciBIVkpXIFtpeHg7cj8KU211eWpvbWggZ3RwLCB5anIgW2l4eDtyIG5wcGw