### PR TITLE
Operation: Extract Hash Values

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -337,6 +337,7 @@
             "Extract domains",
             "Extract file paths",
             "Extract dates",
+            "Extract Hashes",
             "Regular expression",
             "XPath expression",
             "JPath expression",

--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -337,7 +337,7 @@
             "Extract domains",
             "Extract file paths",
             "Extract dates",
-            "Extract Hashes",
+            "Extract hashes",
             "Regular expression",
             "XPath expression",
             "JPath expression",

--- a/src/core/operations/ExtractHashes.mjs
+++ b/src/core/operations/ExtractHashes.mjs
@@ -4,8 +4,8 @@
  * @license Apache-2.0
  */
 
-import Operation from "../Operation";
-import { search } from "../lib/Extract";
+import Operation from "../Operation.mjs";
+import { search } from "../lib/Extract.mjs";
 
 /**
  * Extract Hash Values operation

--- a/src/core/operations/ExtractHashes.mjs
+++ b/src/core/operations/ExtractHashes.mjs
@@ -1,0 +1,81 @@
+/**
+ * @author mshwed [m@ttshwed.com]
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation";
+import { search } from "../lib/Extract";
+
+/**
+ * Extract Hash Values operation
+ */
+class ExtractHashes extends Operation {
+
+    /**
+     * ExtractHashValues constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Extract Hashes";
+        this.module = "Default";
+        this.description = "Extracts hash values based on hash byte length";
+        this.infoURL = "https://en.wikipedia.org/wiki/Comparison_of_cryptographic_hash_functions";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Hash length",
+                type: "number",
+                value: 32
+            },
+            {
+                name: "All hashes",
+                type: "boolean",
+                value: false
+            },
+            {
+                name: "Display Total",
+                type: "boolean",
+                value: false
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        let results = [];
+        let hashCount = 0;
+
+        const hashLength = args[0];
+        const searchAllHashes = args[1];
+        const showDisplayTotal = args[2];
+
+        let hashLengths = [hashLength];
+        if (searchAllHashes) hashLengths = [4, 8, 16, 32, 64, 128, 160, 192, 224, 256, 320, 384, 512, 1024];
+
+        for (let hashLength of hashLengths) {
+            const regex = new RegExp(`(\\b|^)[a-f0-9]{${hashLength}}(\\b|$)`, "g");
+            const searchResults = search(input, regex, null, false);
+
+            hashCount += searchResults.split("\n").length - 1;
+            results.push(searchResults);
+        }
+
+        let output = "";
+        if (showDisplayTotal) {
+            output = `Total Results: ${hashCount}\n\n`;
+        }
+
+        output = output + results.join("");
+        return output;
+    }
+
+}
+
+export default ExtractHashes;

--- a/src/core/operations/ExtractHashes.mjs
+++ b/src/core/operations/ExtractHashes.mjs
@@ -18,7 +18,7 @@ class ExtractHashes extends Operation {
     constructor() {
         super();
 
-        this.name = "Extract Hashes";
+        this.name = "Extract hashes";
         this.module = "Regex";
         this.description = "Extracts potential hashes based on hash character length";
         this.infoURL = "https://en.wikipedia.org/wiki/Comparison_of_cryptographic_hash_functions";

--- a/src/core/operations/ExtractHashes.mjs
+++ b/src/core/operations/ExtractHashes.mjs
@@ -52,9 +52,7 @@ class ExtractHashes extends Operation {
         const results = [];
         let hashCount = 0;
 
-        const hashLength = args[0];
-        const searchAllHashes = args[1];
-        const showDisplayTotal = args[2];
+        const [hashLength, searchAllHashes, showDisplayTotal] = args;
 
         // Convert character length to bit length
         let hashBitLengths = [(hashLength / 2) * 8];

--- a/src/core/operations/ExtractHashes.mjs
+++ b/src/core/operations/ExtractHashes.mjs
@@ -68,8 +68,8 @@ class ExtractHashes extends Operation {
             const regex = new RegExp(`(\\b|^)[a-f0-9]{${hashCharacterLength}}(\\b|$)`, "g");
             const searchResults = search(input, regex, null, false);
 
-            hashCount += searchResults.split("\n").length - 1;
-            results.push(searchResults);
+            hashCount += searchResults.length;
+            results.push(...searchResults);
         }
 
         let output = "";
@@ -77,7 +77,7 @@ class ExtractHashes extends Operation {
             output = `Total Results: ${hashCount}\n\n`;
         }
 
-        output = output + results.join("");
+        output = output + results.join("\n");
         return output;
     }
 

--- a/src/core/operations/ExtractHashes.mjs
+++ b/src/core/operations/ExtractHashes.mjs
@@ -20,13 +20,13 @@ class ExtractHashes extends Operation {
 
         this.name = "Extract Hashes";
         this.module = "Regex";
-        this.description = "Extracts hash values based on hash byte length";
+        this.description = "Extracts potential hashes based on hash character length";
         this.infoURL = "https://en.wikipedia.org/wiki/Comparison_of_cryptographic_hash_functions";
         this.inputType = "string";
         this.outputType = "string";
         this.args = [
             {
-                name: "Hash length",
+                name: "Hash character length",
                 type: "number",
                 value: 32
             },
@@ -56,11 +56,16 @@ class ExtractHashes extends Operation {
         const searchAllHashes = args[1];
         const showDisplayTotal = args[2];
 
-        let hashLengths = [hashLength];
-        if (searchAllHashes) hashLengths = [4, 8, 16, 32, 64, 128, 160, 192, 224, 256, 320, 384, 512, 1024];
+        // Convert character length to bit length
+        let hashBitLengths = [(hashLength / 2) * 8];
 
-        for (let hashLength of hashLengths) {
-            const regex = new RegExp(`(\\b|^)[a-f0-9]{${hashLength}}(\\b|$)`, "g");
+        if (searchAllHashes) hashBitLengths = [4, 8, 16, 32, 64, 128, 160, 192, 224, 256, 320, 384, 512, 1024];
+
+        for (let hashBitLength of hashBitLengths) {
+            // Convert bit length to character length
+            let hashCharacterLength = (hashBitLength / 8) * 2;
+
+            const regex = new RegExp(`(\\b|^)[a-f0-9]{${hashCharacterLength}}(\\b|$)`, "g");
             const searchResults = search(input, regex, null, false);
 
             hashCount += searchResults.split("\n").length - 1;

--- a/src/core/operations/ExtractHashes.mjs
+++ b/src/core/operations/ExtractHashes.mjs
@@ -19,7 +19,7 @@ class ExtractHashes extends Operation {
         super();
 
         this.name = "Extract Hashes";
-        this.module = "Default";
+        this.module = "Regex";
         this.description = "Extracts hash values based on hash byte length";
         this.infoURL = "https://en.wikipedia.org/wiki/Comparison_of_cryptographic_hash_functions";
         this.inputType = "string";

--- a/src/core/operations/ExtractHashes.mjs
+++ b/src/core/operations/ExtractHashes.mjs
@@ -28,7 +28,7 @@ class ExtractHashes extends Operation {
             {
                 name: "Hash character length",
                 type: "number",
-                value: 32
+                value: 40
             },
             {
                 name: "All hashes",
@@ -49,7 +49,7 @@ class ExtractHashes extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        let results = [];
+        const results = [];
         let hashCount = 0;
 
         const hashLength = args[0];
@@ -61,9 +61,9 @@ class ExtractHashes extends Operation {
 
         if (searchAllHashes) hashBitLengths = [4, 8, 16, 32, 64, 128, 160, 192, 224, 256, 320, 384, 512, 1024];
 
-        for (let hashBitLength of hashBitLengths) {
+        for (const hashBitLength of hashBitLengths) {
             // Convert bit length to character length
-            let hashCharacterLength = (hashBitLength / 8) * 2;
+            const hashCharacterLength = (hashBitLength / 8) * 2;
 
             const regex = new RegExp(`(\\b|^)[a-f0-9]{${hashCharacterLength}}(\\b|$)`, "g");
             const searchResults = search(input, regex, null, false);

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -62,6 +62,7 @@ import "./tests/DefangIP.mjs";
 import "./tests/ELFInfo.mjs";
 import "./tests/Enigma.mjs";
 import "./tests/ExtractEmailAddresses.mjs";
+import "./tests/ExtractHashes.mjs";
 import "./tests/Float.mjs";
 import "./tests/FileTree.mjs";
 import "./tests/FletcherChecksum.mjs";

--- a/tests/operations/tests/ExtractHashes.mjs
+++ b/tests/operations/tests/ExtractHashes.mjs
@@ -1,0 +1,77 @@
+/**
+ * ExtractHashes tests.
+ *
+ * @author mshwed [m@ttshwed.com]
+ * @copyright Crown Copyright 2024
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Extract MD5 hash",
+        input: "The quick brown fox jumps over the lazy dog\n\nMD5: 9e107d9d372bb6826bd81d3542a419d6",
+        expectedOutput: "9e107d9d372bb6826bd81d3542a419d6",
+        recipeConfig: [
+            {
+                "op": "Extract Hashes",
+                "args": [32, false, false]
+            },
+        ],
+    },
+    {
+        name: "Extract SHA1 hash",
+        input: "The quick brown fox jumps over the lazy dog\n\nSHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12",
+        expectedOutput: "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12",
+        recipeConfig: [
+            {
+                "op": "Extract Hashes",
+                "args": [40, false, false]
+            },
+        ],
+    },
+    {
+        name: "Extract SHA256 hash",
+        input: "The quick brown fox jumps over the lazy dog\n\nSHA256: d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+        expectedOutput: "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+        recipeConfig: [
+            {
+                "op": "Extract Hashes",
+                "args": [64, false, false]
+            },
+        ],
+    },
+    {
+        name: "Extract SHA512 hash",
+        input: "The quick brown fox jumps over the lazy dog\n\nSHA512: 07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6",
+        expectedOutput: "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6",
+        recipeConfig: [
+            {
+                "op": "Extract Hashes",
+                "args": [128, false, false]
+            },
+        ],
+    },
+    {
+        name: "Extract all hashes",
+        input: "The quick brown fox jumps over the lazy dog\n\nMD5: 9e107d9d372bb6826bd81d3542a419d6\nSHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12\nSHA256: d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+        expectedOutput: "9e107d9d372bb6826bd81d3542a419d6\n2fd4e1c67a2d28fced849ee1bb76e7391b93eb12\nd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+        recipeConfig: [
+            {
+                "op": "Extract Hashes",
+                "args": [0, true, false]
+            },
+        ],
+    },
+    {
+        name: "Extract hashes with total count",
+        input: "The quick brown fox jumps over the lazy dog\n\nMD5: 9e107d9d372bb6826bd81d3542a419d6\nSHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12\nSHA256: d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+        expectedOutput: "Total Results: 3\n\n9e107d9d372bb6826bd81d3542a419d6\n2fd4e1c67a2d28fced849ee1bb76e7391b93eb12\nd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+        recipeConfig: [
+            {
+                "op": "Extract Hashes",
+                "args": [0, true, true]
+            },
+        ],
+    }
+]);

--- a/tests/operations/tests/ExtractHashes.mjs
+++ b/tests/operations/tests/ExtractHashes.mjs
@@ -14,7 +14,7 @@ TestRegister.addTests([
         expectedOutput: "9e107d9d372bb6826bd81d3542a419d6",
         recipeConfig: [
             {
-                "op": "Extract Hashes",
+                "op": "Extract hashes",
                 "args": [32, false, false]
             },
         ],
@@ -25,7 +25,7 @@ TestRegister.addTests([
         expectedOutput: "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12",
         recipeConfig: [
             {
-                "op": "Extract Hashes",
+                "op": "Extract hashes",
                 "args": [40, false, false]
             },
         ],
@@ -36,7 +36,7 @@ TestRegister.addTests([
         expectedOutput: "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
         recipeConfig: [
             {
-                "op": "Extract Hashes",
+                "op": "Extract hashes",
                 "args": [64, false, false]
             },
         ],
@@ -47,7 +47,7 @@ TestRegister.addTests([
         expectedOutput: "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6",
         recipeConfig: [
             {
-                "op": "Extract Hashes",
+                "op": "Extract hashes",
                 "args": [128, false, false]
             },
         ],
@@ -58,7 +58,7 @@ TestRegister.addTests([
         expectedOutput: "9e107d9d372bb6826bd81d3542a419d6\n2fd4e1c67a2d28fced849ee1bb76e7391b93eb12\nd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
         recipeConfig: [
             {
-                "op": "Extract Hashes",
+                "op": "Extract hashes",
                 "args": [0, true, false]
             },
         ],
@@ -69,7 +69,7 @@ TestRegister.addTests([
         expectedOutput: "Total Results: 3\n\n9e107d9d372bb6826bd81d3542a419d6\n2fd4e1c67a2d28fced849ee1bb76e7391b93eb12\nd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
         recipeConfig: [
             {
-                "op": "Extract Hashes",
+                "op": "Extract hashes",
                 "args": [0, true, true]
             },
         ],


### PR DESCRIPTION
References https://github.com/gchq/CyberChef/issues/466

Adds operation for extracting hash values from text blocks. Searches text for hashes based on length.  
Options for:
- Searching for hashes of all lengths. Potential hash lengths taken from "Analyse Hashes" operation. 
- Displaying total hashes found.

<img width="450" alt="Screen Shot 2019-03-11 at 20 01 24" src="https://user-images.githubusercontent.com/780057/54165844-d1c95200-4438-11e9-9525-696a7cb62f6d.png">

If it makes more sense to select hash types by name from a dropdown rather than by character length, I can change that.