### PR TITLE
Utils: don't consume three backslashes at a time

### DIFF
--- a/src/core/Utils.mjs
+++ b/src/core/Utils.mjs
@@ -201,8 +201,7 @@ class Utils {
      * Utils.parseEscapedChars("\\n");
      */
     static parseEscapedChars(str) {
-        return str.replace(/(\\)?\\([bfnrtv'"]|[0-3][0-7]{2}|[0-7]{1,2}|x[\da-fA-F]{2}|u[\da-fA-F]{4}|u\{[\da-fA-F]{1,6}\}|\\)/g, function(m, a, b) {
-            if (a === "\\") return "\\"+b;
+        return str.replace(/\\([bfnrtv'"]|[0-3][0-7]{2}|[0-7]{1,2}|x[\da-fA-F]{2}|u[\da-fA-F]{4}|u\{[\da-fA-F]{1,6}\}|\\)/g, function(m, b) {
             switch (b[0]) {
                 case "\\":
                     return "\\";


### PR DESCRIPTION
fixes #589

This removes the special logic for understanding three backslashes in a row as an escaped single backslash.