### PR TITLE
Bugfix: UUID operation using webworkers

### DIFF
--- a/src/core/operations/UUID.js
+++ b/src/core/operations/UUID.js
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 /**
  * UUID operations.
  *
@@ -17,25 +18,17 @@ const UUID = {
      * @returns {string}
      */
     runGenerateV4: function(input, args) {
-        if (window && typeof(window.crypto) !== "undefined" && typeof(window.crypto.getRandomValues) !== "undefined") {
-            let buf = new Uint32Array(4),
-                i = 0;
-            window.crypto.getRandomValues(buf);
-            return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function(c) {
-                let r = (buf[i >> 3] >> ((i % 8) * 4)) & 0xf,
-                    v = c === "x" ? r : (r & 0x3 | 0x8);
-                i++;
-                return v.toString(16);
-            });
-        } else {
-            return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function(c) {
-                let r = Math.random() * 16 | 0,
-                    v = c === "x" ? r : (r & 0x3 | 0x8);
-                return v.toString(16);
-            });
-        }
-    },
-
+        const buf = new Uint32Array(4).map(() => {
+            return crypto.randomBytes(4).readUInt32BE(0, true);
+        });
+        let i = 0;
+        return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function(c) {
+            let r = (buf[i >> 3] >> ((i % 8) * 4)) & 0xf,
+                v = c === "x" ? r : (r & 0x3 | 0x8);
+            i++;
+            return v.toString(16);
+        });
+    }
 };
 
 export default UUID;


### PR DESCRIPTION
Fixes UUID issue brought up in the [Gitter channel](https://gitter.im/gchq/CyberChef) where the operation had become unusable due to webworkers having no access to the `window` object. UUID operation now uses the native `crypto` package from Node.