### PR TITLE
BugFix: compare odd size elements, like empty line

### DIFF
--- a/src/core/operations/SeqUtils.js
+++ b/src/core/operations/SeqUtils.js
@@ -249,7 +249,7 @@ const SeqUtils = {
             }
         }
 
-        return 0;
+        return a.localeCompare(b);
     },
 
 };

--- a/test/tests/operations/SeqUtils.js
+++ b/test/tests/operations/SeqUtils.js
@@ -10,8 +10,8 @@ import TestRegister from "../../TestRegister.js";
 TestRegister.addTests([
     {
         name: "SeqUtils - Numeric sort photos",
-        input: "Photo-1.jpg\nPhoto-4.jpg\nPhoto-2.jpg\nPhoto-3.jpg\n",
-        expectedOutput: "Photo-1.jpg\nPhoto-2.jpg\nPhoto-3.jpg\nPhoto-4.jpg\n",
+        input: "Photo-1.jpg\nPhoto-4.jpg\nPhoto-2.jpg\nPhoto-3.jpg",
+        expectedOutput: "Photo-1.jpg\nPhoto-2.jpg\nPhoto-3.jpg\nPhoto-4.jpg",
         recipeConfig: [
             {
                 "op": "Sort",


### PR DESCRIPTION
This PR fixes a small bug in my previous PR #142. Instead of assuming strings that are of different size are equal, the function now relays on a regular string compare.

**Before**
```
Input:
11
9

10
d

b
c
a

Output:
9
11

d
10

b
c
a
```

**After**
```
Input:
11
9

10
d

b
c
a

Output:


a
b
c
d
9
10
11
```