### PR TITLE
Bug Fix: Disappearing Popover

### DIFF
--- a/src/web/RecipeWaiter.mjs
+++ b/src/web/RecipeWaiter.mjs
@@ -124,16 +124,21 @@ class RecipeWaiter {
      * @param {event} evt
      */
     opSortEnd(evt) {
-        if (this.removeIntent) {
-            if (evt.item.parentNode.id === "rec-list") {
-                evt.item.remove();
-            }
+        if (this.removeIntent && evt.item.parentNode.id === "rec-list") {
+            evt.item.remove();
             return;
         }
 
         // Reinitialise the popover on the original element in the ops list because for some reason it
-        // gets destroyed and recreated.
-        this.manager.ops.enableOpsListPopovers(evt.clone);
+        // gets destroyed and recreated. If the clone isn't in the ops list, we use the original item instead.
+        let enableOpsElement;
+        if (evt.clone.parentNode && evt.clone.parentNode.classList.contains("op-list")) {
+            enableOpsElement = evt.clone;
+        } else {
+            enableOpsElement = evt.item;
+            $(evt.item).attr("data-toggle", "popover");
+        }
+        this.manager.ops.enableOpsListPopovers(enableOpsElement);
 
         if (evt.item.parentNode.id !== "rec-list") {
             return;


### PR DESCRIPTION
When you drag an operation from the menu right back into the menu again, the popover disappears when  hovering over it. See the following gif for details:
![cc](https://user-images.githubusercontent.com/16269580/59165897-ed68f500-8b1a-11e9-9779-d1d087b077a5.gif)
This PR fixes this issue by recreating the popover on the original item itself, if no clone parent is found.