### PR TITLE
Use toggleString for Key in HMAC

### DIFF
--- a/src/core/operations/HMAC.mjs
+++ b/src/core/operations/HMAC.mjs
@@ -28,8 +28,9 @@ class HMAC extends Operation {
         this.args = [
             {
                 "name": "Key",
-                "type": "binaryString",
-                "value": ""
+                "type": "toggleString",
+                "value": "",
+                "toggleValues": ["Hex", "Decimal", "Base64", "UTF8", "Latin1"]
             },
             {
                 "name": "Hashing function",
@@ -66,7 +67,7 @@ class HMAC extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const key = args[0],
+        const key = Utils.convertToByteString(args[0].string || "", args[0].option),
             hashFunc = args[1].toLowerCase(),
             msg = Utils.arrayBufferToStr(input, false),
             hasher = CryptoApi.getHasher(hashFunc);

--- a/test/tests/operations/Hash.mjs
+++ b/test/tests/operations/Hash.mjs
@@ -411,7 +411,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "HMAC",
-                "args": ["test", "SHA256"]
+                "args": [{"option": "Latin1", "string": "test"}, "SHA256"]
             }
         ]
     },


### PR DESCRIPTION
Use toggleString for Key in HMAC as proposed in #263. This makes HMAC additionally support keys formatted as:
- Hex
- Decimal
- Base64
- UTF-8

HMAC will produce the same results as before when using `Latin1`:
```
Input: asdffa

Old recipe: HMAC('01020304€','MD5')

New recipe: HMAC({'option':'Latin1','string':'01020304€'},'MD5')

Output: 4f0fa244b0dd2f9c257abc906bdf2a7a
```