### PR TITLE
Added decoder for chunked HTTP encoding

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -137,6 +137,7 @@
         "ops": [
             "HTTP request",
             "Strip HTTP headers",
+            "Dechunk HTTP response",
             "Parse User Agent",
             "Parse IP range",
             "Parse IPv6 address",

--- a/src/core/config/scripts/portOperation.mjs
+++ b/src/core/config/scripts/portOperation.mjs
@@ -2239,6 +2239,13 @@ const OP_CONFIG = {
         outputType: "string",
         args: []
     },
+    "Dechunk HTTP response": {
+        module: "HTTP",
+        description: "Parses a HTTP response transferred using transfer-encoding:chunked",
+        inputType: "string",
+        outputType: "string",
+        args: []
+    },
     "Parse User Agent": {
         module: "HTTP",
         description: "Attempts to identify and categorise information contained in a user-agent string.",

--- a/src/core/operations/DechunkHTTP.mjs
+++ b/src/core/operations/DechunkHTTP.mjs
@@ -31,18 +31,18 @@ class DechunkHTTP extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        var chunks = [];
-        var chunkSizeEnd = input.indexOf("\n") + 1;
-        var lineEndings = input.charAt(chunkSizeEnd - 2) == "\r" ? "\r\n" : "\n";
-        var lineEndingsLength = lineEndings.length;
-        var chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        let chunks = [];
+        let chunkSizeEnd = input.indexOf("\n") + 1;
+        let lineEndings = input.charAt(chunkSizeEnd - 2) === "\r" ? "\r\n" : "\n";
+        let lineEndingsLength = lineEndings.length;
+        let chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
         while (!isNaN(chunkSize)) {
             chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd)); 
             input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
             chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
             chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
         }
-        return chunks.join('') + input;
+        return chunks.join("") + input;
     }
 
 }

--- a/src/core/operations/DechunkHTTP.mjs
+++ b/src/core/operations/DechunkHTTP.mjs
@@ -31,13 +31,13 @@ class DechunkHTTP extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        let chunks = [];
+        const chunks = [];
         let chunkSizeEnd = input.indexOf("\n") + 1;
-        let lineEndings = input.charAt(chunkSizeEnd - 2) === "\r" ? "\r\n" : "\n";
-        let lineEndingsLength = lineEndings.length;
+        const lineEndings = input.charAt(chunkSizeEnd - 2) === "\r" ? "\r\n" : "\n";
+        const lineEndingsLength = lineEndings.length;
         let chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
         while (!isNaN(chunkSize)) {
-            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd)); 
+            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd));
             input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
             chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
             chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);

--- a/src/core/operations/DechunkHTTP.mjs
+++ b/src/core/operations/DechunkHTTP.mjs
@@ -1,0 +1,50 @@
+/**
+ * @author sevzero [sevzero@protonmail.com]
+ * @copyright Crown Copyright 2016
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation";
+
+/**
+ * Dechunk HTTP response operation
+ */
+class DechunkHTTP extends Operation {
+
+    /**
+     * DechunkHTTP constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Dechunk HTTP response";
+        this.module = "Default";
+        this.description = "Parses a HTTP response transferred using transfer-encoding:chunked";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        var chunks = [];
+        var chunkSizeEnd = input.indexOf("\n") + 1;
+        var lineEndings = input.charAt(chunkSizeEnd - 2) == "\r" ? "\r\n" : "\n";
+        var lineEndingsLength = lineEndings.length;
+        var chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        while (!isNaN(chunkSize)) {
+            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd)); 
+            input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
+            chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
+            chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        }
+        return chunks.join('') + input;
+    }
+
+}
+
+export default DechunkHTTP;

--- a/src/core/operations/legacy/HTTP.js
+++ b/src/core/operations/legacy/HTTP.js
@@ -45,18 +45,18 @@ const HTTP = {
      * @returns {string}
     */
     runDechunk: function(input, args) {
-        var chunks = [];
-        var chunkSizeEnd = input.indexOf("\n") + 1;
-        var lineEndings = input.charAt(chunkSizeEnd - 2) == "\r" ? "\r\n" : "\n";
-        var lineEndingsLength = lineEndings.length;
-        var chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        let chunks = [];
+        let chunkSizeEnd = input.indexOf("\n") + 1;
+        let lineEndings = input.charAt(chunkSizeEnd - 2) === "\r" ? "\r\n" : "\n";
+        let lineEndingsLength = lineEndings.length;
+        let chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
         while (!isNaN(chunkSize)) {
             chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd)); 
             input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
             chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
             chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
         }
-        return chunks.join('') + input;
+        return chunks.join("") + input;
     },
 
     /**

--- a/src/core/operations/legacy/HTTP.js
+++ b/src/core/operations/legacy/HTTP.js
@@ -45,13 +45,13 @@ const HTTP = {
      * @returns {string}
     */
     runDechunk: function(input, args) {
-        let chunks = [];
+        const chunks = [];
         let chunkSizeEnd = input.indexOf("\n") + 1;
-        let lineEndings = input.charAt(chunkSizeEnd - 2) === "\r" ? "\r\n" : "\n";
-        let lineEndingsLength = lineEndings.length;
+        const lineEndings = input.charAt(chunkSizeEnd - 2) === "\r" ? "\r\n" : "\n";
+        const lineEndingsLength = lineEndings.length;
         let chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
         while (!isNaN(chunkSize)) {
-            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd)); 
+            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd));
             input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
             chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
             chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);

--- a/src/core/operations/legacy/HTTP.js
+++ b/src/core/operations/legacy/HTTP.js
@@ -37,6 +37,27 @@ const HTTP = {
         return (headerEnd < 2) ? input : input.slice(headerEnd, input.length);
     },
 
+    /**
+     * Dechunk response operation
+     *
+     * @param {string} input
+     * @param {Object[]} args}
+     * @returns {string}
+    */
+    runDechunk: function(input, args) {
+        var chunks = [];
+        var chunkSizeEnd = input.indexOf("\n") + 1;
+        var lineEndings = input.charAt(chunkSizeEnd - 2) == "\r" ? "\r\n" : "\n";
+        var lineEndingsLength = lineEndings.length;
+        var chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        while (!isNaN(chunkSize)) {
+            chunks.push(input.slice(chunkSizeEnd, chunkSize + chunkSizeEnd)); 
+            input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
+            chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
+            chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+        }
+        return chunks.join('') + input;
+    },
 
     /**
      * Parse User Agent operation.


### PR DESCRIPTION
This decoder will join up a HTTP response sent using chunked transfer encoding, raised in issue #168.

This is useful when attempting to extract files or gzipped responses sent using chunked transfer encoding, particularly when combined with the gunzip operation.

Resubmitted this PR to the esm branch - Please let me know if I've made any errors.

GCHQ OSS Contributor License Agreement has been signed.