### PR TITLE
Operation: Parse UDP

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -167,6 +167,7 @@
             "Parse IP range",
             "Parse IPv6 address",
             "Parse IPv4 header",
+            "Parse UDP",
             "Parse SSH Host Key",
             "Parse URI",
             "URL Encode",

--- a/src/core/operations/ParseUDP.mjs
+++ b/src/core/operations/ParseUDP.mjs
@@ -63,8 +63,6 @@ class ParseUDP extends Operation {
      * @returns {html}
      */
     present(data) {
-        // const currentRecipeConfig = this.state.opList.map(op => op.config);
-        // console.log(currentRecipeConfig);
         const html = [];
         html.push("<table class='table table-hover table-sm table-bordered' style='table-layout: fixed'>");
         html.push("<tr>");

--- a/src/core/operations/ParseUDP.mjs
+++ b/src/core/operations/ParseUDP.mjs
@@ -1,0 +1,92 @@
+/**
+ * @author h345983745 []
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import Stream from "../lib/Stream.mjs";
+import {toHex} from "../lib/Hex.mjs";
+import OperationError from "../errors/OperationError.mjs";
+
+/**
+ * Parse UDP operation
+ */
+class ParseUDP extends Operation {
+
+    /**
+     * ParseUDP constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Parse UDP";
+        this.module = "Default";
+        this.description = "Parses a UDP header and payload if present.";
+        this.infoURL = "https://wikipedia.org/wiki/User_Datagram_Protocol";
+        this.inputType = "byteArray";
+        this.outputType = "json";
+        this.presentType = "html";
+        this.args = [];
+    }
+
+    /**
+     * @param {Uint8Array} input
+     * @returns {Object}
+     */
+    run(input, args) {
+
+        if (input.length < "8"){
+            throw new OperationError("Need 8 bytes for a UDP Header");
+        }
+
+        const s = new Stream(input);
+        //Parse Header
+        const UDPPacket = {
+            "Source port": s.readInt(2),
+            "Desination port": s.readInt(2),
+            "Length": s.readInt(2),
+            "Checksum": toHex(s.getBytes(2), "0x")
+        };
+        //Parse data if present
+        if (s.hasMore()){
+            UDPPacket.Data = toHex(s.getBytes(UDPPacket.Length - 8), "0x");
+        }
+
+        return UDPPacket;
+
+    }
+
+    /**
+     * Displays the UDP Packet in a table style
+     * @param {Object} data
+     * @returns {html}
+     */
+    present(data) {
+        // const currentRecipeConfig = this.state.opList.map(op => op.config);
+        // console.log(currentRecipeConfig);
+        const html = [];
+        html.push("<table class='table table-hover table-sm table-bordered' style='table-layout: fixed'>");
+        html.push("<tr>");
+        html.push("<th>Field</th>");
+        html.push("<th>Value</th>");
+        html.push("</tr>");
+
+        for (const key in data) {
+            switch (key){
+                default: {
+                    html.push("<tr>");
+                    html.push("<td style=\"word-wrap:break-word\">" + key + "</td>");
+                    html.push("<td>" + data[key] + "</td>");
+                    html.push("</tr>");
+                }
+            }
+        }
+        html.push("</table>");
+        return html.join("");
+    }
+
+}
+
+
+export default ParseUDP;

--- a/src/core/operations/ParseUDP.mjs
+++ b/src/core/operations/ParseUDP.mjs
@@ -22,7 +22,7 @@ class ParseUDP extends Operation {
 
         this.name = "Parse UDP";
         this.module = "Default";
-        this.description = "Parses a UDP header and payload if present.";
+        this.description = "Parses a UDP header and payload (if present).";
         this.infoURL = "https://wikipedia.org/wiki/User_Datagram_Protocol";
         this.inputType = "byteArray";
         this.outputType = "json";
@@ -44,7 +44,7 @@ class ParseUDP extends Operation {
         //Parse Header
         const UDPPacket = {
             "Source port": s.readInt(2),
-            "Desination port": s.readInt(2),
+            "Destination port": s.readInt(2),
             "Length": s.readInt(2),
             "Checksum": toHex(s.getBytes(2), "0x")
         };

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -88,6 +88,7 @@ import "./tests/BLAKE2s";
 import "./tests/Protobuf";
 import "./tests/ParseSSHHostKey";
 import "./tests/DefangIP";
+import "./tests/ParseUDP";
 
 // Cannot test operations that use the File type yet
 //import "./tests/SplitColourChannels";

--- a/tests/operations/tests/ParseUDP.mjs
+++ b/tests/operations/tests/ParseUDP.mjs
@@ -12,7 +12,7 @@ TestRegister.addTests([
     {
         name: "Parse UDP: No Data - JSON",
         input: "04 89 00 35 00 2c 01 01",
-        expectedOutput: "{\"Source port\":1161,\"Desination port\":53,\"Length\":44,\"Checksum\":\"0x010x01\"}",
+        expectedOutput: "{\"Source port\":1161,\"Destination port\":53,\"Length\":44,\"Checksum\":\"0x010x01\"}",
         recipeConfig: [
             {
                 op: "From Hex",
@@ -30,7 +30,7 @@ TestRegister.addTests([
     }, {
         name: "Parse UDP: With Data - JSON",
         input: "04 89 00 35 00 2c 01 01 02 02",
-        expectedOutput: "{\"Source port\":1161,\"Desination port\":53,\"Length\":44,\"Checksum\":\"0x010x01\",\"Data\":\"0x020x02\"}",
+        expectedOutput: "{\"Source port\":1161,\"Destination port\":53,\"Length\":44,\"Checksum\":\"0x010x01\",\"Data\":\"0x020x02\"}",
         recipeConfig: [
             {
                 op: "From Hex",

--- a/tests/operations/tests/ParseUDP.mjs
+++ b/tests/operations/tests/ParseUDP.mjs
@@ -1,0 +1,68 @@
+/**
+ * Parse UDP tests.
+ *
+ * @author h345983745
+ *
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Parse UDP: No Data - JSON",
+        input: "04 89 00 35 00 2c 01 01",
+        expectedOutput: "{\"Source port\":1161,\"Desination port\":53,\"Length\":44,\"Checksum\":\"0x010x01\"}",
+        recipeConfig: [
+            {
+                op: "From Hex",
+                args: ["Auto"],
+            },
+            {
+                op: "Parse UDP",
+                args: [],
+            },
+            {
+                op: "JSON Minify",
+                args: [],
+            },
+        ],
+    }, {
+        name: "Parse UDP: With Data - JSON",
+        input: "04 89 00 35 00 2c 01 01 02 02",
+        expectedOutput: "{\"Source port\":1161,\"Desination port\":53,\"Length\":44,\"Checksum\":\"0x010x01\",\"Data\":\"0x020x02\"}",
+        recipeConfig: [
+            {
+                op: "From Hex",
+                args: ["Auto"],
+            },
+            {
+                op: "Parse UDP",
+                args: [],
+            },
+            {
+                op: "JSON Minify",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Parse UDP: Not Enough Bytes",
+        input: "04 89 00",
+        expectedOutput: "Need 8 bytes for a UDP Header",
+        recipeConfig: [
+            {
+                op: "From Hex",
+                args: ["Auto"],
+            },
+            {
+                op: "Parse UDP",
+                args: [],
+            },
+            {
+                op: "JSON Minify",
+                args: [],
+            },
+        ],
+    }
+]);


### PR DESCRIPTION
Added a basic operation to parse a UDP packet and extract the Source Port, Destination Port, Checksum and Length, as well as any data if present. 

Features:
- Outputs JSON allowing for easy chaining of operations (demonstrated in the last screenshot)
- Renders output into a HTML table if the last operation

<img width="1155" alt="Screenshot 2019-08-19 at 19 52 45" src="https://user-images.githubusercontent.com/47383847/63294853-3bd90380-c2c3-11e9-9387-f0bde15ac40a.png">

<img width="1155" alt="Screenshot 2019-08-19 at 19 54 03" src="https://user-images.githubusercontent.com/47383847/63294883-485d5c00-c2c3-11e9-9627-2f00c2bbb029.png">

<img width="1155" alt="Screenshot 2019-08-19 at 19 52 23" src="https://user-images.githubusercontent.com/47383847/63294909-5ca15900-c2c3-11e9-966c-ba16a15bd59f.png">

_Please ignore the spelling of "destination" in these screenshots, it is not present in the PR_
