### PR TITLE
Get rid of the 'searchfield' style on the search field

### DIFF
--- a/src/web/stylesheets/utils/_overrides.css
+++ b/src/web/stylesheets/utils/_overrides.css
@@ -82,14 +82,6 @@ a:focus {
     border-color: var(--btn-success-hover-border-colour);
 }
 
-input[type="search"] {
-    appearance: searchfield;
-}
-
-input[type="search"]::-webkit-search-cancel-button {
-    appearance: searchfield-cancel-button;
-}
-
 select.form-control:not([size]):not([multiple]), select.custom-file-control:not([size]):not([multiple]) {
     height: unset !important;
 }


### PR DESCRIPTION
I'm not sure why the 'searchfield' style isn't looking so good (in Safari and Firefox), but currently the bounding box size is too small and clips the text.

![image](https://user-images.githubusercontent.com/5242016/66424802-3050b180-e9c3-11e9-8104-4d200ccdd809.png)

To my eyes the text field looks fine without it:

![image](https://user-images.githubusercontent.com/5242016/66425021-95a4a280-e9c3-11e9-87b5-189b770bef5e.png)

This style doesn't appear at all in Chrome, so what about simply deleting it for consistency?

Here's a [short video](https://youbeill.in/scrap/searchfield-style-can-go.mp4) depicting the enabled and disabled states of this style in Safari, Chrome, and Firefox on macOS 10.14.6.