### PR TITLE
Fix HMAC operation when hex key has bytes >= 0x80 (#437)

### DIFF
--- a/src/core/operations/HMAC.mjs
+++ b/src/core/operations/HMAC.mjs
@@ -72,7 +72,7 @@ class HMAC extends Operation {
             msg = Utils.arrayBufferToStr(input, false),
             hasher = CryptoApi.getHasher(hashFunc);
 
-        const mac = CryptoApi.getHmac(CryptoApi.encoder.fromUtf(key), hasher);
+        const mac = CryptoApi.getHmac(key, hasher);
         mac.update(msg);
         return CryptoApi.encoder.toHex(mac.finalize());
     }

--- a/test/tests/operations/Hash.mjs
+++ b/test/tests/operations/Hash.mjs
@@ -405,13 +405,309 @@ TestRegister.addTests([
         ]
     },
     {
-        name: "HMAC SHA256",
+        name: "HMAC: SHA256",
         input: "Hello, World!",
         expectedOutput: "52589bd80ccfa4acbb3f9512dfaf4f700fa5195008aae0b77a9e47dcca75beac",
         recipeConfig: [
             {
                 "op": "HMAC",
                 "args": [{"option": "Latin1", "string": "test"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 1 SHA-224",
+        input: "Hi There",
+        expectedOutput: "896fb1128abbdf196832107cd49df33f47b4b1169912ba4f53684b22",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"}, "SHA224"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 1 SHA-256",
+        input: "Hi There",
+        expectedOutput: "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 1 SHA-384",
+        input: "Hi There",
+        expectedOutput: "afd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59cfaea9ea9076ede7f4af152e8b2fa9cb6",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"}, "SHA384"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 1 SHA-512",
+        input: "Hi There",
+        expectedOutput: "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"}, "SHA512"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 2 SHA-224",
+        input: "what do ya want for nothing?",
+        expectedOutput: "a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "4a656665"}, "SHA224"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 2 SHA-256",
+        input: "what do ya want for nothing?",
+        expectedOutput: "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "4a656665"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 2 SHA-384",
+        input: "what do ya want for nothing?",
+        expectedOutput: "af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "4a656665"}, "SHA384"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 2 SHA-512",
+        input: "what do ya want for nothing?",
+        expectedOutput: "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "4a656665"}, "SHA512"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 3 SHA-224",
+        input: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        expectedOutput: "7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA224"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 3 SHA-256",
+        input: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        expectedOutput: "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 3 SHA-384",
+        input: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        expectedOutput: "88062608d3e6ad8a0aa2ace014c8a86f0aa635d947ac9febe83ef4e55966144b2a5ab39dc13814b94e3ab6e101a34f27",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA384"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 3 SHA-512",
+        input: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        expectedOutput: "fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA512"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 4 SHA-224",
+        input: "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        expectedOutput: "6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "0102030405060708090a0b0c0d0e0f10111213141516171819"}, "SHA224"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 4 SHA-256",
+        input: "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        expectedOutput: "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "0102030405060708090a0b0c0d0e0f10111213141516171819"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 4 SHA-384",
+        input: "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        expectedOutput: "3e8a69b7783c25851933ab6290af6ca77a9981480850009cc5577c6e1f573b4e6801dd23c4a7d679ccf8a386c674cffb",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "0102030405060708090a0b0c0d0e0f10111213141516171819"}, "SHA384"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 4 SHA-512",
+        input: "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        expectedOutput: "b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["None"]
+            },
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "0102030405060708090a0b0c0d0e0f10111213141516171819"}, "SHA512"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 6 SHA-224",
+        input: "Test Using Larger Than Block-Size Key - Hash Key First",
+        expectedOutput: "95e9a0db962095adaebe9b2d6f0dbce2d499f112f2d2b7273fa6870e",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA224"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 6 SHA-256",
+        input: "Test Using Larger Than Block-Size Key - Hash Key First",
+        expectedOutput: "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 6 SHA-384",
+        input: "Test Using Larger Than Block-Size Key - Hash Key First",
+        expectedOutput: "4ece084485813e9088d2c63a041bc5b44f9ef1012a2b588f3cd11f05033ac4c60c2ef6ab4030fe8296248df163f44952",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA384"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 6 SHA-512",
+        input: "Test Using Larger Than Block-Size Key - Hash Key First",
+        expectedOutput: "80b24263c7c1a3ebb71493c1dd7be8b49b46d1f41b4aeec1121b013783f8f3526b56d037e05f2598bd0fd2215d6a1e5295e64f73f63f0aec8b915a985d786598",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA512"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 7 SHA-224",
+        input: "This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
+        expectedOutput: "3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA224"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 7 SHA-256",
+        input: "This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
+        expectedOutput: "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 7 SHA-384",
+        input: "This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
+        expectedOutput: "6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5a678cc31e799176d3860e6110c46523e",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA384"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: RFC4231 Test Case 7 SHA-512",
+        input: "This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
+        expectedOutput: "e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Hex", "string": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "SHA512"]
             }
         ]
     },


### PR DESCRIPTION
Add test vectors from RFC4231