### PR TITLE
configure travis to use node LTS instead of latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - lts/*
 addons:
   chrome: stable
 install: npm install


### PR DESCRIPTION
Since node.js v 12.0.0 was released it was picked up by travis and builds are now failing due to some nasty compiler issues with node-sass. Fix node version to use LTS rather than latest.