### PR TITLE
BUGFIX: UTF-8 handling in hashing operations

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -495,15 +495,16 @@ const Utils = {
      * Converts an ArrayBuffer to a string.
      *
      * @param {ArrayBuffer} arrayBuffer
+     * @param {boolean} [utf8=true] - Whether to attempt to decode the buffer as UTF-8
      * @returns {string}
      *
      * @example
      * // returns "hello"
      * Utils.arrayBufferToStr(Uint8Array.from([104,101,108,108,111]).buffer);
      */
-    arrayBufferToStr: function(arrayBuffer) {
+    arrayBufferToStr: function(arrayBuffer, utf8=true) {
         const byteArray = Array.prototype.slice.call(new Uint8Array(arrayBuffer));
-        return Utils.byteArrayToUtf8(byteArray);
+        return utf8 ? Utils.byteArrayToUtf8(byteArray) : Utils.byteArrayToChars(byteArray);
     },
 
 

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -3010,21 +3010,21 @@ const OperationConfig = {
     "MD2": {
         module: "Hashing",
         description: "The MD2 (Message-Digest 2) algorithm is a cryptographic hash function developed by Ronald Rivest in 1989. The algorithm is optimized for 8-bit computers.<br><br>Although MD2 is no longer considered secure, even as of 2014, it remains in use in public key infrastructures as part of certificates generated with MD2 and RSA.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: []
     },
     "MD4": {
         module: "Hashing",
         description: "The MD4 (Message-Digest 4) algorithm is a cryptographic hash function developed by Ronald Rivest in 1990. The digest length is 128 bits. The algorithm has influenced later designs, such as the MD5, SHA-1 and RIPEMD algorithms.<br><br>The security of MD4 has been severely compromised.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: []
     },
     "MD5": {
         module: "Hashing",
         description: "MD5 (Message-Digest 5) is a widely used hash function. It has been used in a variety of security applications and is also commonly used to check the integrity of files.<br><br>However, MD5 is not collision resistant and it isn't suitable for applications like SSL/TLS certificates or digital signatures that rely on this property.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: []
     },
@@ -3054,21 +3054,21 @@ const OperationConfig = {
     "SHA0": {
         module: "Hashing",
         description: "SHA-0 is a retronym applied to the original version of the 160-bit hash function published in 1993 under the name 'SHA'. It was withdrawn shortly after publication due to an undisclosed 'significant flaw' and replaced by the slightly revised version SHA-1.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: []
     },
     "SHA1": {
         module: "Hashing",
         description: "The SHA (Secure Hash Algorithm) hash functions were designed by the NSA. SHA-1 is the most established of the existing SHA hash functions and it is used in a variety of security applications and protocols.<br><br>However, SHA-1's collision resistance has been weakening as new attacks are discovered or improved.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: []
     },
     "SHA2": {
         module: "Hashing",
         description: "The SHA-2 (Secure Hash Algorithm 2) hash functions were designed by the NSA. SHA-2 includes significant changes from its predecessor, SHA-1. The SHA-2 family consists of hash functions with digests (hash values) that are 224, 256, 384 or 512 bits: SHA224, SHA256, SHA384, SHA512.<br><br><ul><li>SHA-512 operates on 64-bit words.</li><li>SHA-256 operates on 32-bit words.</li><li>SHA-384 is largely identical to SHA-512 but is truncated to 384 bytes.</li><li>SHA-224 is largely identical to SHA-256 but is truncated to 224 bytes.</li><li>SHA-512/224 and SHA-512/256 are truncated versions of SHA-512, but the initial values are generated using the method described in Federal Information Processing Standards (FIPS) PUB 180-4.</li></ul>",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: [
             {
@@ -3081,7 +3081,7 @@ const OperationConfig = {
     "SHA3": {
         module: "Hashing",
         description: "The SHA-3 (Secure Hash Algorithm 3) hash functions were released by NIST on August 5, 2015. Although part of the same series of standards, SHA-3 is internally quite different from the MD5-like structure of SHA-1 and SHA-2.<br><br>SHA-3 is a subset of the broader cryptographic primitive family Keccak designed by Guido Bertoni, Joan Daemen, Michaël Peeters, and Gilles Van Assche, building upon RadioGatún.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: [
             {
@@ -3094,7 +3094,7 @@ const OperationConfig = {
     "Keccak": {
         module: "Hashing",
         description: "The Keccak hash algorithm was designed by Guido Bertoni, Joan Daemen, Michaël Peeters, and Gilles Van Assche, building upon RadioGatún. It was selected as the winner of the SHA-3 design competition.<br><br>This version of the algorithm is Keccak[c=2d] and differs from the SHA-3 specification.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: [
             {
@@ -3107,7 +3107,7 @@ const OperationConfig = {
     "Shake": {
         module: "Hashing",
         description: "Shake is an Extendable Output Function (XOF) of the SHA-3 hash algorithm, part of the Keccak family, allowing for variable output length/size.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: [
             {
@@ -3126,7 +3126,7 @@ const OperationConfig = {
     "RIPEMD": {
         module: "Hashing",
         description: "RIPEMD (RACE Integrity Primitives Evaluation Message Digest) is a family of cryptographic hash functions developed in Leuven, Belgium, by Hans Dobbertin, Antoon Bosselaers and Bart Preneel at the COSIC research group at the Katholieke Universiteit Leuven, and first published in 1996.<br><br>RIPEMD was based upon the design principles used in MD4, and is similar in performance to the more popular SHA-1.<br><br>",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: [
             {
@@ -3139,14 +3139,14 @@ const OperationConfig = {
     "HAS-160": {
         module: "Hashing",
         description: "HAS-160 is a cryptographic hash function designed for use with the Korean KCDSA digital signature algorithm. It is derived from SHA-1, with assorted changes intended to increase its security. It produces a 160-bit output.<br><br>HAS-160 is used in the same way as SHA-1. First it divides input in blocks of 512 bits each and pads the final block. A digest function updates the intermediate hash value by processing the input blocks in turn.<br><br>The message digest algorithm consists of 80 rounds.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: []
     },
     "Whirlpool": {
         module: "Hashing",
         description: "Whirlpool is a cryptographic hash function designed by Vincent Rijmen (co-creator of AES) and Paulo S. L. M. Barreto, who first described it in 2000.<br><br>Several variants exist:<ul><li>Whirlpool-0 is the original version released in 2000.</li><li>Whirlpool-T is the first revision, released in 2001, improving the generation of the s-box.</li><li>Wirlpool is the latest revision, released in 2003, fixing a flaw in the difusion matrix.</li></ul>",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: [
             {
@@ -3159,7 +3159,7 @@ const OperationConfig = {
     "Snefru": {
         module: "Hashing",
         description: "Snefru is a cryptographic hash function invented by Ralph Merkle in 1990 while working at Xerox PARC. The function supports 128-bit and 256-bit output. It was named after the Egyptian Pharaoh Sneferu, continuing the tradition of the Khufu and Khafre block ciphers.<br><br>The original design of Snefru was shown to be insecure by Eli Biham and Adi Shamir who were able to use differential cryptanalysis to find hash collisions. The design was then modified by increasing the number of iterations of the main pass of the algorithm from two to eight.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: [
             {
@@ -3177,7 +3177,7 @@ const OperationConfig = {
     "HMAC": {
         module: "Hashing",
         description: "Keyed-Hash Message Authentication Codes (HMAC) are a mechanism for message authentication using cryptographic hash functions.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: [
             {
@@ -3244,7 +3244,7 @@ const OperationConfig = {
     "Generate all hashes": {
         module: "Hashing",
         description: "Generates all available hashes and checksums for the input.",
-        inputType: "string",
+        inputType: "ArrayBuffer",
         outputType: "string",
         args: []
     },

--- a/test/tests/operations/Hash.js
+++ b/test/tests/operations/Hash.js
@@ -415,4 +415,264 @@ TestRegister.addTests([
             }
         ]
     },
+    {
+        name: "MD5: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "4f4f02e2646545aa8fc42f613c9aa068",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "MD5",
+                "args": []
+            }
+        ]
+    },
+    {
+        name: "SHA1: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "2c5400aaee7e8ad4cad29bfbdf8d566924e5442c",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA1",
+                "args": []
+            }
+        ]
+    },
+    {
+        name: "SHA2 224: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "66c166eba2529ecc44a7b7b218a64a8e3892f873c8d231e8e3c1ef3d",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA2",
+                "args": ["224"]
+            }
+        ]
+    },
+    {
+        name: "SHA2 256: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "186ffd22c3af83995afa4a0316023f81a7f8834fd16bd2ed358c7b1b8182ba41",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA2",
+                "args": ["256"]
+            }
+        ]
+    },
+    {
+        name: "SHA2 384: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "2a6369ffec550ea0bfb810b3b8246b7d6b7f060edfae88441f0f242b98b91549aa4ff407de38c6d03b5f377434ad2f36",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA2",
+                "args": ["384"]
+            }
+        ]
+    },
+    {
+        name: "SHA2 512: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "544ae686522c05b70d12b460b5b39ea0a758eb4027333edbded7e2b3f467aa605804f71f54db61a7bbe50e6e7898510635efd6721fd418a9ea4d05b286d12806",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA2",
+                "args": ["512"]
+            }
+        ]
+    },
+    {
+        name: "SHA3 224: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "e2c07562ee8c2d73e3dd309efea257159abd0948ebc14619bab9ffb3",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA3",
+                "args": ["224"]
+            }
+        ]
+    },
+    {
+        name: "SHA3 256: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "55a55275387586afd1ed64757c9ee7ad1d96ca81a5b7b742c40127856ee78a2d",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA3",
+                "args": ["256"]
+            }
+        ]
+    },
+    {
+        name: "SHA3 384: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "39f8796dd697dc39e5a943817833793f2c29dc0d1adc7037854c0fb51e135c6bd26b113240c4fb1e3fcc16ff8690c91a",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA3",
+                "args": ["384"]
+            }
+        ]
+    },
+    {
+        name: "SHA3 512: Complex bytes",
+        input: "10dc10e32010de10d010dc10d810d910d010e12e",
+        expectedOutput: "ee9061bed83b1ad1e2fc4a4bac72a5a65a23a0fa55193b808af0a3e2013b718a5a3e40474765b4f93d1b2747401058a5b58099cc890a159db92b2ea816287add",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "SHA3",
+                "args": ["512"]
+            }
+        ]
+    },
+    {
+        name: "MD5: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "2e93ee2b5b2a337ccb678c7db12eff1b",
+        recipeConfig: [
+            {
+                "op": "MD5",
+                "args": []
+            }
+        ]
+    },
+    {
+        name: "SHA1: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "87f483b1515dce672be044bf183ae8103e3b2d4b",
+        recipeConfig: [
+            {
+                "op": "SHA1",
+                "args": []
+            }
+        ]
+    },
+    {
+        name: "SHA2 224: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "563ca57b500157717961a5fa87ce42c6db76a488c98ea9c28d620770",
+        recipeConfig: [
+            {
+                "op": "SHA2",
+                "args": ["224"]
+            }
+        ]
+    },
+    {
+        name: "SHA2 256: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "36abbb4622ffff06aa3e3cea266765601b21457bb3755a0a2cf0a206422863c1",
+        recipeConfig: [
+            {
+                "op": "SHA2",
+                "args": ["256"]
+            }
+        ]
+    },
+    {
+        name: "SHA2 384: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "140b929391a66c9a943bcd60e6964f0d19526d3bc9ba020fbb29aae51cddb8e63a78784d8770f1d36335bf4efff8c131",
+        recipeConfig: [
+            {
+                "op": "SHA2",
+                "args": ["384"]
+            }
+        ]
+    },
+    {
+        name: "SHA2 512: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "04a7887c400bf647b7c67b9a0f1ada70d176348b5afdfebea184f7e62748849828669c7b5160be99455fdbf625589bd1689c003bc06ef60c39607d825a2f8838",
+        recipeConfig: [
+            {
+                "op": "SHA2",
+                "args": ["512"]
+            }
+        ]
+    },
+    {
+        name: "SHA3 224: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "b3ffc9620949f879cb561fb240452494e2566cb4e4f701a85715e14f",
+        recipeConfig: [
+            {
+                "op": "SHA3",
+                "args": ["224"]
+            }
+        ]
+    },
+    {
+        name: "SHA3 256: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "b5f247d725b46546c832502cd07bccb5d4de0c41a6665d3944ed2cc55cd9d156",
+        recipeConfig: [
+            {
+                "op": "SHA3",
+                "args": ["256"]
+            }
+        ]
+    },
+    {
+        name: "SHA3 384: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "93e87b9aa8c9c47eba146adac357c525b418b71677f6db01d1c760d87b058682e639c8d43a8bfe91529cecd9800700e3",
+        recipeConfig: [
+            {
+                "op": "SHA3",
+                "args": ["384"]
+            }
+        ]
+    },
+    {
+        name: "SHA3 512: UTF-8",
+        input: "ნუ პანიკას",
+        expectedOutput: "1fbc484b5184982561795162757717474eebc846ca9f10029a75a54cdd897a7b48d1db42f2478fa1d5d213a0dd7de71c809cb19c60581ba57e7289d29408fb36",
+        recipeConfig: [
+            {
+                "op": "SHA3",
+                "args": ["512"]
+            }
+        ]
+    },
 ]);


### PR DESCRIPTION
The hashing operations were causing various bugs in certain circumstances.

Tests have been added for the following input types:
- Plain ASCII text
- Complex binary input
- UTF-8 text

Expected test results were generated using Python3.6 hashlib.

Hashing operations now all take input as an ArrayBuffer and decode strings as UTF-8 by default. Binary input is handled correctly. All tests currently pass.

Closes #249.