### PR TITLE
Make Split more flexible so it can be used to join

### DIFF
--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -2125,13 +2125,13 @@ const OperationConfig = {
         args: [
             {
                 name: "Split delimiter",
-                type: "binaryShortString",
-                value: StrUtils.SPLIT_DELIM
+                type: "editableOption",
+                value: StrUtils.SPLIT_DELIM_OPTIONS
             },
             {
                 name: "Join delimiter",
-                type: "option",
-                value: StrUtils.DELIMITER_OPTIONS
+                type: "editableOption",
+                value: StrUtils.JOIN_DELIM_OPTIONS
             }
         ]
     },

--- a/src/core/operations/StrUtils.js
+++ b/src/core/operations/StrUtils.js
@@ -65,12 +65,28 @@ const StrUtils = {
      * @constant
      * @default
      */
-    SPLIT_DELIM: ",",
+    SPLIT_DELIM_OPTIONS: [
+        {name: "Line feed", value: "\\n"},
+        {name: "CRLF", value: "\\r\\n"},
+        {name: "Space", value: " "},
+        {name: "Comma", value: ","},
+        {name: "Semi-colon", value: ";"},
+        {name: "Colon", value: ":"},
+        {name: "Nothing (separate chars)", value: ""}
+    ],
     /**
      * @constant
      * @default
      */
-    DELIMITER_OPTIONS: ["Line feed", "CRLF", "Space", "Comma", "Semi-colon", "Colon", "Nothing (separate chars)"],
+    JOIN_DELIM_OPTIONS: [
+        {name: "Line feed", value: "\\n"},
+        {name: "CRLF", value: "\\r\\n"},
+        {name: "Space", value: " "},
+        {name: "Comma", value: ","},
+        {name: "Semi-colon", value: ";"},
+        {name: "Colon", value: ":"},
+        {name: "Nothing (join chars)", value: ""}
+    ],
 
     /**
      * Split operation.
@@ -80,8 +96,8 @@ const StrUtils = {
      * @returns {string}
      */
     runSplit: function(input, args) {
-        let splitDelim = args[0] || StrUtils.SPLIT_DELIM,
-            joinDelim = Utils.charRep[args[1]],
+        let splitDelim = args[0],
+            joinDelim = args[1],
             sections = input.split(splitDelim);
 
         return sections.join(joinDelim);


### PR DESCRIPTION
This PR realizes the use of "editableOption" for the two parameters of Split;
- Split delimiter
- Join delimiter

The benefit is that a user is free to enter any other delimiters, making Split way more powerful. It can now actually be used to rejoin the input to a different output format.

For example, the input contains items per line and the output show have all items on one line, separated by comma's:
```
Input:
Item1
Item2
Item3

Split delimiter: \n
Join delimiter: , (<comma><space>)

Output:
Item1, Item2, Item3
```

Before it was not possible to use multiple characters as Join delimiter. Additionally some suggestions for the Split delimiter are offered.