### PR TITLE
Registers - pass input as arguments

### DIFF
--- a/src/core/ChefWorker.js
+++ b/src/core/ChefWorker.js
@@ -92,7 +92,7 @@ async function bake(data) {
     } catch (err) {
         self.postMessage({
             action: "bakeError",
-            data: err.message
+            data: err.message.split(":").slice(1).join(":").slice(1) // Cut off worker blurb
         });
     }
 }
@@ -182,13 +182,15 @@ self.setOption = function(option, value) {
  * Send register values back to the app.
  *
  * @param {number} opIndex
+ * @param {number} numPrevRegisters
  * @param {string[]} registers
  */
-self.setRegisters = function(opIndex, registers) {
+self.setRegisters = function(opIndex, numPrevRegisters, registers) {
     self.postMessage({
         action: "setRegisters",
         data: {
             opIndex: opIndex,
+            numPrevRegisters: numPrevRegisters,
             registers: registers
         }
     });

--- a/src/core/ChefWorker.js
+++ b/src/core/ChefWorker.js
@@ -176,3 +176,20 @@ self.setOption = function(option, value) {
         }
     });
 };
+
+
+/**
+ * Send register values back to the app.
+ *
+ * @param {number} opIndex
+ * @param {string[]} registers
+ */
+self.setRegisters = function(opIndex, registers) {
+    self.postMessage({
+        action: "setRegisters",
+        data: {
+            opIndex: opIndex,
+            registers: registers
+        }
+    });
+};

--- a/src/core/FlowControl.js
+++ b/src/core/FlowControl.js
@@ -127,14 +127,13 @@ const FlowControl = {
          */
         function replaceRegister(str) {
             // Replace references to registers ($Rn) with contents of registers
-            str = str ? str.replace(/((?:^|[^\\])(?:\\.|[^\\])*?)\$R(\d{1,2})/g, (match, pre, regNum) => {
+            return str.replace(/(\\*)\$R(\d{1,2})/g, (match, slashes, regNum) => {
                 const index = parseInt(regNum, 10) + 1;
-                return (index <= state.numRegisters || index >= state.numRegisters + registers.length) ?
-                    match : pre + registers[index - state.numRegisters];
-            }) : str;
-
-            // Unescape remaining register references
-            return str ? str.replace(/\\\$R(\d{1,2})/, "$R$1") : str;
+                if (index <= state.numRegisters || index >= state.numRegisters + registers.length)
+                    return match;
+                if (slashes.length % 2 !== 0) return match.slice(1); // Remove escape
+                return slashes + registers[index - state.numRegisters];
+            });
         }
 
         // Step through all subsequent ops and replace registers in args with extracted content

--- a/src/core/FlowControl.js
+++ b/src/core/FlowControl.js
@@ -113,6 +113,12 @@ const FlowControl = {
             input = state.dish.get(Dish.STRING),
             registers = input.match(extractor);
 
+        if (!registers) return state;
+
+        if (ENVIRONMENT_IS_WORKER()) {
+            self.setRegisters(state.progress, registers.slice(1));
+        }
+
         /**
          * Replaces references to registers (e.g. $R0) with the contents of those registers.
          *

--- a/src/core/Recipe.js
+++ b/src/core/Recipe.js
@@ -145,7 +145,7 @@ Recipe.prototype.lastOpIndex = function(startIndex) {
  */
 Recipe.prototype.execute = async function(dish, startFrom) {
     startFrom = startFrom || 0;
-    let op, input, output, numJumps = 0;
+    let op, input, output, numJumps = 0, numRegisters = 0;
 
     for (let i = startFrom; i < this.opList.length; i++) {
         op = this.opList[i];
@@ -162,15 +162,17 @@ Recipe.prototype.execute = async function(dish, startFrom) {
             if (op.isFlowControl()) {
                 // Package up the current state
                 let state = {
-                    "progress": i,
-                    "dish":     dish,
-                    "opList":   this.opList,
-                    "numJumps": numJumps
+                    "progress":     i,
+                    "dish":         dish,
+                    "opList":       this.opList,
+                    "numJumps":     numJumps,
+                    "numRegisters": numRegisters
                 };
 
                 state = await op.run(state);
                 i = state.progress;
                 numJumps = state.numJumps;
+                numRegisters = state.numRegisters;
             } else {
                 output = await op.run(input, op.getIngValues());
                 dish.set(output, op.outputType);

--- a/src/core/config/Categories.js
+++ b/src/core/config/Categories.js
@@ -317,6 +317,7 @@ const Categories = [
         ops: [
             "Fork",
             "Merge",
+            "Register",
             "Jump",
             "Conditional Jump",
             "Return",

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -116,6 +116,30 @@ const OperationConfig = {
         flowControl: true,
         args: []
     },
+    "Register": {
+        module: "Default",
+        description: "Extract data from the input and store it in registers which can then be passed into subsequent operations as arguments. Regular expression capture groups are used to select the data to extract.<br><br>To use registers in arguments, refer to them using the notation <code>$Rn</code> where n is the register number, starting at 0.<br><br>For example:<br>Input: <code>Test</code><br>Extractor: <code>(.*)</code><br>Argument: <code>$R0</code> becomes <code>Test</code><br><br>Registers can be escaped in arguments using a backslash. e.g. <code>\\$R0</code> would become <code>$R0</code> rather than <code>Test</code>.",
+        inputType: "string",
+        outputType: "string",
+        flowControl: true,
+        args: [
+            {
+                name: "Extractor",
+                type: "binaryString",
+                value: "([\\s\\S]*)"
+            },
+            {
+                name: "Case insensitive",
+                type: "boolean",
+                value: true
+            },
+            {
+                name: "Multiline matching",
+                type: "boolean",
+                value: false
+            },
+        ]
+    },
     "Jump": {
         module: "Default",
         description: "Jump forwards or backwards over the specified number of operations.",

--- a/src/core/config/modules/Default.js
+++ b/src/core/config/modules/Default.js
@@ -154,6 +154,7 @@ OpModules.Default = {
     "Generate HOTP":        OTP.runHOTP,
     "Fork":                 FlowControl.runFork,
     "Merge":                FlowControl.runMerge,
+    "Register":             FlowControl.runRegister,
     "Jump":                 FlowControl.runJump,
     "Conditional Jump":     FlowControl.runCondJump,
     "Return":               FlowControl.runReturn,

--- a/src/web/RecipeWaiter.js
+++ b/src/web/RecipeWaiter.js
@@ -1,5 +1,6 @@
 import HTMLOperation from "./HTMLOperation.js";
 import Sortable from "sortablejs";
+import Utils from "../core/Utils.js";
 
 
 /**
@@ -433,6 +434,31 @@ RecipeWaiter.prototype.opAdd = function(e) {
  */
 RecipeWaiter.prototype.opRemove = function(e) {
     window.dispatchEvent(this.manager.statechange);
+};
+
+
+/**
+ * Sets register values.
+ *
+ * @param {number} opIndex
+ * @param {string[]} registers
+ */
+RecipeWaiter.prototype.setRegisters = function(opIndex, registers) {
+    const op = document.querySelector(`#rec-list .operation:nth-child(${opIndex + 1})`),
+        prevRegList = op.querySelector(".register-list");
+
+    // Remove previous div
+    if (prevRegList) prevRegList.remove();
+
+    let registerList = [];
+    for (let i = 0; i < registers.length; i++) {
+        registerList.push(`$R${i} = ${Utils.truncate(Utils.printable(registers[i]), 100)}`);
+    }
+    const registerListEl = `<div class="register-list">
+            ${registerList.join("<br>")}
+        </div>`;
+
+    op.insertAdjacentHTML("beforeend", registerListEl);
 };
 
 export default RecipeWaiter;

--- a/src/web/RecipeWaiter.js
+++ b/src/web/RecipeWaiter.js
@@ -441,18 +441,19 @@ RecipeWaiter.prototype.opRemove = function(e) {
  * Sets register values.
  *
  * @param {number} opIndex
+ * @param {number} numPrevRegisters
  * @param {string[]} registers
  */
-RecipeWaiter.prototype.setRegisters = function(opIndex, registers) {
+RecipeWaiter.prototype.setRegisters = function(opIndex, numPrevRegisters, registers) {
     const op = document.querySelector(`#rec-list .operation:nth-child(${opIndex + 1})`),
         prevRegList = op.querySelector(".register-list");
 
     // Remove previous div
     if (prevRegList) prevRegList.remove();
-
+window.Utils = Utils;
     let registerList = [];
     for (let i = 0; i < registers.length; i++) {
-        registerList.push(`$R${i} = ${Utils.truncate(Utils.printable(registers[i]), 100)}`);
+        registerList.push(`$R${numPrevRegisters + i} = ${Utils.escapeHtml(Utils.truncate(Utils.printable(registers[i]), 100))}`);
     }
     const registerListEl = `<div class="register-list">
             ${registerList.join("<br>")}

--- a/src/web/RecipeWaiter.js
+++ b/src/web/RecipeWaiter.js
@@ -450,7 +450,7 @@ RecipeWaiter.prototype.setRegisters = function(opIndex, numPrevRegisters, regist
 
     // Remove previous div
     if (prevRegList) prevRegList.remove();
-window.Utils = Utils;
+
     let registerList = [];
     for (let i = 0; i < registers.length; i++) {
         registerList.push(`$R${numPrevRegisters + i} = ${Utils.escapeHtml(Utils.truncate(Utils.printable(registers[i]), 100))}`);

--- a/src/web/WorkerWaiter.js
+++ b/src/web/WorkerWaiter.js
@@ -61,6 +61,9 @@ WorkerWaiter.prototype.handleChefMessage = function(e) {
         case "optionUpdate":
             this.app.options[r.data.option] = r.data.value;
             break;
+        case "setRegisters":
+            this.manager.recipe.setRegisters(r.data.opIndex, r.data.registers);
+            break;
         case "highlightsCalculated":
             this.manager.highlighter.displayHighlights(r.data.pos, r.data.direction);
             break;

--- a/src/web/WorkerWaiter.js
+++ b/src/web/WorkerWaiter.js
@@ -62,7 +62,7 @@ WorkerWaiter.prototype.handleChefMessage = function(e) {
             this.app.options[r.data.option] = r.data.value;
             break;
         case "setRegisters":
-            this.manager.recipe.setRegisters(r.data.opIndex, r.data.registers);
+            this.manager.recipe.setRegisters(r.data.opIndex, r.data.numPrevRegisters, r.data.registers);
             break;
         case "highlightsCalculated":
             this.manager.highlighter.displayHighlights(r.data.pos, r.data.direction);

--- a/src/web/stylesheets/components/_operation.css
+++ b/src/web/stylesheets/components/_operation.css
@@ -201,3 +201,13 @@ button.dropdown-toggle {
     background-color: var(--disabled-bg-colour) !important;
     border-color: var(--disabled-border-colour) !important;
 }
+
+.break .register-list {
+    color: var(--fc-breakpoint-operation-font-colour) !important;
+    background-color: var(--fc-breakpoint-operation-border-colour) !important;
+}
+
+.disabled .register-list {
+    color: var(--disabled-font-colour) !important;
+    background-color: var(--disabled-border-colour) !important;
+}

--- a/src/web/stylesheets/components/_operation.css
+++ b/src/web/stylesheets/components/_operation.css
@@ -124,6 +124,12 @@ button.dropdown-toggle {
     background-color: var(--secondary-background-colour);
 }
 
+.register-list {
+    background-color: var(--fc-operation-border-colour);
+    font-family: var(--fixed-width-font-family);
+    padding: 10px;
+}
+
 .op-icon {
     float: right;
     margin-left: 10px;


### PR DESCRIPTION
This PR introduces the 'Register' operation which allows you to extract data from the input and store it in registers which can then be used in subsequent operation arguments.

![image](https://user-images.githubusercontent.com/22770796/30984635-c17a4714-a485-11e7-8c6c-be5017ae369b.png)

Multiple registers can be created in a single operation, and multiple register operations can be used together.

![image](https://user-images.githubusercontent.com/22770796/30984764-2fb90490-a486-11e7-8d11-620aa56b0b24.png)

This closes #26.