### PR TITLE
Update disassembler library

### DIFF
--- a/src/core/vendor/DisassembleX86-64.mjs
+++ b/src/core/vendor/DisassembleX86-64.mjs
@@ -3553,7 +3553,7 @@ export function LoadBinCode( HexStr )
 
   var len = HexStr.length;
 
-  for( var i = 0, el = 0, Sing = 0, int32 = 0; i < len; i += 8 )
+  for( var i = 0, el = 0, Sign = 0, int32 = 0; i < len; i += 8 )
   {
     //It is faster to read 8 hex digits at a time if possible.
 
@@ -3569,22 +3569,22 @@ export function LoadBinCode( HexStr )
 
     //The variable sing corrects the unusable sing bits during the 4 byte rotation algorithm.
 
-    Sing = int32;
+    Sign = int32;
 
-    //Remove the Sing bit value if active for when the number is changed to int32 during rotation.
+    //Remove the Sign bit value if active for when the number is changed to int32 during rotation.
 
     int32 ^= int32 & 0x80000000;
 
-    //Rotate the 32 bit int so that each number is put in order in the BinCode array. Add the Sing Bit positions back though each rotation.
+    //Rotate the 32 bit int so that each number is put in order in the BinCode array. Add the Sign Bit positions back though each rotation.
 
     int32 = ( int32 >> 24 ) | ( ( int32 << 8 ) & 0x7FFFFFFF );
-    BinCode[el++] = ( ( ( Sing >> 24 ) & 0x80 ) | int32 ) & 0xFF;
+    BinCode[el++] = ( ( ( Sign >> 24 ) & 0x80 ) | int32 ) & 0xFF;
     int32 = ( int32 >> 24 ) | ( ( int32 << 8 ) & 0x7FFFFFFF );
-    BinCode[el++] = ( ( ( Sing >> 16 ) & 0x80 ) | int32 ) & 0xFF;
+    BinCode[el++] = ( ( ( Sign >> 16 ) & 0x80 ) | int32 ) & 0xFF;
     int32 = ( int32 >> 24 ) | ( ( int32 << 8 ) & 0x7FFFFFFF );
-    BinCode[el++] = ( ( ( Sing >> 8 ) & 0x80 ) | int32 ) & 0xFF;
+    BinCode[el++] = ( ( ( Sign >> 8 ) & 0x80 ) | int32 ) & 0xFF;
     int32 = ( int32 >> 24 ) | ( ( int32 << 8 ) & 0x7FFFFFFF );
-    BinCode[el++] = ( ( Sing & 0x80 ) | int32 ) & 0xFF;
+    BinCode[el++] = ( ( Sign & 0x80 ) | int32 ) & 0xFF;
   }
 
   //Remove elements past the Number of bytes in HexStr because int 32 is always 4 bytes it is possible to end in an uneven number.
@@ -3974,11 +3974,11 @@ function DecodeImmediate( type, BySize, SizeSetting )
 
   var Pad32 = 0, Pad64 = 0;
 
-  //*Initialize the Sing value that is only set for Negative, or Positive Relative displacements.
+  //*Initialize the Sign value that is only set for Negative, or Positive Relative displacements.
 
-  var Sing = 0;
+  var Sign = 0;
 
-  //*Initialize the Sing Extend variable size as 0 Some Immediate numbers Sing extend.
+  //*Initialize the Sign Extend variable size as 0 Some Immediate numbers Sign extend.
 
   var Extend = 0;
 
@@ -4052,7 +4052,7 @@ function DecodeImmediate( type, BySize, SizeSetting )
     
     var n = Math.min( 0x100000000, Math.pow( 2, 4 << ( S + 1 ) ) );
     
-    //Sing bit adjust.
+    //Sign bit adjust.
     
     if( V32 >= ( n >> 1 ) ) { V32 -= n; }
     
@@ -4091,9 +4091,9 @@ function DecodeImmediate( type, BySize, SizeSetting )
 
     var Center = 2 * ( 1 << ( n << 3 ) - 2 );
 
-    //By default the Sing is Positive.
+    //By default the Sign is Positive.
 
-    Sing = 1;
+    Sign = 1;
 
     /*-------------------------------------------------------------------------------------------------------------------------
     Calculate the VSIB displacement size if it is a VSIB Disp8.
@@ -4113,9 +4113,9 @@ function DecodeImmediate( type, BySize, SizeSetting )
 
       V32 = Center * 2 - V32;
 
-      //The Sing is negative.
+      //The Sign is negative.
 
-      Sing = 2;
+      Sign = 2;
     }
   }
 
@@ -4149,7 +4149,7 @@ function DecodeImmediate( type, BySize, SizeSetting )
 
   //*Return the Imm.
 
-  return ( ( Sing > 0 ? ( Sing > 1 ? "-" : "+" ) : "" ) + Imm.toUpperCase() );
+  return ( ( Sign > 0 ? ( Sign > 1 ? "-" : "+" ) : "" ) + Imm.toUpperCase() );
 
 }
 

--- a/src/core/vendor/DisassembleX86-64.mjs
+++ b/src/core/vendor/DisassembleX86-64.mjs
@@ -1,4 +1,32 @@
 /*-------------------------------------------------------------------------------------------------------------------------
+Created by Damian Recoskie (https://github.com/Recoskie/X86-64-Disassembler-JS) 
+  & exported for CyberChef by Matt [me@mitt.dev]
+---------------------------------------------------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2019 Damian Recoskie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-------------------------------------------------------------------------------------------------------------------------*/
+
+
+/*-------------------------------------------------------------------------------------------------------------------------
 Binary byte code array.
 ---------------------------------------------------------------------------------------------------------------------------
 Function ^LoadBinCode()^ takes a string input of hex and loads it into the BinCode array it is recommended that the location
@@ -3585,7 +3613,6 @@ function NextByte()
   if ( CodePos < BinCode.length ) //If not out of bounds.
   {
     //Convert current byte to String, and pad.
-    var t;
 
     ( ( t = BinCode[CodePos++].toString(16) ).length === 1) && ( t = "0" + t );
 
@@ -4017,21 +4044,33 @@ function DecodeImmediate( type, BySize, SizeSetting )
 
     Pad32 = ( Math.min( BitMode, 1 ) << 2 ) + 4; Pad64 = Math.max( Math.min( BitMode, 2 ), 1 ) << 3;
 
-    //Add the 32 bit section to V32.
+    //Carry bit to 64 bit section.
+    
+    var C64 = 0;
+    
+    //Relative size.
+    
+    var n = Math.min( 0x100000000, Math.pow( 2, 4 << ( S + 1 ) ) );
+    
+    //Sing bit adjust.
+    
+    if( V32 >= ( n >> 1 ) ) { V32 -= n; }
+    
+    //Add position.
+    
+    V32 += Pos32;
+    
+    //Remove carry bit and add it to C64.
 
-    var C64 = 0; V32 += Pos32;
+    ( C64 = ( ( V32 ) >= 0x100000000 ) ) && ( V32 -= 0x100000000 );
+    
+    //Do not carry to 64 if address is 32, and below.
+    
+    if ( S <= 2 ) { C64 = false; }
 
-    //If bit mode is 16 bits only the first 16 bits are used, or if Size Attribute is 16 bit.
+    //Add the 64 bit position plus carry.
 
-    ( BitMode <= 0 || SizeAttrSelect <= 0 ) && ( V32 &= 0xFFFF );
-
-    //Adjust the 32 bit relative address section if it was not cropped to 16 bit's.
-
-    ( C64 = ( ( V32 ) > 0xFFFFFFFF ) ) && ( V32 -= 0x100000000 );
-
-    //Add the 64 bit address section if in 64 bit mode, or higher.
-
-    ( BitMode >= 2 ) && ( ( V64 += Pos64 + C64 ) > 0xFFFFFFFF ) && ( V64 -= 0x100000000 );
+    ( ( V64 += Pos64 + C64 ) > 0xFFFFFFFF ) && ( V64 -= 0x100000000 );
   }
 
   /*---------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Update to disassembler to fix jump addresses ([issue](https://github.com/Recoskie/X86-64-Disassembler-JS/issues/6) from upstream). Also added license information and author accreditation.
Thanks to @JohnLaTwC for flagging this up on [Twitter](https://twitter.com/JohnLaTwC/status/1104539516038045697).

Addtionally, at some point we should update this operation to use something like [zydis](https://github.com/zyantific/zydis) with WASM but I'll have to do more research before I commit to doing that. :stuck_out_tongue: 