### PR TITLE
Update forge version to 0.9.1 to correct DES and 3DES CTR mode results, and update tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9480,9 +9480,9 @@
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-forge": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "node-gyp": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.26",
     "ngeohash": "^0.6.3",
-    "node-forge": "^0.8.5",
+    "node-forge": "^0.9.1",
     "node-md6": "^0.1.0",
     "nodom": "^2.2.0",
     "notepack.io": "^2.2.0",

--- a/tests/node/tests/operations.mjs
+++ b/tests/node/tests/operations.mjs
@@ -70,13 +70,13 @@ TestRegister.addApiTests([
     }),
 
     it("AES decrypt: toggleString and option", () => {
-        const result = AESDecrypt("812c34ae6af353244a63c6ce23b7c34286b60be28ea4645523d4494700e7", {
+        const result = AESDecrypt("4a123af235a507bbc9d5871721d61b98504d569a9a5a7847e2d78315fec7", {
             key: {
                 string: "some longer key1",
                 option: "utf8",
             },
             iv: {
-                string: "some iv",
+                string: "some iv some iv1",
                 option: "utf8",
             },
             mode: "OFB",
@@ -916,8 +916,13 @@ smothering ampersand abreast
     it("Triple DES encrypt / decrypt", () => {
         assert.strictEqual(
             chef.tripleDESDecrypt(
-                chef.tripleDESEncrypt("Destroy Money", {key: {string: "30 31 2f 30 34 2f 31 39 39 39 20 32 32 3a 33 33 3a 30 3130 31 2f 30 34", option: "Hex"}}),
-                {key: {string: "30 31 2f 30 34 2f 31 39 39 39 20 32 32 3a 33 33 3a 30 3130 31 2f 30 34", option: "Hex"}}).toString(),
+                chef.tripleDESEncrypt("Destroy Money", {
+                    key: {string: "30 31 2f 30 34 2f 31 39 39 39 20 32 32 3a 33 33 3a 30 3130 31 2f 30 34", option: "Hex"},
+                    iv: {string: "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 0000 00 00 00 00", option: "Hex"}}),
+                {
+                    key: {string: "30 31 2f 30 34 2f 31 39 39 39 20 32 32 3a 33 33 3a 30 3130 31 2f 30 34", option: "Hex"},
+                    iv: {string: "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 0000 00 00 00 00", option: "Hex"}
+                }).toString(),
             "Destroy Money");
     }),
 

--- a/tests/operations/tests/Crypt.mjs
+++ b/tests/operations/tests/Crypt.mjs
@@ -537,9 +537,10 @@ Triple DES uses a key length of 24 bytes (192 bits).`,
         ],
     },
     {
+        // play.golang.org/p/4Qm2hfLGsqc
         name: "DES Encrypt: DES-CTR, Binary",
         input: "7a0e643132750e96d805d11e9e48e281fa39a41039286423cc1c045e5442b40bf1c3f2822bded3f9c8ef11cb25da64dda9c7ab87c246bd305385150c98f31465c2a6180fe81d31ea289b916504d5a12e1de26cb10adba84a0cb0c86f94bc14bc554f3018",
-        expectedOutput: "09015087e15b0937ab0ae5a84d66e520893690a6ea066382bf1330e8876cb3aa82ccc634f8f0d458bbe0257df6f4637cdac89f311168ba91208a21ba4bdd13c4b1a92cb93b33364b5b94a5d3d7fba68f6eed5807d9f5afeb7fbffcd94792131d264004ae",
+        expectedOutput: "09015087e15b0937c462fd5974af0c4b5880de136a5680453c99f4500628cbeca769623515d836985110b93eacfea7fa4a7b2b3cb4f67acbb5f7e8ddb5a5d445da74bf6572b0a874befa3888c81110776388e400afd8dc908dcc0c018c7753355f8a1c9f",
         recipeConfig: [
             {
                 "op": "DES Encrypt",
@@ -630,9 +631,10 @@ DES uses a key length of 8 bytes (64 bits).`,
         ],
     },
     {
+        // play.golang.org/p/RElT6pVeNz2
         name: "Triple DES Encrypt: DES-EDE3-CTR, Binary",
         input: "7a0e643132750e96d805d11e9e48e281fa39a41039286423cc1c045e5442b40bf1c3f2822bded3f9c8ef11cb25da64dda9c7ab87c246bd305385150c98f31465c2a6180fe81d31ea289b916504d5a12e1de26cb10adba84a0cb0c86f94bc14bc554f3018",
-        expectedOutput: "874d32cd7bdae52c254687e2d7e7093b077af2ec70878f99315f52a21ded5fb10c80a47e6271384335ac47376c758f675484fd7b8be9568aaec643f0d15cffdf3fe54ef3a1b2da50d5d8c7994d7a4a94e0a13a4d437443f0f1f39e93dd13ff06a80c66e4",
+        expectedOutput: "874d32cd7bdae52cd8630d3ab2bf373e7110e13713caa6a8bfed9d9dd802d0ebe93128ac0d0f05abcc56237b75fb69207dba11e68ddc4b0118a4c75e7248bbd80aaba4dd4436642546ec6ca7fa7526f3b0018ed5194c409dc2c1484530b968af554984f3",
         recipeConfig: [
             {
                 "op": "Triple DES Encrypt",
@@ -1160,9 +1162,10 @@ Triple DES uses a key length of 24 bytes (192 bits).`,
         ],
     },
     {
+        // play.golang.org/p/FpvqncmPk7R
         name: "DES Decrypt: DES-CTR, Binary",
         input: "09015087e15b0937ab0ae5a84d66e520893690a6ea066382bf1330e8876cb3aa82ccc634f8f0d458bbe0257df6f4637cdac89f311168ba91208a21ba4bdd13c4b1a92cb93b33364b5b94a5d3d7fba68f6eed5807d9f5afeb7fbffcd94792131d264004ae",
-        expectedOutput: "7a0e643132750e96d805d11e9e48e281fa39a41039286423cc1c045e5442b40bf1c3f2822bded3f9c8ef11cb25da64dda9c7ab87c246bd305385150c98f31465c2a6180fe81d31ea289b916504d5a12e1de26cb10adba84a0cb0c86f94bc14bc554f3018",
+        expectedOutput: "7a0e643132750e96b76dc9efa7810bea2b8feaa5b97887e44f96c0e6d506cc4dd4665683c6f63139221f8d887fd0a05b39741f8a67d87d6ac6f8dc6b668bd3e4a97b8bd3a19eafd5cdf50c3e1b3f17d61087d0b67cf6db31fec338b75f5954942c852829",
         recipeConfig: [
             {
                 "op": "DES Decrypt",
@@ -1253,9 +1256,10 @@ DES uses a key length of 8 bytes (64 bits).`,
         ],
     },
     {
+        // play.golang.org/p/iBacN9kX_RO
         name: "Triple DES Decrypt: DES-EDE3-CTR, Binary",
         input: "874d32cd7bdae52c254687e2d7e7093b077af2ec70878f99315f52a21ded5fb10c80a47e6271384335ac47376c758f675484fd7b8be9568aaec643f0d15cffdf3fe54ef3a1b2da50d5d8c7994d7a4a94e0a13a4d437443f0f1f39e93dd13ff06a80c66e4",
-        expectedOutput: "7a0e643132750e96d805d11e9e48e281fa39a41039286423cc1c045e5442b40bf1c3f2822bded3f9c8ef11cb25da64dda9c7ab87c246bd305385150c98f31465c2a6180fe81d31ea289b916504d5a12e1de26cb10adba84a0cb0c86f94bc14bc554f3018",
+        expectedOutput: "7a0e643132750e9625205bc6fb10dc848c53b7cb5a654d1242aecb6191ad3b5114727e5044a0ee11311575873c54829a80f9471ac473a0bbe5e791a23be75062f7e8f2210d998f9fbbaf3a5bb3dacd494d42d82950e3ab273f821eb979168315a80ad20f",
         recipeConfig: [
             {
                 "op": "Triple DES Decrypt",

--- a/tests/operations/tests/Crypt.mjs
+++ b/tests/operations/tests/Crypt.mjs
@@ -76,7 +76,7 @@ The following algorithms will be used based on the size of the key:
         ],
     },
     {
-        name: "AES Encrypt: AES-128-CBC, no IV, ASCII",
+        name: "AES Encrypt: AES-128-CBC with IV0, ASCII",
         input: "The quick brown fox jumps over the lazy dog.",
         expectedOutput: "2ef6c3fdb1314b5c2c326a2087fe1a82d5e73bf605ec8431d73e847187fc1c8fbbe969c177df1ecdf8c13f2f505f9498",
         recipeConfig: [
@@ -84,14 +84,14 @@ The following algorithms will be used based on the size of the key:
                 "op": "AES Encrypt",
                 "args": [
                     {"option": "Hex", "string": "00112233445566778899aabbccddeeff"},
-                    {"option": "Hex", "string": ""},
+                    {"option": "Hex", "string": "00000000000000000000000000000000"},
                     "CBC", "Raw", "Hex"
                 ]
             }
         ],
     },
     {
-        name: "AES Encrypt: AES-128-CTR, no IV, ASCII",
+        name: "AES Encrypt: AES-128-CTR with IV0, ASCII",
         input: "The quick brown fox jumps over the lazy dog.",
         expectedOutput: "a98c9e8e3b7c894384d740e4f0f4ed0be2bbb1e0e13a255812c3c6b0a629e4ad759c075b2469c6f4fb2c0cf9",
         recipeConfig: [
@@ -99,14 +99,14 @@ The following algorithms will be used based on the size of the key:
                 "op": "AES Encrypt",
                 "args": [
                     {"option": "Hex", "string": "00112233445566778899aabbccddeeff"},
-                    {"option": "Hex", "string": ""},
+                    {"option": "Hex", "string": "00000000000000000000000000000000"},
                     "CTR", "Raw", "Hex"
                 ]
             }
         ],
     },
     {
-        name: "AES Encrypt: AES-128-CBC with IV, ASCII",
+        name: "AES Encrypt: AES-128-CBC with IV1, ASCII",
         input: "The quick brown fox jumps over the lazy dog.",
         expectedOutput: "4fa077d50cc71a57393e7b542c4e3aea0fb75383b97083f2f568ffc13c0e7a47502ec6d9f25744a061a3a5e55fe95e8d",
         recipeConfig: [
@@ -681,7 +681,7 @@ The following algorithms will be used based on the size of the key:
         ],
     },
     {
-        name: "AES Decrypt: AES-128-CBC, no IV, ASCII",
+        name: "AES Decrypt: AES-128-CBC with IV0, ASCII",
         input: "2ef6c3fdb1314b5c2c326a2087fe1a82d5e73bf605ec8431d73e847187fc1c8fbbe969c177df1ecdf8c13f2f505f9498",
         expectedOutput: "The quick brown fox jumps over the lazy dog.",
         recipeConfig: [
@@ -689,7 +689,7 @@ The following algorithms will be used based on the size of the key:
                 "op": "AES Decrypt",
                 "args": [
                     {"option": "Hex", "string": "00112233445566778899aabbccddeeff"},
-                    {"option": "Hex", "string": ""},
+                    {"option": "Hex", "string": "00000000000000000000000000000000"},
                     "CBC", "Hex", "Raw",
                     {"option": "Hex", "string": ""}
                 ]
@@ -697,7 +697,7 @@ The following algorithms will be used based on the size of the key:
         ],
     },
     {
-        name: "AES Decrypt: AES-128-CTR, no IV, ASCII",
+        name: "AES Decrypt: AES-128-CTR with IV0, ASCII",
         input: "a98c9e8e3b7c894384d740e4f0f4ed0be2bbb1e0e13a255812c3c6b0a629e4ad759c075b2469c6f4fb2c0cf9",
         expectedOutput: "The quick brown fox jumps over the lazy dog.",
         recipeConfig: [
@@ -705,7 +705,7 @@ The following algorithms will be used based on the size of the key:
                 "op": "AES Decrypt",
                 "args": [
                     {"option": "Hex", "string": "00112233445566778899aabbccddeeff"},
-                    {"option": "Hex", "string": ""},
+                    {"option": "Hex", "string": "00000000000000000000000000000000"},
                     "CTR", "Hex", "Raw",
                     {"option": "Hex", "string": ""}
                 ]


### PR DESCRIPTION
Background: https://github.com/gchq/CyberChef/pull/647

This PR updates forge version to 0.9.1 to correct DES and 3DES CTR modes' outputs. forge 0.9.1 also enforces IV size to be the same as the cipher's block size. This PR updates the tests in which IVs are absent or are not the correct size.

The ground truths of tests for DES-CTR and DES-EDE3-CTR modes appear to have been generated by previous versions of forge, and are therefore incorrect. This PR corrects them using the results from GoLang's standard library and pyCryptoDome