### PR TITLE
Added decoder for chunked HTTP encoding

### DIFF
--- a/src/core/config/Categories.js
+++ b/src/core/config/Categories.js
@@ -150,6 +150,7 @@ const Categories = [
         ops: [
             "HTTP request",
             "Strip HTTP headers",
+            "Dechunk HTTP response",
             "Parse User Agent",
             "Parse IP range",
             "Parse IPv6 address",

--- a/src/core/config/OperationConfig.js
+++ b/src/core/config/OperationConfig.js
@@ -1846,6 +1846,13 @@ const OperationConfig = {
         outputType: "string",
         args: []
     },
+    "Dechunk HTTP response": {
+        module: "HTTP",
+        description: "Parses a HTTP response transferred using transfer-encoding:chunked",
+        inputType: "string",
+        outputType: "string",
+        args: []
+    },
     "Parse User Agent": {
         module: "HTTP",
         description: "Attempts to identify and categorise information contained in a user-agent string.",

--- a/src/core/config/modules/HTTP.js
+++ b/src/core/config/modules/HTTP.js
@@ -16,6 +16,7 @@ let OpModules = typeof self === "undefined" ? {} : self.OpModules || {};
 OpModules.HTTP = {
     "HTTP request":       HTTP.runHTTPRequest,
     "Strip HTTP headers": HTTP.runStripHeaders,
+    "Dechunk HTTP response": HTTP.runDechunk,
     "Parse User Agent":   HTTP.runParseUserAgent,
 };
 

--- a/src/core/operations/HTTP.js
+++ b/src/core/operations/HTTP.js
@@ -37,6 +37,28 @@ const HTTP = {
         return (headerEnd < 2) ? input : input.slice(headerEnd, input.length);
     },
 
+    /**
+     * Dechunk response operation
+     *
+     * @param {string} input
+     * @param {Object[]} args}
+     * @returns {string}
+    */
+    runDechunk: function(input, args) {
+        var chunks = [];
+        var chunkSizeEnd = input.indexOf("\n") + 1;
+        var lineEndings = input.charAt(chunkSizeEnd - 2) == "\r" ? "\r\n" : "\n";
+        var lineEndingsLength = lineEndings.length;
+        var chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        while (!isNaN(chunkSize)) {
+            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd)); 
+            input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
+            chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
+            chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        }
+        return chunks.join('') + input;
+    },
+
 
     /**
      * Parse User Agent operation.

--- a/src/core/operations/HTTP.js
+++ b/src/core/operations/HTTP.js
@@ -45,18 +45,18 @@ const HTTP = {
      * @returns {string}
     */
     runDechunk: function(input, args) {
-        var chunks = [];
-        var chunkSizeEnd = input.indexOf("\n") + 1;
-        var lineEndings = input.charAt(chunkSizeEnd - 2) == "\r" ? "\r\n" : "\n";
-        var lineEndingsLength = lineEndings.length;
-        var chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        let chunks = [];
+        let chunkSizeEnd = input.indexOf("\n") + 1;
+        let lineEndings = input.charAt(chunkSizeEnd - 2) === "\r" ? "\r\n" : "\n";
+        let lineEndingsLength = lineEndings.length;
+        let chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
         while (!isNaN(chunkSize)) {
-            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd)); 
+            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd));
             input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
             chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
             chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
         }
-        return chunks.join('') + input;
+        return chunks.join("") + input;
     },
 
 


### PR DESCRIPTION
This decoder will join up a HTTP response sent using chunked transfer encoding, raised in issue #168.

This is useful when attempting to extract files or gzipped responses sent using chunked transfer encoding, particularly when combined with the gunzip operation.