### PR TITLE
Operation: DNS Over HTTPS

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -155,6 +155,7 @@
         "name": "Networking",
         "ops": [
             "HTTP request",
+            "DNS over HTTPS",
             "Strip HTTP headers",
             "Dechunk HTTP response",
             "Parse User Agent",

--- a/src/core/operations/DNSOverHTTPS.mjs
+++ b/src/core/operations/DNSOverHTTPS.mjs
@@ -1,0 +1,93 @@
+/**
+ * @author h345983745 []
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+import jpath from "jsonpath";
+import Operation from "../Operation";
+import OperationError from "../errors/OperationError";
+
+/**
+ * HTTPS Over DNS operation
+ */
+class HTTPSOverDNS extends Operation {
+
+    /**
+     * HTTPSOverDNS constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "DNS Over HTTPS";
+        this.module = "Code";
+        this.description = "Calls out to HTTPS Over DNS Resolvers";
+        this.infoURL = "https://en.wikipedia.org/wiki/DNS_over_HTTPS";
+        this.inputType = "string";
+        this.outputType = "JSON";
+        this.args = [
+            {
+                name: "Resolver",
+                type: "editableOption",
+                value: [
+                    {
+                        name: "Google",
+                        value: "https://dns.google.com/resolve"
+                    },
+                    {
+                        name: "Cloudflare",
+                        value: "https://cloudflare-dns.com/dns-query"
+                    }
+                ]
+            },
+            {
+                name: "Request Type",
+                type: "option",
+                value: [
+                    "A",
+                    "AAAA",
+                    "TXT",
+                    "MX"
+                ]
+            },
+            {
+                name: "Show Just Answer Data",
+                type: "boolean",
+                value: false
+            },
+            {
+                name: "Validate DNSSEC",
+                type: "boolean",
+                value: true
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {JSON}
+     */
+    run(input, args) {
+        const [resolver, requestType, justAnswer, DNSSEC] = args;
+
+        var url = new URL(resolver);
+        var params = {name:input, type:requestType, cd:DNSSEC};
+
+        url.search = new URLSearchParams(params)
+
+        console.log(url.toString())
+        
+        return fetch(url, {headers:{'accept': 'application/dns-json'}}).then(response => {return response.json()})
+        .then(data => {
+            if(justAnswer){
+                return jpath.query(data, "$.Answer[*].data")
+            }
+            return data;
+
+        }).catch(e => {throw new OperationError("Error making request to " + url + e.toString())})
+
+    }
+
+}
+
+export default HTTPSOverDNS;

--- a/src/core/operations/DNSOverHTTPS.mjs
+++ b/src/core/operations/DNSOverHTTPS.mjs
@@ -24,6 +24,7 @@ class HTTPSOverDNS extends Operation {
         this.infoURL = "https://en.wikipedia.org/wiki/DNS_over_HTTPS";
         this.inputType = "string";
         this.outputType = "JSON";
+        this.manualBake = true;
         this.args = [
             {
                 name: "Resolver",
@@ -69,13 +70,16 @@ class HTTPSOverDNS extends Operation {
      */
     run(input, args) {
         const [resolver, requestType, justAnswer, DNSSEC] = args;
-
-        var url = new URL(resolver);
+        try{
+            var url = new URL(resolver);
+        } catch (error) {
+            throw new OperationError(error.toString() + 
+            "\n\nThis error could be caused by one of the following:\n" +
+            " - An invalid Resolver URL\n" )
+        }
         var params = {name:input, type:requestType, cd:DNSSEC};
-
         url.search = new URLSearchParams(params)
 
-        console.log(url.toString())
         
         return fetch(url, {headers:{'accept': 'application/dns-json'}}).then(response => {return response.json()})
         .then(data => {
@@ -84,7 +88,7 @@ class HTTPSOverDNS extends Operation {
             }
             return data;
 
-        }).catch(e => {throw new OperationError("Error making request to " + url + e.toString())})
+        }).catch(e => {throw new OperationError("Error making request to :" + url + e.toString())})
 
     }
 

--- a/src/core/operations/DNSOverHTTPS.mjs
+++ b/src/core/operations/DNSOverHTTPS.mjs
@@ -20,11 +20,11 @@ class HTTPSOverDNS extends Operation {
 
         this.name = "DNS over HTTPS";
         this.module = "Code";
-        this.description = ["Takes a single domain name and performs a DNS lookup using DNS vver HTTPS.",
+        this.description = ["Takes a single domain name and performs a DNS lookup using DNS over HTTPS.",
         "<br><br>",
         "By default, <a href='https://developers.cloudflare.com/1.1.1.1/dns-over-https/'>Cloudflare</a> and <a href='https://developers.google.com/speed/public-dns/docs/dns-over-https'>Google</a> DNS over HTTPS services are supported.",
         "<br><br>",
-        "Can be used with any service that supports the GET paramaters <code>name</code> and <code>type</code>."].join('\n');
+        "Can be used with any service that supports the GET parameters <code>name</code> and <code>type</code>."].join('\n');
         this.infoURL = "https://en.wikipedia.org/wiki/DNS_over_HTTPS";
         this.inputType = "string";
         this.outputType = "JSON";
@@ -55,7 +55,7 @@ class HTTPSOverDNS extends Operation {
                 ]
             },
             {
-                name: "Show Just Answer Data",
+                name: "Answer Data Only",
                 type: "boolean",
                 value: false
             },
@@ -92,7 +92,8 @@ class HTTPSOverDNS extends Operation {
             }
             return data;
 
-        }).catch(e => {throw new OperationError("Error making request to :" + url + e.toString())})
+        }).catch(e => {throw new OperationError("Error making request to : " + url + "\n" + 
+            "Error Message:  " + e.toString())})
 
     }
 

--- a/src/core/operations/DNSOverHTTPS.mjs
+++ b/src/core/operations/DNSOverHTTPS.mjs
@@ -21,10 +21,10 @@ class HTTPSOverDNS extends Operation {
         this.name = "DNS over HTTPS";
         this.module = "Code";
         this.description = ["Takes a single domain name and performs a DNS lookup using DNS over HTTPS.",
-        "<br><br>",
-        "By default, <a href='https://developers.cloudflare.com/1.1.1.1/dns-over-https/'>Cloudflare</a> and <a href='https://developers.google.com/speed/public-dns/docs/dns-over-https'>Google</a> DNS over HTTPS services are supported.",
-        "<br><br>",
-        "Can be used with any service that supports the GET parameters <code>name</code> and <code>type</code>."].join('\n');
+                            "<br><br>",
+                            "By default, <a href='https://developers.cloudflare.com/1.1.1.1/dns-over-https/'>Cloudflare</a> and <a href='https://developers.google.com/speed/public-dns/docs/dns-over-https'>Google</a> DNS over HTTPS services are supported.",
+                            "<br><br>",
+                            "Can be used with any service that supports the GET parameters <code>name</code> and <code>type</code>."].join("\n");
         this.infoURL = "https://en.wikipedia.org/wiki/DNS_over_HTTPS";
         this.inputType = "string";
         this.outputType = "JSON";
@@ -76,27 +76,31 @@ class HTTPSOverDNS extends Operation {
      */
     run(input, args) {
         const [resolver, requestType, justAnswer, DNSSEC] = args;
-        try{
-            var url = new URL(resolver);
+        let url = URL;
+        try {
+            url = new URL(resolver);
         } catch (error) {
-            throw new OperationError(error.toString() + 
+            throw new OperationError(error.toString() +
             "\n\nThis error could be caused by one of the following:\n" +
-            " - An invalid Resolver URL\n" )
+            " - An invalid Resolver URL\n");
         }
-        var params = {name:input, type:requestType, cd:DNSSEC};
+        const params = {name: input, type: requestType, cd: DNSSEC};
 
-        url.search = new URLSearchParams(params)
+        url.search = new URLSearchParams(params);
 
-        
-        return fetch(url, {headers:{'accept': 'application/dns-json'}}).then(response => {return response.json()})
-        .then(data => {
-            if(justAnswer){
-                return jpath.query(data, "$.Answer[*].data")
-            }
-            return data;
+        return fetch(url, {headers: {"accept": "application/dns-json"}}).then(response => {
+            return response.json();
+        })
+            .then(data => {
+                if (justAnswer) {
+                    return jpath.query(data, "$.Answer[*].data");
+                }
+                return data;
 
-        }).catch(e => {throw new OperationError("Error making request to : " + url + "\n" + 
-            "Error Message:  " + e.toString())})
+            }).catch(e => {
+                throw new OperationError("Error making request to : " + url + "\n" +
+                    "Error Message:  " + e.toString());
+            });
 
     }
 

--- a/src/core/operations/DNSOverHTTPS.mjs
+++ b/src/core/operations/DNSOverHTTPS.mjs
@@ -3,7 +3,6 @@
  * @copyright Crown Copyright 2019
  * @license Apache-2.0
  */
-import jpath from "jsonpath";
 import Operation from "../Operation";
 import OperationError from "../errors/OperationError";
 
@@ -19,7 +18,7 @@ class HTTPSOverDNS extends Operation {
         super();
 
         this.name = "DNS over HTTPS";
-        this.module = "Code";
+        this.module = "Default";
         this.description = ["Takes a single domain name and performs a DNS lookup using DNS over HTTPS.",
                             "<br><br>",
                             "By default, <a href='https://developers.cloudflare.com/1.1.1.1/dns-over-https/'>Cloudflare</a> and <a href='https://developers.google.com/speed/public-dns/docs/dns-over-https'>Google</a> DNS over HTTPS services are supported.",
@@ -93,7 +92,7 @@ class HTTPSOverDNS extends Operation {
         })
             .then(data => {
                 if (justAnswer) {
-                    return jpath.query(data, "$.Answer[*].data");
+                    return this.extractData(data.Answer);
                 }
                 return data;
 
@@ -104,6 +103,25 @@ class HTTPSOverDNS extends Operation {
 
     }
 
+
+    /**
+     * Construct an array of just data from a DNS Answer section
+     * @private
+     * @param {JSON} data
+     * @returns {JSON}
+     */
+    extractData(data) {
+        if (typeof(data) == "undefined"){
+            return [];
+        } else {
+            const dataValues = [];
+            data.forEach(element => {
+                dataValues.push(element.data);
+            });
+            return dataValues;
+
+        }
+    }
 }
 
 export default HTTPSOverDNS;

--- a/src/core/operations/DNSOverHTTPS.mjs
+++ b/src/core/operations/DNSOverHTTPS.mjs
@@ -18,9 +18,13 @@ class HTTPSOverDNS extends Operation {
     constructor() {
         super();
 
-        this.name = "DNS Over HTTPS";
+        this.name = "DNS over HTTPS";
         this.module = "Code";
-        this.description = "Calls out to HTTPS Over DNS Resolvers";
+        this.description = ["Takes a single domain name and performs a DNS lookup using DNS vver HTTPS.",
+        "<br><br>",
+        "By default, <a href='https://developers.cloudflare.com/1.1.1.1/dns-over-https/'>Cloudflare</a> and <a href='https://developers.google.com/speed/public-dns/docs/dns-over-https'>Google</a> DNS over HTTPS services are supported.",
+        "<br><br>",
+        "Can be used with any service that supports the GET paramaters <code>name</code> and <code>type</code>."].join('\n');
         this.infoURL = "https://en.wikipedia.org/wiki/DNS_over_HTTPS";
         this.inputType = "string";
         this.outputType = "JSON";

--- a/src/core/operations/DNSOverHTTPS.mjs
+++ b/src/core/operations/DNSOverHTTPS.mjs
@@ -51,7 +51,9 @@ class HTTPSOverDNS extends Operation {
                     "A",
                     "AAAA",
                     "TXT",
-                    "MX"
+                    "MX",
+                    "DNSKEY",
+                    "NS"
                 ]
             },
             {
@@ -82,6 +84,7 @@ class HTTPSOverDNS extends Operation {
             " - An invalid Resolver URL\n" )
         }
         var params = {name:input, type:requestType, cd:DNSSEC};
+
         url.search = new URLSearchParams(params)
 
         


### PR DESCRIPTION
Pull request to implement #433. 

Takes a domain name as input, before performing a fetch request to the specified resolver. If only the answer data is needed, an option to just return a JSON array of values is implemented. 

~~It is worth noting that I have put this is the "code" module as I noticed that _jsonpath_ library is used by the [jpath](https://github.com/gchq/CyberChef/blob/master/src/core/operations/JPathExpression.mjs) recipe. It is also used in this recipe to implement the feature of only returning answer data rather than the full JSON response. I'm new to the CyberChef codebase so please let me know if there is a better way of doing this!~~

EDIT: I have now removed the _jsonpath_ import and moved to the "Default" module.

Example Outputs:

<img width="1151" alt="screenshot 2019-02-06 at 23 30 36" src="https://user-images.githubusercontent.com/47383847/52397548-dacbaa00-2aad-11e9-9873-7f54c00386dc.png">
<img width="1151" alt="screenshot 2019-02-06 at 23 31 29" src="https://user-images.githubusercontent.com/47383847/52397552-dbfcd700-2aad-11e9-8a3c-a338698b920f.png">




