### PR TITLE
Update NodeRecipe so args is optional in bake config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5839,8 +5839,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5861,14 +5860,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5883,20 +5880,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6013,8 +6007,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6026,7 +6019,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6041,7 +6033,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6049,14 +6040,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6075,7 +6064,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6156,8 +6144,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6169,7 +6156,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6255,8 +6241,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6292,7 +6277,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6312,7 +6296,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6356,14 +6339,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/node/NodeRecipe.mjs
+++ b/src/node/NodeRecipe.mjs
@@ -43,9 +43,8 @@ class NodeRecipe {
             } else {
                 throw new TypeError("Inputted function not a Chef operation.");
             }
-        // CASE: op with configuration
+        // CASE: op, maybe with configuration
         } else if (ing.op) {
-            // Return op and args pair for opList item.
             const sanitisedOp = this._validateIngredient(ing.op);
             if (ing.args) {
                 return {op: sanitisedOp, args: ing.args};

--- a/src/node/NodeRecipe.mjs
+++ b/src/node/NodeRecipe.mjs
@@ -44,10 +44,13 @@ class NodeRecipe {
                 throw new TypeError("Inputted function not a Chef operation.");
             }
         // CASE: op with configuration
-        } else if (ing.op && ing.args) {
+        } else if (ing.op) {
             // Return op and args pair for opList item.
             const sanitisedOp = this._validateIngredient(ing.op);
-            return {op: sanitisedOp, args: ing.args};
+            if (ing.args) {
+                return {op: sanitisedOp, args: ing.args};
+            }
+            return sanitisedOp;
         } else {
             throw new TypeError("Recipe can only contain function names or functions");
         }

--- a/tests/node/tests/nodeApi.mjs
+++ b/tests/node/tests/nodeApi.mjs
@@ -259,6 +259,13 @@ TestRegister.addApiTests([
         assert.strictEqual(result.toString(), "73:6f:6d:65:20:69:6e:70:75:74");
     }),
 
+    it("chef.bake: should take single JSON object desribing op with optional args", () => {
+        const result = chef.bake("some input", {
+            op: chef.toHex,
+        });
+        assert.strictEqual(result.toString(), "73 6f 6d 65 20 69 6e 70 75 74");
+    }),
+
     it("chef.bake: should take single JSON object describing op and args ARRAY", () => {
         const result = chef.bake("some input", {
             op: chef.toHex,
@@ -295,6 +302,21 @@ TestRegister.addApiTests([
         assert.strictEqual(result.toString(), "67;63;72;66;146;72;66;144;72;66;65;72;62;60;72;66;71;72;66;145;72;67;60;72;67;65;72;67;64");
     }),
 
+    it("chef.bake: should take multiple ops in JSON object form, some without args", () => {
+        const result = chef.bake("some input", [
+            {
+                op: chef.toHex,
+            },
+            {
+                op: "to octal",
+                args: {
+                    delimiter: "Semi-colon",
+                }
+            }
+        ]);
+        assert.strictEqual(result.toString(), "67;63;40;66;146;40;66;144;40;66;65;40;62;60;40;66;71;40;66;145;40;67;60;40;67;65;40;67;64");
+    }),
+
     it("chef.bake: should handle op with multiple args", () => {
         const result = chef.bake("some input", {
             op: "to morse code",
@@ -322,6 +344,17 @@ TestRegister.addApiTests([
                 "args": [false] }
         ]);
         assert.strictEqual(result.toString(), "begin_something_anananaaaaak_da_aaak_da_aaaaananaaaaaaan_da_aaaaaaanan_da_aaak_end_something");
+    }),
+
+    it("chef.bake: should accept Clean JSON format from Chef website - args optional", () => {
+        const result = chef.bake("some input", [
+            { "op": "To Morse Code" },
+            { "op": "Hex to PEM",
+                "args": ["SOMETHING"] },
+            { "op": "To Snake case",
+                "args": [false] }
+        ]);
+        assert.strictEqual(result.toString(), "begin_something_aaaaaaaaaaaaaa_end_something");
     }),
 
     it("Excluded operations: throw a sensible error when you try and call one", () => {


### PR DESCRIPTION
With this change, `bake` can handle recipes where an `op` property is set, but no `args` property is. This is helpful for when we want to POST configs over some RESTful API, but don't need to explicitly define each argument.

Missing arguments fall back to their defaults, as is the case when just the operation is defined.

This sample input to bake is now valid:
``` javascript
[
  { "op": "To Morse Code" }, // no "args" property, so recipe will fall back to default args here
  { "op": "Hex to PEM",
    "args": ["SOMETHING"] },
  { "op": "To Snake case",
    "args": [false] }
]
```