### PR TITLE
Add url defang

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -207,7 +207,8 @@
             "Escape string",
             "Unescape string",
             "Pseudo-Random Number Generator",
-            "Sleep"
+            "Sleep",
+            "Defang URL"
         ]
     },
     {

--- a/src/core/operations/DefangURL.mjs
+++ b/src/core/operations/DefangURL.mjs
@@ -1,0 +1,43 @@
+/**
+ * @author arnydo [arnydo@protonmail.com]
+ * @copyright Crown Copyright 2016
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation";
+
+/**
+ * DefangURL operation
+ */
+class DefangURL extends Operation {
+
+    /**
+     * DefangURL constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Defang URL";
+        this.module = "URL";
+        this.description = "Takes a Universal Resource Locator (URL) and 'Defangs' it; meaning, the URL becomes invalid and neutralizes the risk of accidentally clicking on a malicious link.<br><br>This is often used when dealing with malicious links or IOCs.<br><br>Works well when combined with the 'Extract URLs' operation.";
+        this.infoURL = "";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        let defang = input.replace(/http/gi, "hxxp");
+        defang = defang.replace(/\./g, "[.]");
+        defang = defang.replace(/:\/\//g, "[://]");
+        return defang;
+    }
+
+}
+
+export default DefangURL;


### PR DESCRIPTION
Simple operation to "Defang" a URL. Replaces "." with "[.]" and "://" with "[://]" to render the URL invalid and prevent accidental clicking/browsing. Often used with IOCs.

Works well when used after the "ExtractURLs" operation.

Example:
https://baddomain.io/badfile.exe -> hxxps[://]baddomain[.]io/badfile[.]exe