### PR TITLE
Add "Play Audio" Operation

### DIFF
--- a/src/core/Utils.mjs
+++ b/src/core/Utils.mjs
@@ -1065,6 +1065,31 @@ class Utils {
         }[token];
     }
 
+
+    /**
+     * Turns a dataURI into a byte array.
+     * Credit to sanddune (https://jsfiddle.net/uubnnr0w/380/)
+     *
+     * @param {String} dataURI
+     * @returns {Array}
+     */
+    static convertDataURIToBinary(dataURI) {
+        const BASE64_MARKER = ";base64,";
+        const base64Index = dataURI.indexOf(BASE64_MARKER) + BASE64_MARKER.length;
+        const base64 = dataURI.substring(base64Index);
+
+        const raw = atob(base64);
+        const rawLength = raw.length;
+
+        const array = new Uint8Array(new ArrayBuffer(rawLength));
+
+        for (let i = 0; i < rawLength; i++) {
+            array[i] = raw.charCodeAt(i);
+        }
+
+        return array;
+    }
+
 }
 
 export default Utils;

--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -204,7 +204,8 @@
             "Escape string",
             "Unescape string",
             "Pseudo-Random Number Generator",
-            "Sleep"
+            "Sleep",
+            "Play Audio"
         ]
     },
     {

--- a/src/core/operations/PlayAudio.mjs
+++ b/src/core/operations/PlayAudio.mjs
@@ -1,0 +1,60 @@
+/**
+ * @author gchq77703 []
+ * @copyright Crown Copyright 2018
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation";
+import Utils from "../Utils";
+
+/**
+ * Play Audio operation
+ */
+class PlayAudio extends Operation {
+
+    /**
+     * PlayAudio constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Play Audio";
+        this.module = "Default";
+        this.description = "Plays an audio file from a base 64 encoded data URI.  URI must contain a valid audio mediatype.";
+        this.infoURL = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.presentType = "html";
+        this.args = [];
+    }
+
+    /**
+     * Presents a given Data URI as an audio element.
+     *
+     * @param {String} input
+     * @returns {String}
+     */
+    present(input) {
+        const type = input.split(";")[0].split(":")[1];
+        const binary = Utils.convertDataURIToBinary(input);
+        const blob = new Blob([binary], { type: type});
+        const src = URL.createObjectURL(blob);
+
+
+        return `<audio id="audio" controls>
+                    <source id="audioSource" src="${src}" type="${type}"/>
+                </audio>`;
+    }
+
+    /**
+     * @param {String} input
+     * @param {Object[]} args
+     * @returns {String}
+     */
+    run(input, args) {
+        return input;
+    }
+
+}
+
+export default PlayAudio;

--- a/src/core/operations/PlayAudio.mjs
+++ b/src/core/operations/PlayAudio.mjs
@@ -37,7 +37,7 @@ class PlayAudio extends Operation {
     present(input) {
         const type = input.split(";")[0].split(":")[1];
         const binary = Utils.convertDataURIToBinary(input);
-        const blob = new Blob([binary], { type: type});
+        const blob = new Blob([binary], { type: type });
         const src = URL.createObjectURL(blob);
 
 


### PR DESCRIPTION
Adds the ability to render a media data URI into a playable audio file.  These look something like [this](https://hastebin.com/raw/unuwokidur).  To get this into something that's playable we parse the data URI for it's type and convert the rest into binary data.  We then create a blob from this data and from that blob we can create a blob URI which is a valid `src` on an audio element.

Creating this from the `File` type would seem simple following that logic, as it is just an extension to a `Blob`.  Unfortunately, this is not the case because it appears `Dish.mjs` doesn't persist the type of a file (nor could I see a way of it doing so, especially due to the MIME type possibly changing through processing).