### PR TITLE
Stop treating backslashes in CSV as escape character

### DIFF
--- a/src/core/Utils.mjs
+++ b/src/core/Utils.mjs
@@ -555,8 +555,6 @@ class Utils {
             if (renderNext) {
                 cell += b;
                 renderNext = false;
-            } else if (b === "\\") {
-                renderNext = true;
             } else if (b === "\"" && !inString) {
                 inString = true;
             } else if (b === "\"" && inString) {


### PR DESCRIPTION
Fixes #375.

This just removes the logic to ignore backslashes and only render the next character, which seems to work as expected.