### PR TITLE
Fixing the babel, scrypt, and base58 issues

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,7 @@
                 "node": "6.5"
             },
             "modules": false,
-            "useBuiltIns": "usage"
+            "useBuiltIns": "entry"
         }]
     ],
     "plugins": [

--- a/src/core/operations/FromBase58.mjs
+++ b/src/core/operations/FromBase58.mjs
@@ -103,9 +103,8 @@ class FromBase58 extends Operation {
             }
         });
 
-        while (zeroPrefix > 0) {
+        while (zeroPrefix--) {
             result.push(0);
-            zeroPrefix--;
         }
 
         return result.reverse();

--- a/src/core/operations/FromBase58.mjs
+++ b/src/core/operations/FromBase58.mjs
@@ -71,6 +71,11 @@ class FromBase58 extends Operation {
 
         if (input.length === 0) return [];
 
+        let zeroPrefix = 0;
+        for (let i = 0; i < input.length && input[i] === alphabet[0]; i++) {
+            zeroPrefix++;
+        }
+
         [].forEach.call(input, function(c, charIndex) {
             const index = alphabet.indexOf(c);
 
@@ -97,6 +102,11 @@ class FromBase58 extends Operation {
                 carry = carry >> 8;
             }
         });
+
+        while (zeroPrefix > 0) {
+            result.push(0);
+            zeroPrefix--;
+        }
 
         return result.reverse();
     }

--- a/src/core/operations/Scrypt.mjs
+++ b/src/core/operations/Scrypt.mjs
@@ -62,7 +62,7 @@ class Scrypt extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const salt = Utils.convertToByteString(args[0].string || "", args[0].option),
+        const salt = Buffer.from(Utils.convertToByteArray(args[0].string || "", args[0].option)),
             iterations = args[1],
             memFactor = args[2],
             parallelFactor = args[3],

--- a/src/core/operations/ToBase58.mjs
+++ b/src/core/operations/ToBase58.mjs
@@ -53,6 +53,11 @@ class ToBase58 extends Operation {
 
         if (input.length === 0) return "";
 
+        let zeroPrefix = 0;
+        for (let i = 0; i < input.length && input[i] === 0; i++) {
+            zeroPrefix++;
+        }
+
         input.forEach(function(b) {
             let carry = (result[0] << 8) + b;
             result[0] = carry % 58;
@@ -74,7 +79,7 @@ class ToBase58 extends Operation {
             return alphabet[b];
         }).reverse().join("");
 
-        while (result.length < input.length) {
+        while (zeroPrefix--) {
             result = alphabet[0] + result;
         }
 

--- a/test/tests/operations/Base58.mjs
+++ b/test/tests/operations/Base58.mjs
@@ -54,6 +54,28 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "To Base58 with null prefix and suffix",
+        input: "\0\0\0Hello\0\0\0",
+        expectedOutput: "111D7LMXYjHjTu",
+        recipeConfig: [
+            {
+                op: "To Base58",
+                args: ["123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"],
+            },
+        ],
+    },
+    {
+        name: "From Base58 with null prefix and suffix",
+        input: "111D7LMXYjHjTu",
+        expectedOutput: "\0\0\0Hello\0\0\0",
+        recipeConfig: [
+            {
+                op: "From Base58",
+                args: ["123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"],
+            },
+        ],
+    },
+    {
         name: "From Base58 (Bitcoin): 'StV1DL6CwTryKyV'",
         input: "StV1DL6CwTryKyV",
         expectedOutput: "hello world",


### PR DESCRIPTION
This should hopefully fix a few issues:
Static file loading issues: #388, #395, #393 (I also am not experiencing a #402 CharEnc issue with this build but I am not sure if this is a fix for this issue)
Scrypt using string for salt: #401 
Base58 converting \x00 at begining and ending incorrectly: #380