### PR TITLE
change empty Dish initialisation to use ArrayBuffer

### DIFF
--- a/src/core/Dish.mjs
+++ b/src/core/Dish.mjs
@@ -21,8 +21,8 @@ class Dish {
      * @param {Dish} [dish=null] - A dish to clone
      */
     constructor(dish=null) {
-        this.value = [];
-        this.type = Dish.BYTE_ARRAY;
+        this.value = new ArrayBuffer(0);
+        this.type = Dish.ARRAY_BUFFER;
 
         if (dish &&
             dish.hasOwnProperty("value") &&


### PR DESCRIPTION
A new Dish with no arguments will now construct a zero-length ArrayBuffer.

This will make an empty dish consistent with the new base type of ArrayBuffer.
