### PR TITLE
Feature: Add octal support to Change IP Format.

### DIFF
--- a/src/core/operations/ChangeIPFormat.mjs
+++ b/src/core/operations/ChangeIPFormat.mjs
@@ -29,12 +29,12 @@ class ChangeIPFormat extends Operation {
             {
                 "name": "Input format",
                 "type": "option",
-                "value": ["Dotted Decimal", "Decimal", "Hex"]
+                "value": ["Dotted Decimal", "Decimal", "Octal", "Hex"]
             },
             {
                 "name": "Output format",
                 "type": "option",
-                "value": ["Dotted Decimal", "Decimal", "Hex"]
+                "value": ["Dotted Decimal", "Decimal", "Octal", "Hex"]
             }
         ];
     }
@@ -54,7 +54,6 @@ class ChangeIPFormat extends Operation {
             if (lines[i] === "") continue;
             let baIp = [];
             let octets;
-            let decimal;
 
             if (inFormat === outFormat) {
                 output += lines[i] + "\n";
@@ -70,11 +69,10 @@ class ChangeIPFormat extends Operation {
                     }
                     break;
                 case "Decimal":
-                    decimal = lines[i].toString();
-                    baIp.push(decimal >> 24 & 255);
-                    baIp.push(decimal >> 16 & 255);
-                    baIp.push(decimal >> 8 & 255);
-                    baIp.push(decimal & 255);
+                    baIp = this.fromNumber(lines[i].toString(), 10);
+                    break;
+                case "Octal":
+                    baIp = this.fromNumber(lines[i].toString(), 8);
                     break;
                 case "Hex":
                     baIp = fromHex(lines[i]);
@@ -100,6 +98,10 @@ class ChangeIPFormat extends Operation {
                     decIp = ((baIp[0] << 24) | (baIp[1] << 16) | (baIp[2] << 8) | baIp[3]) >>> 0;
                     output += decIp.toString() + "\n";
                     break;
+                case "Octal":
+                    decIp = ((baIp[0] << 24) | (baIp[1] << 16) | (baIp[2] << 8) | baIp[3]) >>> 0;
+                    output += "0" + decIp.toString(8) + "\n";
+                    break;
                 case "Hex":
                     hexIp = "";
                     for (j = 0; j < baIp.length; j++) {
@@ -113,6 +115,22 @@ class ChangeIPFormat extends Operation {
         }
 
         return output.slice(0, output.length-1);
+    }
+
+    /**
+     * Constructs an array of IP address octets from a numerical value.
+     * @param {string} value The value of the IP address
+     * @param {number} radix The numeral system to be used
+     * @returns {number[]}
+     */
+    fromNumber(value, radix) {
+        const decimal = parseInt(value, radix);
+        const baIp = [];
+        baIp.push(decimal >> 24 & 255);
+        baIp.push(decimal >> 16 & 255);
+        baIp.push(decimal >> 8 & 255);
+        baIp.push(decimal & 255);
+        return baIp;
     }
 
 }

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -26,6 +26,7 @@ import "./tests/BitwiseOp";
 import "./tests/ByteRepr";
 import "./tests/CartesianProduct";
 import "./tests/CharEnc";
+import "./tests/ChangeIPFormat";
 import "./tests/Charts";
 import "./tests/Checksum";
 import "./tests/Ciphers";

--- a/tests/operations/tests/ChangeIPFormat.mjs
+++ b/tests/operations/tests/ChangeIPFormat.mjs
@@ -1,0 +1,52 @@
+/**
+ * Change IP format tests.
+ *
+ * @author Chris Smith
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Change IP format: Dotted Decimal to Hex",
+        input: "192.168.1.1",
+        expectedOutput: "c0a80101",
+        recipeConfig: [
+            {
+                op: "Change IP format",
+                args: ["Dotted Decimal", "Hex"],
+            },
+        ],
+    }, {
+        name: "Change IP format: Decimal to Dotted Decimal",
+        input: "3232235777",
+        expectedOutput: "192.168.1.1",
+        recipeConfig: [
+            {
+                op: "Change IP format",
+                args: ["Decimal", "Dotted Decimal"],
+            },
+        ],
+    }, {
+        name: "Change IP format: Hex to Octal",
+        input: "c0a80101",
+        expectedOutput: "030052000401",
+        recipeConfig: [
+            {
+                op: "Change IP format",
+                args: ["Hex", "Octal"],
+            },
+        ],
+    }, {
+        name: "Change IP format: Octal to Decimal",
+        input: "030052000401",
+        expectedOutput: "3232235777",
+        recipeConfig: [
+            {
+                op: "Change IP format",
+                args: ["Octal", "Decimal"],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
I couldn't see any tests for the existing functionality so I've added some that ensure each of the four input and output formats is tested once.

The logic for octal and decimal is very similar so I've pulled some of it out into a separate method to save duplicating all the bit-fiddling.