### PR TITLE
PHP Deserialize return null for N

### DIFF
--- a/src/core/operations/PHPDeserialize.mjs
+++ b/src/core/operations/PHPDeserialize.mjs
@@ -128,8 +128,7 @@ class PHPDeserialize extends Operation {
             switch (kind) {
                 case "n":
                     expect(";");
-                    return "";
-
+                    return "null";
                 case "i":
                 case "d":
                 case "b": {


### PR DESCRIPTION
PHP Deserialize now returns proper null value for a value of N in PHP serialized data.

Closes #641 