### PR TITLE
CSS label / register-list Aesthetics

### DIFF
--- a/src/web/stylesheets/components/_operation.css
+++ b/src/web/stylesheets/components/_operation.css
@@ -116,6 +116,13 @@ div.toggle-string {
     left: 12px;
 }
 
+.operation label.bmd-label-floating {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    width: calc(100% - 13px);
+}
+
 .operation .bmd-form-group .bmd-help {
     margin-top: -17px;
 }
@@ -172,6 +179,7 @@ div.toggle-string {
     background-color: var(--fc-operation-border-colour);
     font-family: var(--fixed-width-font-family);
     padding: 10px;
+    word-break: break-all;
 }
 
 .op-icon {


### PR DESCRIPTION
Occasionally depending on the page width and the operation used, the label.bmd-label-floating's wraps and covers the input - CSS to hide the wrap

On register-list, if the regex match is not words (spaces that can be wrapped) and longer than the div, it'll overrun - added CSS of word-break: break-all