### PR TITLE
Upgrade node-sass version to fix compilation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jsdoc-babel": "^0.5.0",
     "mini-css-extract-plugin": "^0.6.0",
     "nightwatch": "^1.0.19",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.12.0",
     "postcss-css-variables": "^0.12.0",
     "postcss-import": "^12.0.1",
     "postcss-loader": "^3.0.0",


### PR DESCRIPTION
I encountered this problem:
https://github.com/sass/libsass/issues/2883

More info:
https://github.com/sass/node-sass/commit/e59f5ba248af14d1850b8e9e0ac48c62a14988af
> If you're running Node 12, you must be running node-sass 4.12.

And it was indeed fixed by upgrading the version of `node-sass`.