### PR TITLE
To/From Insensitive Regex Operations

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -189,6 +189,8 @@
             "Remove null bytes",
             "To Upper case",
             "To Lower case",
+			"To Case Insensitive Regex",
+			"From Case Insensitive Regex",
             "Add line numbers",
             "Remove line numbers",
             "To Table",

--- a/src/core/operations/FromCaseInsensitiveRegex.mjs
+++ b/src/core/operations/FromCaseInsensitiveRegex.mjs
@@ -1,0 +1,39 @@
+/**
+ * @author masq [github.cyberchef@masq.cc]
+ * @copyright Crown Copyright 2018
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation";
+
+/**
+ * From Case Insensitive Regex operation
+ */
+class FromCaseInsensitiveRegex extends Operation {
+
+    /**
+     * FromCaseInsensitiveRegex constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "From Case Insensitive Regex";
+        this.module = "Default";
+        this.description = "Converts a case-insensitive regex string to a case sensitive regex string (no guarantee on it being the proper original casing) in case /i wasn't available at the time but now is, or you need it to be case-sensitive again.";
+        this.infoURL = "https://wikipedia.org/wiki/Regular_expression";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        return input.replace(/\[[a-z]{2}\]/ig, m => m[1].toUpperCase() === m[2].toUpperCase() ? m[1] : m);
+    }
+}
+
+export default FromCaseInsensitiveRegex;

--- a/src/core/operations/ToCaseInsensitiveRegex.mjs
+++ b/src/core/operations/ToCaseInsensitiveRegex.mjs
@@ -1,0 +1,39 @@
+/**
+ * @author masq [github.cyberchef@masq.cc]
+ * @copyright Crown Copyright 2018
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation";
+
+/**
+ * To Case Insensitive Regex operation
+ */
+class ToCaseInsensitiveRegex extends Operation {
+
+    /**
+     * ToCaseInsensitiveRegex constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "To Case Insensitive Regex";
+        this.module = "Default";
+        this.description = "Converts a case-sensitive regex string into a case-insensitive regex string in case /i flag is unavailable to you.";
+        this.infoURL = "https://wikipedia.org/wiki/Regular_expression";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        return input.replace(/[a-z]/ig, m => `[${m.toLowerCase()}${m.toUpperCase()}]`);
+    }
+}
+
+export default ToCaseInsensitiveRegex;

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -82,6 +82,7 @@ import "./tests/operations/TranslateDateTimeFormat";
 import "./tests/operations/Magic";
 import "./tests/operations/ParseTLV";
 import "./tests/operations/Media";
+import "./tests/operations/ToFromInsensitiveRegex";
 
 let allTestsPassing = true;
 const testStatusCounts = {

--- a/test/tests/operations/ToFromInsensitiveRegex.mjs
+++ b/test/tests/operations/ToFromInsensitiveRegex.mjs
@@ -1,0 +1,56 @@
+/**
+ * To/From Case Insensitive Regex tests.
+ *
+ * @author masq [github.cyberchef@masq.cc]
+ *
+ * @copyright Crown Copyright 2018
+ * @license Apache-2.0
+ */
+import TestRegister from "../../TestRegister";
+
+TestRegister.addTests([
+    {
+        name: "To Case Insensitive Regex: nothing",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "From Case Insensitive Regex: nothing",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                op: "From Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: simple test",
+        input: "S0meth!ng",
+        expectedOutput: "[sS]0[mM][eE][tT][hH]![nN][gG]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "From Case Insensitive Regex: simple test",
+        input: "[sS]0[mM][eE][tT][hH]![nN][Gg] [wr][On][g]?",
+        expectedOutput: "s0meth!nG [wr][On][g]?",
+        recipeConfig: [
+            {
+                op: "From Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
Just a small utility I personally find useful. I sometimes deal with regexes that can't use flags such as /i or \c to make them case-insensitive, so I often need to transform them to regexes that _are_ case-insensitive, and doing so by hand is tedious and awful. Usually I'm working with a regex that is a fairly straightforward string though... for example,

Case-sensitive:
```
Mozilla/[0-9].[0-9] .*
```

Case-insensitive:
```
[mM][oO][zZ][iI][lL][lL][aA]/[0-9].[0-9] .*
```

I haven't really needed to work with crazier regexes, so it might be a kinda fragile operation, but it gets the job done for my purposes, hoping others get use out of it too. Suggestions welcome!