### PR TITLE
Operation: BLAKE2 hashing functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,6 +2249,11 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "babel-plugin-transform-builtin-extend": "1.1.2",
     "bcryptjs": "^2.4.3",
     "bignumber.js": "^8.1.1",
+    "blakejs": "^1.1.0",
     "bootstrap": "4.2.1",
     "bootstrap-colorpicker": "^2.5.3",
     "bootstrap-material-design": "^4.1.1",

--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -313,7 +313,9 @@
             "Adler-32 Checksum",
             "CRC-16 Checksum",
             "CRC-32 Checksum",
-            "TCP/IP Checksum"
+            "TCP/IP Checksum",
+            "BLAKE2b",
+            "BLAKE2s"
         ]
     },
     {

--- a/src/core/operations/BLAKE2b.mjs
+++ b/src/core/operations/BLAKE2b.mjs
@@ -21,7 +21,7 @@ class BLAKE2b extends Operation {
         this.name = "BLAKE2b";
         this.module = "Hashing";
         this.description = "Performs BLAKE2b hashing on the input. Returns the output HEX encoded.";
-        this.infoURL = "https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2";
+        this.infoURL = "https://wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2b_algorithm";
         this.inputType = "string";
         this.outputType = "string";
         this.args = [

--- a/src/core/operations/BLAKE2b.mjs
+++ b/src/core/operations/BLAKE2b.mjs
@@ -36,6 +36,11 @@ class BLAKE2b extends Operation {
                 "name": "Output Encoding",
                 "type": "option",
                 "value": ["Hex", "Base64", "Raw"]
+            }, {
+                "name": "Key",
+                "type": "toggleString",
+                "value": "",
+                "toggleValues": ["UTF8", "Decimal", "Base64", "Hex", "Latin1"]
             }
         ];
     }
@@ -47,14 +52,19 @@ class BLAKE2b extends Operation {
      */
     run(input, args) {
         const [outSize, outFormat] = args;
-
+        let key = Utils.convertToByteArray(args[2].string || "", args[2].option);
+        if (key.length === 0){
+            key = null;
+        } else if (key.length > 64){
+            throw new OperationError(["Key cannot be greater than 64 bytes", "It is currently " + key.length +" bytes."].join("\n"));
+        }
         switch (outFormat) {
             case "Hex":
-                return blakejs.blake2bHex(input, null, outSize / 8);
+                return blakejs.blake2bHex(input, key, outSize / 8);
             case "Base64":
-                return toBase64(blakejs.blake2b(input, null, outSize / 8));
+                return toBase64(blakejs.blake2b(input, key, outSize / 8));
             case "Raw":
-                return Utils.arrayBufferToStr(blakejs.blake2b(input, null, outSize / 8).buffer);
+                return Utils.arrayBufferToStr(blakejs.blake2b(input, key, outSize / 8).buffer);
             default:
                 return new OperationError("Unsupported Output Type");
         }

--- a/src/core/operations/BLAKE2b.mjs
+++ b/src/core/operations/BLAKE2b.mjs
@@ -6,6 +6,9 @@
 
 import Operation from "../Operation";
 import blakejs from "blakejs";
+import OperationError from "../errors/OperationError";
+import Utils from "../Utils";
+import { toBase64 } from "../lib/Base64";
 
 /**
  * BLAKE2b operation
@@ -29,6 +32,10 @@ class BLAKE2b extends Operation {
                 "name": "Size",
                 "type": "option",
                 "value": ["512", "384", "256", "160", "128"]
+            }, {
+                "name": "Output Encoding",
+                "type": "option",
+                "value": ["Hex", "Base64", "Raw"]
             }
         ];
     }
@@ -36,11 +43,21 @@ class BLAKE2b extends Operation {
     /**
      * @param {string} input
      * @param {Object[]} args
-     * @returns {string} The input having been hashed with BLAKE2b, HEX encoded.
+     * @returns {string} The input having been hashed with BLAKE2b in the encoding format speicifed.
      */
     run(input, args) {
-        const [outSize] = args;
-        return blakejs.blake2bHex(input, null, outSize / 8);
+        const [outSize, outFormat] = args;
+
+        switch (outFormat) {
+            case "Hex":
+                return blakejs.blake2bHex(input, null, outSize / 8);
+            case "Base64":
+                return toBase64(blakejs.blake2b(input, null, outSize / 8));
+            case "Raw":
+                return Utils.arrayBufferToStr(blakejs.blake2b(input, null, outSize / 8).buffer);
+            default:
+                return new OperationError("Unsupported Output Type");
+        }
     }
 
 }

--- a/src/core/operations/BLAKE2b.mjs
+++ b/src/core/operations/BLAKE2b.mjs
@@ -1,5 +1,5 @@
 /**
- * @author h [h]
+ * @author h345983745
  * @copyright Crown Copyright 2019
  * @license Apache-2.0
  */

--- a/src/core/operations/BLAKE2b.mjs
+++ b/src/core/operations/BLAKE2b.mjs
@@ -23,7 +23,9 @@ class BLAKE2b extends Operation {
 
         this.name = "BLAKE2b";
         this.module = "Hashing";
-        this.description = "Performs BLAKE2b hashing on the input. Returns the output HEX encoded.";
+        this.description = `Performs BLAKE2b hashing on the input.  
+        <br><br> BLAKE2b is a flavour of the BLAKE cryptographic hash function that is optimized for 64-bit platforms and produces digests of any size between 1 and 64 bytes.
+        <br><br> Supports the use of an optional key.`;
         this.infoURL = "https://wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2b_algorithm";
         this.inputType = "string";
         this.outputType = "string";
@@ -56,7 +58,7 @@ class BLAKE2b extends Operation {
         if (key.length === 0){
             key = null;
         } else if (key.length > 64){
-            throw new OperationError(["Key cannot be greater than 64 bytes", "It is currently " + key.length +" bytes."].join("\n"));
+            throw new OperationError(["Key cannot be greater than 64 bytes", "It is currently " + key.length + " bytes."].join("\n"));
         }
         switch (outFormat) {
             case "Hex":

--- a/src/core/operations/BLAKE2b.mjs
+++ b/src/core/operations/BLAKE2b.mjs
@@ -1,0 +1,48 @@
+/**
+ * @author h [h]
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation";
+import blakejs from "blakejs";
+
+/**
+ * BLAKE2b operation
+ */
+class BLAKE2b extends Operation {
+
+    /**
+     * BLAKE2b constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "BLAKE2b";
+        this.module = "Hashing";
+        this.description = "Performs BLAKE2b hashing on the input. Returns the output HEX encoded.";
+        this.infoURL = "https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                "name": "Size",
+                "type": "option",
+                "value": ["512", "384", "256", "160", "128"]
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string} The input having been hashed with BLAKE2b, HEX encoded.
+     */
+    run(input, args) {
+        const [outSize] = args;
+        return blakejs.blake2bHex(input, null, outSize / 8);
+    }
+
+}
+
+export default BLAKE2b;

--- a/src/core/operations/BLAKE2s.mjs
+++ b/src/core/operations/BLAKE2s.mjs
@@ -6,7 +6,9 @@
 
 import Operation from "../Operation";
 import blakejs from "blakejs";
-
+import OperationError from "../errors/OperationError";
+import Utils from "../Utils";
+import { toBase64 } from "../lib/Base64";
 /**
  * BLAKE2s Operation
  */
@@ -29,6 +31,10 @@ class BLAKE2s extends Operation {
                 "name": "Size",
                 "type": "option",
                 "value": ["256", "160", "128"]
+            }, {
+                "name": "Output Encoding",
+                "type": "option",
+                "value": ["Hex", "Base64", "Raw"]
             }
         ];
     }
@@ -36,11 +42,20 @@ class BLAKE2s extends Operation {
     /**
      * @param {string} input
      * @param {Object[]} args
-     * @returns {string} The input having been hashed with BLAKE2s, HEX encoded.
+     * @returns {string} The input having been hashed with BLAKE2s in the encoding format speicifed.
      */
     run(input, args) {
-        const [outSize] = args;
-        return blakejs.blake2sHex(input, null, outSize / 8);
+        const [outSize, outFormat] = args;
+        switch (outFormat) {
+            case "Hex":
+                return blakejs.blake2sHex(input, null, outSize / 8);
+            case "Base64":
+                return toBase64(blakejs.blake2s(input, null, outSize / 8));
+            case "Raw":
+                return Utils.arrayBufferToStr(blakejs.blake2s(input, null, outSize / 8).buffer);
+            default:
+                return new OperationError("Unsupported Output Type");
+        }
     }
 
 }

--- a/src/core/operations/BLAKE2s.mjs
+++ b/src/core/operations/BLAKE2s.mjs
@@ -1,0 +1,48 @@
+/**
+ * @author h [h]
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation";
+import blakejs from "blakejs";
+
+/**
+ * BLAKE2s Operation
+ */
+class BLAKE2s extends Operation {
+
+    /**
+     * BLAKE2s constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "BLAKE2s";
+        this.module = "Hashing";
+        this.description = "Performs BLAKE2s hashing on the input. Returns the output HEX encoded.";
+        this.infoURL = "https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                "name": "Size",
+                "type": "option",
+                "value": ["256", "160", "128"]
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string} The input having been hashed with BLAKE2s, HEX encoded.
+     */
+    run(input, args) {
+        const [outSize] = args;
+        return blakejs.blake2sHex(input, null, outSize / 8);
+    }
+
+}
+
+export default BLAKE2s;

--- a/src/core/operations/BLAKE2s.mjs
+++ b/src/core/operations/BLAKE2s.mjs
@@ -21,7 +21,7 @@ class BLAKE2s extends Operation {
         this.name = "BLAKE2s";
         this.module = "Hashing";
         this.description = "Performs BLAKE2s hashing on the input. Returns the output HEX encoded.";
-        this.infoURL = "https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2";
+        this.infoURL = "https://wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2";
         this.inputType = "string";
         this.outputType = "string";
         this.args = [

--- a/src/core/operations/BLAKE2s.mjs
+++ b/src/core/operations/BLAKE2s.mjs
@@ -35,6 +35,12 @@ class BLAKE2s extends Operation {
                 "name": "Output Encoding",
                 "type": "option",
                 "value": ["Hex", "Base64", "Raw"]
+            },
+            {
+                "name": "Key",
+                "type": "toggleString",
+                "value": "",
+                "toggleValues": ["UTF8", "Decimal", "Base64", "Hex", "Latin1"]
             }
         ];
     }
@@ -46,13 +52,19 @@ class BLAKE2s extends Operation {
      */
     run(input, args) {
         const [outSize, outFormat] = args;
+        let key = Utils.convertToByteArray(args[2].string || "", args[2].option);
+        if (key.length === 0){
+            key = null;
+        } else if (key.length > 32){
+            throw new OperationError(["Key cannot be greater than 32 bytes", "It is currently " + key.length +" bytes."].join("\n"));
+        }
         switch (outFormat) {
             case "Hex":
-                return blakejs.blake2sHex(input, null, outSize / 8);
+                return blakejs.blake2sHex(input, key, outSize / 8);
             case "Base64":
-                return toBase64(blakejs.blake2s(input, null, outSize / 8));
+                return toBase64(blakejs.blake2s(input, key, outSize / 8));
             case "Raw":
-                return Utils.arrayBufferToStr(blakejs.blake2s(input, null, outSize / 8).buffer);
+                return Utils.arrayBufferToStr(blakejs.blake2s(input, key, outSize / 8).buffer);
             default:
                 return new OperationError("Unsupported Output Type");
         }

--- a/src/core/operations/BLAKE2s.mjs
+++ b/src/core/operations/BLAKE2s.mjs
@@ -1,5 +1,5 @@
 /**
- * @author h [h]
+ * @author h345983745
  * @copyright Crown Copyright 2019
  * @license Apache-2.0
  */

--- a/src/core/operations/BLAKE2s.mjs
+++ b/src/core/operations/BLAKE2s.mjs
@@ -22,7 +22,9 @@ class BLAKE2s extends Operation {
 
         this.name = "BLAKE2s";
         this.module = "Hashing";
-        this.description = "Performs BLAKE2s hashing on the input. Returns the output HEX encoded.";
+        this.description = `Performs BLAKE2s hashing on the input.  
+        <br><br> BLAKE2s is a flavour of the BLAKE cryptographic hash function that is optimized for 8 to 32-bit platforms and produces digests of any size between 1 and 32 bytes.
+        <br><br> Supports the use of an optional key.`;
         this.infoURL = "https://wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2";
         this.inputType = "string";
         this.outputType = "string";
@@ -56,7 +58,7 @@ class BLAKE2s extends Operation {
         if (key.length === 0){
             key = null;
         } else if (key.length > 32){
-            throw new OperationError(["Key cannot be greater than 32 bytes", "It is currently " + key.length +" bytes."].join("\n"));
+            throw new OperationError(["Key cannot be greater than 32 bytes", "It is currently " + key.length + " bytes."].join("\n"));
         }
         switch (outFormat) {
             case "Hex":

--- a/src/core/operations/GenerateAllHashes.mjs
+++ b/src/core/operations/GenerateAllHashes.mjs
@@ -90,14 +90,14 @@ class GenerateAllHashes extends Operation {
                 "\nWhirlpool:   " + (new Whirlpool()).run(arrayBuffer, ["Whirlpool"]) +
                 "\nSSDEEP:      " + (new SSDEEP()).run(str) +
                 "\nCTPH:        " + (new CTPH()).run(str) +
-                "\nBLAKE2b-512: " + (new BLAKE2b).run(str, ["512", "Hex"]) +
-                "\nBLAKE2b-384: " + (new BLAKE2b).run(str, ["384", "Hex"]) +
-                "\nBLAKE2b-256: " + (new BLAKE2b).run(str, ["256", "Hex"]) +
-                "\nBLAKE2b-160: " + (new BLAKE2b).run(str, ["160", "Hex"]) +
-                "\nBLAKE2b-128: " + (new BLAKE2b).run(str, ["128", "Hex"]) +
-                "\nBLAKE2s-256: " + (new BLAKE2s).run(str, ["256", "Hex"]) +
-                "\nBLAKE2s-160: " + (new BLAKE2s).run(str, ["160", "Hex"]) +
-                "\nBLAKE2s-128: " + (new BLAKE2s).run(str, ["128", "Hex"]) +
+                "\nBLAKE2b-512: " + (new BLAKE2b).run(str, ["512", "Hex", {string: "", option: "UTF8"}]) +
+                "\nBLAKE2b-384: " + (new BLAKE2b).run(str, ["384", "Hex", {string: "", option: "UTF8"}]) +
+                "\nBLAKE2b-256: " + (new BLAKE2b).run(str, ["256", "Hex", {string: "", option: "UTF8"}]) +
+                "\nBLAKE2b-160: " + (new BLAKE2b).run(str, ["160", "Hex", {string: "", option: "UTF8"}]) +
+                "\nBLAKE2b-128: " + (new BLAKE2b).run(str, ["128", "Hex", {string: "", option: "UTF8"}]) +
+                "\nBLAKE2s-256: " + (new BLAKE2s).run(str, ["256", "Hex", {string: "", option: "UTF8"}]) +
+                "\nBLAKE2s-160: " + (new BLAKE2s).run(str, ["160", "Hex", {string: "", option: "UTF8"}]) +
+                "\nBLAKE2s-128: " + (new BLAKE2s).run(str, ["128", "Hex", {string: "", option: "UTF8"}]) +
                 "\n\nChecksums:" +
                 "\nFletcher-8:  " + (new Fletcher8Checksum).run(byteArray, []) +
                 "\nFletcher-16: " + (new Fletcher16Checksum).run(byteArray, []) +

--- a/src/core/operations/GenerateAllHashes.mjs
+++ b/src/core/operations/GenerateAllHashes.mjs
@@ -90,14 +90,14 @@ class GenerateAllHashes extends Operation {
                 "\nWhirlpool:   " + (new Whirlpool()).run(arrayBuffer, ["Whirlpool"]) +
                 "\nSSDEEP:      " + (new SSDEEP()).run(str) +
                 "\nCTPH:        " + (new CTPH()).run(str) +
-                "\nBLAKE2b-512: " + (new BLAKE2b).run(str, ["512"]) +
-                "\nBLAKE2b-384: " + (new BLAKE2b).run(str, ["384"]) +
-                "\nBLAKE2b-256: " + (new BLAKE2b).run(str, ["256"]) +
-                "\nBLAKE2b-160: " + (new BLAKE2b).run(str, ["160"]) +
-                "\nBLAKE2b-128: " + (new BLAKE2b).run(str, ["128"]) +
-                "\nBLAKE2s-256: " + (new BLAKE2s).run(str, ["256"]) +
-                "\nBLAKE2s-160: " + (new BLAKE2s).run(str, ["160"]) +
-                "\nBLAKE2s-128: " + (new BLAKE2s).run(str, ["128"]) +
+                "\nBLAKE2b-512: " + (new BLAKE2b).run(str, ["512", "Hex"]) +
+                "\nBLAKE2b-384: " + (new BLAKE2b).run(str, ["384", "Hex"]) +
+                "\nBLAKE2b-256: " + (new BLAKE2b).run(str, ["256", "Hex"]) +
+                "\nBLAKE2b-160: " + (new BLAKE2b).run(str, ["160", "Hex"]) +
+                "\nBLAKE2b-128: " + (new BLAKE2b).run(str, ["128", "Hex"]) +
+                "\nBLAKE2s-256: " + (new BLAKE2s).run(str, ["256", "Hex"]) +
+                "\nBLAKE2s-160: " + (new BLAKE2s).run(str, ["160", "Hex"]) +
+                "\nBLAKE2s-128: " + (new BLAKE2s).run(str, ["128", "Hex"]) +
                 "\n\nChecksums:" +
                 "\nFletcher-8:  " + (new Fletcher8Checksum).run(byteArray, []) +
                 "\nFletcher-16: " + (new Fletcher16Checksum).run(byteArray, []) +

--- a/src/core/operations/GenerateAllHashes.mjs
+++ b/src/core/operations/GenerateAllHashes.mjs
@@ -28,6 +28,8 @@ import Fletcher64Checksum from "./Fletcher64Checksum";
 import Adler32Checksum from "./Adler32Checksum";
 import CRC16Checksum from "./CRC16Checksum";
 import CRC32Checksum from "./CRC32Checksum";
+import BLAKE2b from "./BLAKE2b";
+import BLAKE2s from "./BLAKE2s";
 
 /**
  * Generate all hashes operation
@@ -88,6 +90,14 @@ class GenerateAllHashes extends Operation {
                 "\nWhirlpool:   " + (new Whirlpool()).run(arrayBuffer, ["Whirlpool"]) +
                 "\nSSDEEP:      " + (new SSDEEP()).run(str) +
                 "\nCTPH:        " + (new CTPH()).run(str) +
+                "\nBLAKE2b-512: " + (new BLAKE2b).run(str, ["512"]) +
+                "\nBLAKE2b-384: " + (new BLAKE2b).run(str, ["384"]) +
+                "\nBLAKE2b-256: " + (new BLAKE2b).run(str, ["256"]) +
+                "\nBLAKE2b-160: " + (new BLAKE2b).run(str, ["160"]) +
+                "\nBLAKE2b-128: " + (new BLAKE2b).run(str, ["128"]) +
+                "\nBLAKE2s-256: " + (new BLAKE2s).run(str, ["256"]) +
+                "\nBLAKE2s-160: " + (new BLAKE2s).run(str, ["160"]) +
+                "\nBLAKE2s-128: " + (new BLAKE2s).run(str, ["128"]) +
                 "\n\nChecksums:" +
                 "\nFletcher-8:  " + (new Fletcher8Checksum).run(byteArray, []) +
                 "\nFletcher-16: " + (new Fletcher16Checksum).run(byteArray, []) +

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -86,6 +86,8 @@ import "./tests/Enigma";
 import "./tests/Bombe";
 import "./tests/MultipleBombe";
 import "./tests/Typex";
+import "./tests/BLAKE2b";
+import "./tests/BLAKE2s";
 
 // Cannot test operations that use the File type yet
 //import "./tests/SplitColourChannels";

--- a/tests/operations/tests/BLAKE2b.mjs
+++ b/tests/operations/tests/BLAKE2b.mjs
@@ -1,7 +1,7 @@
 /**
  * BitwiseOp tests
  *
- * @author n1474335 [n1474335@gmail.com]
+ * @author h345983745
  * @copyright Crown Copyright 2017
  * @license Apache-2.0
  */

--- a/tests/operations/tests/BLAKE2b.mjs
+++ b/tests/operations/tests/BLAKE2b.mjs
@@ -14,7 +14,7 @@ TestRegister.addTests([
         expectedOutput: "4386a08a265111c9896f56456e2cb61a64239115c4784cf438e36cc851221972da3fb0115f73cd02486254001f878ab1fd126aac69844ef1c1ca152379d0a9bd",
         recipeConfig: [
             { "op": "BLAKE2b",
-                "args": ["512", "Hex"] }
+                "args": ["512", "Hex", {string: "", option: "UTF8"}] }
         ]
     },
     {
@@ -23,7 +23,7 @@ TestRegister.addTests([
         expectedOutput: "4d388e82ca8f866e606b6f6f0be910abd62ad6e98c0adfc27cf35acf948986d5c5b9c18b6f47261e1e679eb98edf8e2d",
         recipeConfig: [
             { "op": "BLAKE2b",
-                "args": ["384", "Hex"] }
+                "args": ["384", "Hex", {string: "", option: "UTF8"}] }
         ]
     },
     {
@@ -32,7 +32,7 @@ TestRegister.addTests([
         expectedOutput: "1dc01772ee0171f5f614c673e3c7fa1107a8cf727bdf5a6dadb379e93c0d1d00",
         recipeConfig: [
             { "op": "BLAKE2b",
-                "args": ["256", "Hex"] }
+                "args": ["256", "Hex", {string: "", option: "UTF8"}] }
         ]
     },
     {
@@ -41,7 +41,16 @@ TestRegister.addTests([
         expectedOutput: "6a8489e6fd6e51fae12ab271ec7fc8134dd5d737",
         recipeConfig: [
             { "op": "BLAKE2b",
-                "args": ["160", "Hex"] }
+                "args": ["160", "Hex", {string: "", option: "UTF8"}] }
+        ]
+    },
+    {
+        name: "BLAKE2b: Key Test",
+        input: "message data",
+        expectedOutput: "3d363ff7401e02026f4a4687d4863ced",
+        recipeConfig: [
+            { "op": "BLAKE2b",
+                "args": ["128", "Hex", {string: "pseudorandom key", option: "UTF8"}] }
         ]
     }
 ]);

--- a/tests/operations/tests/BLAKE2b.mjs
+++ b/tests/operations/tests/BLAKE2b.mjs
@@ -1,0 +1,47 @@
+/**
+ * BitwiseOp tests
+ *
+ * @author n1474335 [n1474335@gmail.com]
+ * @copyright Crown Copyright 2017
+ * @license Apache-2.0
+ */
+import TestRegister from "../TestRegister";
+
+TestRegister.addTests([
+    {
+        name: "BLAKE2b: 512 - Hello World",
+        input: "Hello World",
+        expectedOutput: "4386a08a265111c9896f56456e2cb61a64239115c4784cf438e36cc851221972da3fb0115f73cd02486254001f878ab1fd126aac69844ef1c1ca152379d0a9bd",
+        recipeConfig: [
+            { "op": "BLAKE2b",
+                "args": ["512"] }
+        ]
+    },
+    {
+        name: "BLAKE2b: 384 - Hello World",
+        input: "Hello World",
+        expectedOutput: "4d388e82ca8f866e606b6f6f0be910abd62ad6e98c0adfc27cf35acf948986d5c5b9c18b6f47261e1e679eb98edf8e2d",
+        recipeConfig: [
+            { "op": "BLAKE2b",
+                "args": ["384"] }
+        ]
+    },
+    {
+        name: "BLAKE2b: 256 - Hello World",
+        input: "Hello World",
+        expectedOutput: "1dc01772ee0171f5f614c673e3c7fa1107a8cf727bdf5a6dadb379e93c0d1d00",
+        recipeConfig: [
+            { "op": "BLAKE2b",
+                "args": ["256"] }
+        ]
+    },
+    {
+        name: "BLAKE2b: 160 - Hello World",
+        input: "Hello World",
+        expectedOutput: "6a8489e6fd6e51fae12ab271ec7fc8134dd5d737",
+        recipeConfig: [
+            { "op": "BLAKE2b",
+                "args": ["160"] }
+        ]
+    }
+]);

--- a/tests/operations/tests/BLAKE2b.mjs
+++ b/tests/operations/tests/BLAKE2b.mjs
@@ -2,7 +2,7 @@
  * BitwiseOp tests
  *
  * @author h345983745
- * @copyright Crown Copyright 2017
+ * @copyright Crown Copyright 2019
  * @license Apache-2.0
  */
 import TestRegister from "../TestRegister";
@@ -14,7 +14,7 @@ TestRegister.addTests([
         expectedOutput: "4386a08a265111c9896f56456e2cb61a64239115c4784cf438e36cc851221972da3fb0115f73cd02486254001f878ab1fd126aac69844ef1c1ca152379d0a9bd",
         recipeConfig: [
             { "op": "BLAKE2b",
-                "args": ["512"] }
+                "args": ["512", "Hex"] }
         ]
     },
     {
@@ -23,7 +23,7 @@ TestRegister.addTests([
         expectedOutput: "4d388e82ca8f866e606b6f6f0be910abd62ad6e98c0adfc27cf35acf948986d5c5b9c18b6f47261e1e679eb98edf8e2d",
         recipeConfig: [
             { "op": "BLAKE2b",
-                "args": ["384"] }
+                "args": ["384", "Hex"] }
         ]
     },
     {
@@ -32,7 +32,7 @@ TestRegister.addTests([
         expectedOutput: "1dc01772ee0171f5f614c673e3c7fa1107a8cf727bdf5a6dadb379e93c0d1d00",
         recipeConfig: [
             { "op": "BLAKE2b",
-                "args": ["256"] }
+                "args": ["256", "Hex"] }
         ]
     },
     {
@@ -41,7 +41,7 @@ TestRegister.addTests([
         expectedOutput: "6a8489e6fd6e51fae12ab271ec7fc8134dd5d737",
         recipeConfig: [
             { "op": "BLAKE2b",
-                "args": ["160"] }
+                "args": ["160", "Hex"] }
         ]
     }
 ]);

--- a/tests/operations/tests/BLAKE2s.mjs
+++ b/tests/operations/tests/BLAKE2s.mjs
@@ -1,7 +1,7 @@
 /**
  * BitwiseOp tests
  *
- * @author n1474335 [n1474335@gmail.com]
+ * @author h345983745
  * @copyright Crown Copyright 2017
  * @license Apache-2.0
  */

--- a/tests/operations/tests/BLAKE2s.mjs
+++ b/tests/operations/tests/BLAKE2s.mjs
@@ -14,7 +14,7 @@ TestRegister.addTests([
         expectedOutput: "7706af019148849e516f95ba630307a2018bb7bf03803eca5ed7ed2c3c013513",
         recipeConfig: [
             { "op": "BLAKE2s",
-                "args": ["256", "Hex"] }
+                "args": ["256", "Hex", {string: "", option: "UTF8"}] }
         ]
     },
     {
@@ -23,7 +23,7 @@ TestRegister.addTests([
         expectedOutput: "0e4fcfc2ee0097ac1d72d70b595a39e09a3c7c7e",
         recipeConfig: [
             { "op": "BLAKE2s",
-                "args": ["160", "Hex"] }
+                "args": ["160", "Hex", {string: "", option: "UTF8"}] }
         ]
     },
     {
@@ -32,7 +32,16 @@ TestRegister.addTests([
         expectedOutput: "9964ee6f36126626bf864363edfa96f6",
         recipeConfig: [
             { "op": "BLAKE2s",
-                "args": ["128", "Hex"] }
+                "args": ["128", "Hex", {string: "", option: "UTF8"}] }
+        ]
+    },
+    {
+        name: "BLAKE2s: Key Test",
+        input: "Hello World",
+        expectedOutput: "9964ee6f36126626bf864363edfa96f6",
+        recipeConfig: [
+            { "op": "BLAKE2s",
+                "args": ["128", "Hex", {string: "", option: "UTF8"}] }
         ]
     }
 ]);

--- a/tests/operations/tests/BLAKE2s.mjs
+++ b/tests/operations/tests/BLAKE2s.mjs
@@ -1,0 +1,38 @@
+/**
+ * BitwiseOp tests
+ *
+ * @author n1474335 [n1474335@gmail.com]
+ * @copyright Crown Copyright 2017
+ * @license Apache-2.0
+ */
+import TestRegister from "../TestRegister";
+
+TestRegister.addTests([
+    {
+        name: "BLAKE2s: 256 - Hello World",
+        input: "Hello World",
+        expectedOutput: "7706af019148849e516f95ba630307a2018bb7bf03803eca5ed7ed2c3c013513",
+        recipeConfig: [
+            { "op": "BLAKE2s",
+                "args": ["256"] }
+        ]
+    },
+    {
+        name: "BLAKE2s: 160 - Hello World",
+        input: "Hello World",
+        expectedOutput: "0e4fcfc2ee0097ac1d72d70b595a39e09a3c7c7e",
+        recipeConfig: [
+            { "op": "BLAKE2s",
+                "args": ["160"] }
+        ]
+    },
+    {
+        name: "BLAKE2s: 128 - Hello World",
+        input: "Hello World",
+        expectedOutput: "9964ee6f36126626bf864363edfa96f6",
+        recipeConfig: [
+            { "op": "BLAKE2s",
+                "args": ["128"] }
+        ]
+    }
+]);

--- a/tests/operations/tests/BLAKE2s.mjs
+++ b/tests/operations/tests/BLAKE2s.mjs
@@ -2,7 +2,7 @@
  * BitwiseOp tests
  *
  * @author h345983745
- * @copyright Crown Copyright 2017
+ * @copyright Crown Copyright 2019
  * @license Apache-2.0
  */
 import TestRegister from "../TestRegister";
@@ -14,7 +14,7 @@ TestRegister.addTests([
         expectedOutput: "7706af019148849e516f95ba630307a2018bb7bf03803eca5ed7ed2c3c013513",
         recipeConfig: [
             { "op": "BLAKE2s",
-                "args": ["256"] }
+                "args": ["256", "Hex"] }
         ]
     },
     {
@@ -23,7 +23,7 @@ TestRegister.addTests([
         expectedOutput: "0e4fcfc2ee0097ac1d72d70b595a39e09a3c7c7e",
         recipeConfig: [
             { "op": "BLAKE2s",
-                "args": ["160"] }
+                "args": ["160", "Hex"] }
         ]
     },
     {
@@ -32,7 +32,7 @@ TestRegister.addTests([
         expectedOutput: "9964ee6f36126626bf864363edfa96f6",
         recipeConfig: [
             { "op": "BLAKE2s",
-                "args": ["128"] }
+                "args": ["128", "Hex"] }
         ]
     }
 ]);


### PR DESCRIPTION
A pull request to implement #523.

Still to do:

- [x] Add to "Generate all hashes" operation
- [x] Look into having Hex, Base64 and Raw as output formats
- [x] Look at adding the option to provide a key
- [x] Enhance description

Example:

<img width="1151" alt="Screenshot 2019-03-31 at 18 48 37" src="https://user-images.githubusercontent.com/47383847/55292685-c89f2580-53e5-11e9-9bbc-5dc00efdda98.png">


