### PR TITLE
Add FangURL

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -183,6 +183,7 @@
             "Encode NetBIOS Name",
             "Decode NetBIOS Name",
             "Defang URL",
+            "Fang URL",
             "Defang IP Addresses"
         ]
     },

--- a/src/core/operations/FangURL.mjs
+++ b/src/core/operations/FangURL.mjs
@@ -69,7 +69,7 @@ class FangURL extends Operation {
 function fangURL(url, dots, http, slashes) {
     if (dots) url = url.replace(/\[\.\]/g, ".");
     if (http) url = url.replace(/hxxp/g, "http");
-    if (slashes) url = url.replace(/\[\:\/\/\]/g, "://");
+    if (slashes) url = url.replace(/[://]/g, "://");
 
     return url;
 }

--- a/src/core/operations/FangURL.mjs
+++ b/src/core/operations/FangURL.mjs
@@ -1,0 +1,77 @@
+/**
+ * @author arnydo [github@arnydo.com]
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+
+/**
+ * FangURL operation
+ */
+class FangURL extends Operation {
+
+    /**
+     * FangURL constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Fang URL";
+        this.module = "Default";
+        this.description = "Takes a 'Defanged' Universal Resource Locator (URL) and 'Fangs' it. Meaning, it removes the alterations (defanged) that render it useless so that it can be used again.";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Escape [.]",
+                type: "boolean",
+                value: true
+            },
+            {
+                name: "Escape hxxp",
+                type: "boolean",
+                value: true
+            },
+            {
+                name: "Escape ://",
+                type: "boolean",
+                value: true
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const [dots, http, slashes] = args;
+
+        input = fangURL(input, dots, http, slashes);
+
+        return input;
+    }
+
+}
+
+
+/**
+ * Defangs a given URL
+ *
+ * @param {string} url
+ * @param {boolean} dots
+ * @param {boolean} http
+ * @param {boolean} slashes
+ * @returns {string}
+ */
+function fangURL(url, dots, http, slashes) {
+    if (dots) url = url.replace(/\[\.\]/g, ".");
+    if (http) url = url.replace(/hxxp/g, "http");
+    if (slashes) url = url.replace(/\[\:\/\/\]/g, "://");
+
+    return url;
+}
+
+export default FangURL;


### PR DESCRIPTION
FangURL takes a "defanged" URL that was previously rendered useless and allows it to be functional again. In cases where a batch of "defanged" urls have been obtained this will allow for a quick process to return them to their original format. Often necessary when injecting into other systems.