### PR TITLE
Misc: Updated issues to use issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,1 @@
-<!-- Prefix the title above with one of the following: -->
-<!-- Bug report: -->
-<!-- Operation request: -->
-<!-- Feature request: -->
-<!-- Misc: -->
-
-### Summary
-
-
-### Example
-<!-- If describing a bug, tell us what happens instead of the expected behavior -->
-<!-- Include a link that triggers the bug if possible -->
-<!-- If you are requesting a new operation, include example input and output -->
-
+<!-- Prefix the title above with 'Misc:' -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'Bug report: <Insert title here>'
+labels: bug
+assignees: ''
+
+---
+
+<!-- Prefix the title above with 'Bug report:' -->
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior or a link to the recipe / input used to cause the bug:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (if relevant, please complete the following information):**
+ - OS: [e.g. Windows] 
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for the project
+title: 'Feature request: <Insert title here>'
+labels: feature
+assignees: ''
+
+---
+<!-- Prefix the title above with 'Feature request:' -->
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/operation-request.md
+++ b/.github/ISSUE_TEMPLATE/operation-request.md
@@ -1,0 +1,16 @@
+---
+name: Operation request
+about: Suggest an operation
+title: 'Operation request: <Insert title here>'
+labels: operation
+assignees: ''
+
+---
+
+<!-- Prefix the title above with 'Operation request:' -->
+
+## Summary
+
+### Example Input
+
+### Example Output


### PR DESCRIPTION
## Background 

When browsing the project I noticed the following message when viewing the [issue_template.md](https://github.com/gchq/CyberChef/blob/master/.github/ISSUE_TEMPLATE.md) file. 

<img width="935" alt="Screenshot 2019-05-19 at 15 45 52" src="https://user-images.githubusercontent.com/47383847/57983748-475f2900-7a4d-11e9-9a7a-5102dd2937ff.png">

More details on issue templates can be found [here](https://help.github.com/en/articles/about-issue-and-pull-request-templates).

## Proposed Changes

- Updated to have predefined issue templates for the following:
  - Bug Reports
  - Operation Requests
  - Feature Requests
- The default issue template now has no suggested layout, however does have a comment asking for 'Misc: ' to be used in the title. 

### Notes

- The feature and bug reports are the standard GitHub suggested templates with the following small changes and may wish to be customized further.
  - Bug Report:
    - Suggests adding a link to the recipe / input used to cause the bug under `To Reproduce`

### Screenshots

#### Creating an issue

<img width="676" alt="image" src="https://user-images.githubusercontent.com/47383847/57984805-4206dc00-7a57-11e9-9454-d5039c03adc9.png">
