### PR TITLE
Theme configuration through url

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ You can use as many operations as you like in simple or complex ways. Some examp
      - It should be noted that none of your recipe configuration or input (either text or files) is ever sent to the CyberChef web server - all processing is carried out within your browser, on your own computer.
      - Due to this feature, CyberChef can be downloaded and run locally. You can use the link in the top left corner of the app to download a full copy of CyberChef and drop it into a virtual machine, share it with other people, or host it in a closed network.
 
+## Url prefilling
+
+By manipulation of CyberChef's url hash, you can change the initial settings with which the page opens.
+The format is `https://gchq.github.io/CyberChef/#recipe=Function()&input=...`
+
+Supported options are `recipe`, `input`, and `theme`.
 
 ## Browser support
 

--- a/src/web/App.mjs
+++ b/src/web/App.mjs
@@ -453,6 +453,7 @@ class App {
      * Searches the URI parameters for recipe and input parameters.
      * If recipe is present, replaces the current recipe with the recipe provided in the URI.
      * If input is present, decodes and sets the input to the one provided in the URI.
+     * If theme is present, uses the theme.
      *
      * @fires Manager#statechange
      */
@@ -489,6 +490,10 @@ class App {
                 const inputData = fromBase64(this.uriParams.input);
                 this.setInput(inputData);
             } catch (err) {}
+        }
+
+        if (this.uriParams.theme) {
+            document.querySelector(":root").className = this.uriParams.theme;
         }
 
         this.autoBakePause = false;


### PR DESCRIPTION
I added a `theme` parameter to the query string that overrides the user's theme.
I made it override rather than only take effect by default because if a page with a dark theme is trying to embed a cyberchef window, it would be jarring if the cyberchef frame had a light theme.

A better balance may be to make the `theme` parameter only accept `light` or `dark`. If the user's preferred theme is light and the `theme` parameter is `light`, then the user's theme will be used. Otherwise, the theme will be set to some dark theme.

Fixes #594.