### PR TITLE
bugfix for UTF16 vs UTF8 problems

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -389,15 +389,8 @@ module.exports = function (grunt) {
                 command: "node build/prod/sitemap.js > build/prod/sitemap.xml"
             },
             generateConfig: {
-                command: [
-                    "echo '\n--- Regenerating config files. ---'",
-                    "mkdir -p src/core/config/modules",
-                    "echo 'export default {};\n' > src/core/config/modules/OpModules.mjs",
-                    "echo '[]\n' > src/core/config/OperationConfig.json",
-                    "node --experimental-modules --no-warnings --no-deprecation src/core/config/scripts/generateOpsIndex.mjs",
-                    "node --experimental-modules --no-warnings --no-deprecation src/core/config/scripts/generateConfig.mjs",
-                    "echo '--- Config scripts finished. ---\n'"
-                ].join(";")
+                command: "node --experimental-modules --no-warnings --no-deprecation src/core/config/scripts/generateDefaults.mjs",
+                stdout: true
             },
             opTests: {
                 command: "node --experimental-modules --no-warnings --no-deprecation tests/operations/index.mjs"

--- a/src/core/config/scripts/generateDefaults.mjs
+++ b/src/core/config/scripts/generateDefaults.mjs
@@ -1,0 +1,49 @@
+/**
+ * This script automatically generates OperationConfig.json, containing metadata
+ * for each operation in the src/core/operations directory.
+ * It also generates modules in the src/core/config/modules directory to separate
+ * out operations into logical collections.
+ *
+ * @author David B Heise [david@heiseink.com] 
+ * @copyright Crown Copyright 2018
+ * @license Apache-2.0
+ */
+
+/*eslint no-console: ["off"] */
+
+import path from "path";
+import fs from "fs";
+import process from "process";
+import childProcess from "child_process"
+
+
+const mkdirSync = function (dirPath) {
+    try {
+        fs.mkdirSync(dirPath)
+    } catch (err) {
+        if (err.code !== 'EEXIST') throw err
+    }
+}
+
+const mkdirpSync = function (dirPath) {
+    const parts = dirPath.split(path.sep)
+    for (let i = 1; i <= parts.length; i++) {
+        mkdirSync(path.join.apply(null, parts.slice(0, i)))
+    }
+}
+
+
+const dir = process.cwd();
+
+//Create the Destination Folder
+mkdirpSync(path.join(dir, "src/core/config/modules"))
+
+//Create the default files
+fs.writeFileSync(path.join(dir, "src/core/config/modules/OpModules.mjs"), "export default{};\n")
+fs.writeFileSync(path.join(dir, "src/core/config/OperationConfig.json"), "[]\n")
+
+//Run the generateOpsIndex.mjs file
+childProcess.fork(path.join(dir, "src/core/config/scripts/generateOpsIndex.mjs"), { execArgv: ["--experimental-modules","--no-warnings","--no-deprecation"]})
+
+//Run the generateConfig.mjs file
+childProcess.fork(path.join(dir, "src/core/config/scripts/generateConfig.mjs"), { execArgv: ["--experimental-modules","--no-warnings","--no-deprecation"]})

--- a/src/core/config/scripts/generateDefaults.mjs
+++ b/src/core/config/scripts/generateDefaults.mjs
@@ -11,29 +11,11 @@ import fs from "fs";
 import process from "process";
 import childProcess from "child_process";
 
-
-const mkdirSync = function (dirPath) {    
-    try {
-        fs.mkdirSync(dirPath);
-        console.log("Folder Ensured: " + dirPath);
-    } catch (err) {
-        if (err.code !== "EEXIST") throw err;
-    }
-};
-
-const mkdirpSync = function (dirPath) {
-    const parts = dirPath.split(path.sep);
-    for (let i = 1; i <= parts.length; i++) {
-        mkdirSync(path.join.apply(null, parts.slice(0, i)));
-    }
-};
-
-
 const dir = process.cwd();
 const newPath = path.join(dir, "src/core/config/modules");
 
 //Create the Destination Folder
-mkdirpSync(newPath);
+fs.mkdirSync(newPath, { recursive: true });
 
 //Create the default files
 fs.writeFileSync(path.join(newPath, "OpModules.mjs"), "export default{};\n");

--- a/src/core/config/scripts/generateDefaults.mjs
+++ b/src/core/config/scripts/generateDefaults.mjs
@@ -4,7 +4,7 @@
  * It also generates modules in the src/core/config/modules directory to separate
  * out operations into logical collections.
  *
- * @author David B Heise [david@heiseink.com] 
+ * @author David B Heise [david@heiseink.com]
  * @copyright Crown Copyright 2018
  * @license Apache-2.0
  */
@@ -14,36 +14,36 @@
 import path from "path";
 import fs from "fs";
 import process from "process";
-import childProcess from "child_process"
+import childProcess from "child_process";
 
 
 const mkdirSync = function (dirPath) {
     try {
-        fs.mkdirSync(dirPath)
+        fs.mkdirSync(dirPath);
     } catch (err) {
-        if (err.code !== 'EEXIST') throw err
+        if (err.code !== "EEXIST") throw err;
     }
-}
+};
 
 const mkdirpSync = function (dirPath) {
-    const parts = dirPath.split(path.sep)
+    const parts = dirPath.split(path.sep);
     for (let i = 1; i <= parts.length; i++) {
-        mkdirSync(path.join.apply(null, parts.slice(0, i)))
+        mkdirSync(path.join.apply(null, parts.slice(0, i)));
     }
-}
+};
 
 
 const dir = process.cwd();
 
 //Create the Destination Folder
-mkdirpSync(path.join(dir, "src/core/config/modules"))
+mkdirpSync(path.join(dir, "src/core/config/modules"));
 
 //Create the default files
-fs.writeFileSync(path.join(dir, "src/core/config/modules/OpModules.mjs"), "export default{};\n")
-fs.writeFileSync(path.join(dir, "src/core/config/OperationConfig.json"), "[]\n")
+fs.writeFileSync(path.join(dir, "src/core/config/modules/OpModules.mjs"), "export default{};\n");
+fs.writeFileSync(path.join(dir, "src/core/config/OperationConfig.json"), "[]\n");
 
 //Run the generateOpsIndex.mjs file
-childProcess.fork(path.join(dir, "src/core/config/scripts/generateOpsIndex.mjs"), { execArgv: ["--experimental-modules","--no-warnings","--no-deprecation"]})
+childProcess.fork(path.join(dir, "src/core/config/scripts/generateOpsIndex.mjs"), { execArgv: ["--experimental-modules","--no-warnings","--no-deprecation"]});
 
 //Run the generateConfig.mjs file
-childProcess.fork(path.join(dir, "src/core/config/scripts/generateConfig.mjs"), { execArgv: ["--experimental-modules","--no-warnings","--no-deprecation"]})
+childProcess.fork(path.join(dir, "src/core/config/scripts/generateConfig.mjs"), { execArgv: ["--experimental-modules","--no-warnings","--no-deprecation"]});

--- a/src/core/config/scripts/generateDefaults.mjs
+++ b/src/core/config/scripts/generateDefaults.mjs
@@ -12,11 +12,10 @@ import process from "process";
 import childProcess from "child_process";
 
 
-const mkdirSync = function (dirPath) {
-    
+const mkdirSync = function (dirPath) {    
     try {
         fs.mkdirSync(dirPath);
-        console.log("Folder Ensured: " + dirPath)
+        console.log("Folder Ensured: " + dirPath);
     } catch (err) {
         if (err.code !== "EEXIST") throw err;
     }
@@ -37,8 +36,8 @@ const newPath = path.join(dir, "src/core/config/modules");
 mkdirpSync(newPath);
 
 //Create the default files
-fs.writeFileSync(path.join(dir, "src/core/config/modules/OpModules.mjs"), "export default{};\n", {"flag": "w"});
-fs.writeFileSync(path.join(dir, "src/core/config/OperationConfig.json"), "[]\n", {"flag": "w"});
+fs.writeFileSync(path.join(newPath, "OpModules.mjs"), "export default{};\n");
+fs.writeFileSync(path.join(dir, "src/core/config/OperationConfig.json"), "[]\n");
 
 //Run the generateOpsIndex.mjs file
 childProcess.fork(path.join(dir, "src/core/config/scripts/generateOpsIndex.mjs"), { execArgv: ["--experimental-modules", "--no-warnings", "--no-deprecation"]});

--- a/src/core/config/scripts/generateDefaults.mjs
+++ b/src/core/config/scripts/generateDefaults.mjs
@@ -1,15 +1,10 @@
 /**
- * This script automatically generates OperationConfig.json, containing metadata
- * for each operation in the src/core/operations directory.
- * It also generates modules in the src/core/config/modules directory to separate
- * out operations into logical collections.
+ * This script automatically generates empty default files
  *
  * @author David B Heise [david@heiseink.com]
  * @copyright Crown Copyright 2018
  * @license Apache-2.0
  */
-
-/*eslint no-console: ["off"] */
 
 import path from "path";
 import fs from "fs";
@@ -18,6 +13,7 @@ import childProcess from "child_process";
 
 
 const mkdirSync = function (dirPath) {
+    console.log("Ensuring Folder: " + dirPath)
     try {
         fs.mkdirSync(dirPath);
     } catch (err) {
@@ -34,16 +30,17 @@ const mkdirpSync = function (dirPath) {
 
 
 const dir = process.cwd();
+const newPath = path.join(dir, "src/core/config/modules");
 
 //Create the Destination Folder
-mkdirpSync(path.join(dir, "src/core/config/modules"));
+mkdirpSync(newPath);
 
 //Create the default files
-fs.writeFileSync(path.join(dir, "src/core/config/modules/OpModules.mjs"), "export default{};\n");
-fs.writeFileSync(path.join(dir, "src/core/config/OperationConfig.json"), "[]\n");
+fs.writeFileSync(path.join(dir, "src/core/config/modules/OpModules.mjs"), "export default{};\n", {"flag": "w"});
+fs.writeFileSync(path.join(dir, "src/core/config/OperationConfig.json"), "[]\n", {"flag": "w"});
 
 //Run the generateOpsIndex.mjs file
-childProcess.fork(path.join(dir, "src/core/config/scripts/generateOpsIndex.mjs"), { execArgv: ["--experimental-modules","--no-warnings","--no-deprecation"]});
+childProcess.fork(path.join(dir, "src/core/config/scripts/generateOpsIndex.mjs"), { execArgv: ["--experimental-modules", "--no-warnings", "--no-deprecation"]});
 
 //Run the generateConfig.mjs file
-childProcess.fork(path.join(dir, "src/core/config/scripts/generateConfig.mjs"), { execArgv: ["--experimental-modules","--no-warnings","--no-deprecation"]});
+childProcess.fork(path.join(dir, "src/core/config/scripts/generateConfig.mjs"), { execArgv: ["--experimental-modules", "--no-warnings", "--no-deprecation"]});

--- a/src/core/config/scripts/generateDefaults.mjs
+++ b/src/core/config/scripts/generateDefaults.mjs
@@ -13,9 +13,10 @@ import childProcess from "child_process";
 
 
 const mkdirSync = function (dirPath) {
-    console.log("Ensuring Folder: " + dirPath)
+    
     try {
         fs.mkdirSync(dirPath);
+        console.log("Folder Ensured: " + dirPath)
     } catch (err) {
         if (err.code !== "EEXIST") throw err;
     }


### PR DESCRIPTION
On systems running UTF16 prompt (i.e. CMD and/or PowerShell on Windows), ECHO will output in UTF16 which will not work in nodeJS (must have UTF8)

This change just moves the actions that were in a grunt file shell command, to a javascript file.