### PR TITLE
Bug Fix: Added support for non-prefixed default namespace xpath expression

### DIFF
--- a/src/core/operations/XPathExpression.mjs
+++ b/src/core/operations/XPathExpression.mjs
@@ -57,7 +57,7 @@ class XPathExpression extends Operation {
 
         let nodes;
         try {
-            nodes = xpath.select(query, doc);
+            nodes = xpath.parse(query).select({ node: doc, allowAnyNamespaceForNoPrefix: true });
         } catch (err) {
             throw new OperationError(`Invalid XPath. Details:\n${err.message}.`);
         }


### PR DESCRIPTION
References https://github.com/gchq/CyberChef/issues/495

Modified xpath select call to support the allowAnyNamespaceForNoPrefix flag which will allow using prefix-less node tests to match nodes with no prefix.