### PR TITLE
DES Encrypt/Decrypt - checks length of IV string

### DIFF
--- a/src/core/operations/DESDecrypt.mjs
+++ b/src/core/operations/DESDecrypt.mjs
@@ -73,6 +73,11 @@ class DESDecrypt extends Operation {
 DES uses a key length of 8 bytes (64 bits).
 Triple DES uses a key length of 24 bytes (192 bits).`);
         }
+        if (iv.length !== 8) {
+            throw new OperationError(`Invalid IV length: ${iv.length} bytes
+
+DES uses an IV length of 8 bytes (64 bits).`);
+        }
 
         input = Utils.convertToByteString(input, inputType);
 

--- a/src/core/operations/DESEncrypt.mjs
+++ b/src/core/operations/DESEncrypt.mjs
@@ -73,6 +73,11 @@ class DESEncrypt extends Operation {
 DES uses a key length of 8 bytes (64 bits).
 Triple DES uses a key length of 24 bytes (192 bits).`);
         }
+        if (iv.length !== 8) {
+            throw new OperationError(`Invalid IV length: ${iv.length} bytes
+
+DES uses an IV length of 8 bytes (64 bits).`);
+        }
 
         input = Utils.convertToByteString(input, inputType);
 

--- a/tests/node/tests/operations.mjs
+++ b/tests/node/tests/operations.mjs
@@ -400,7 +400,7 @@ color: white;
             },
             iv: {
                 string: "threetwo",
-                option: "Hex",
+                option: "utf8",
             },
             mode: "ECB",
         });
@@ -415,7 +415,7 @@ color: white;
             },
             iv: {
                 string: "threetwo",
-                option: "Hex",
+                option: "utf8",
             },
             mode: "ECB",
         });


### PR DESCRIPTION
Checks the length of IV string when encrypting.  DES encrypt/decrypt test was updated to use utf8 instead of HEX.

Closes #682 