### PR TITLE
diff.mjs: Allows showing subtraction

### DIFF
--- a/src/core/operations/Diff.mjs
+++ b/src/core/operations/Diff.mjs
@@ -50,7 +50,7 @@ class Diff extends Operation {
             {
                 "name": "Show subtraction",
                 "type": "boolean",
-                "value": true
+                "value": false
             },
             {
                 "name": "Ignore whitespace",
@@ -123,7 +123,7 @@ class Diff extends Operation {
             } else if (diff[i].removed) {
                 if (showRemoved) output += "<span class='hl3'>" + Utils.escapeHtml(diff[i].value) + "</span>";
             } else if (!showSubtraction) {
-                output += Utils.escapeHtml(diff[i].value) + "</span>";
+                output += Utils.escapeHtml(diff[i].value);
             }
         }
 

--- a/src/core/operations/Diff.mjs
+++ b/src/core/operations/Diff.mjs
@@ -48,6 +48,11 @@ class Diff extends Operation {
                 "value": true
             },
             {
+                "name": "Show subtraction",
+                "type": "boolean",
+                "value": true
+            },
+            {
                 "name": "Ignore whitespace",
                 "type": "boolean",
                 "value": false,
@@ -67,6 +72,7 @@ class Diff extends Operation {
                 diffBy,
                 showAdded,
                 showRemoved,
+                showSubtraction,
                 ignoreWhitespace
             ] = args,
             samples = input.split(sampleDelim);
@@ -116,8 +122,8 @@ class Diff extends Operation {
                 if (showAdded) output += "<span class='hl5'>" + Utils.escapeHtml(diff[i].value) + "</span>";
             } else if (diff[i].removed) {
                 if (showRemoved) output += "<span class='hl3'>" + Utils.escapeHtml(diff[i].value) + "</span>";
-            } else {
-                output += Utils.escapeHtml(diff[i].value);
+            } else if (!showSubtraction) {
+                output += Utils.escapeHtml(diff[i].value) + "</span>";
             }
         }
 

--- a/tests/operations/tests/StrUtils.mjs
+++ b/tests/operations/tests/StrUtils.mjs
@@ -15,7 +15,29 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "Diff",
-                "args": ["\\n\\n", "Character", true, true, false]
+                "args": ["\\n\\n", "Character", true, true, false, false]
+            }
+        ],
+    },
+    {
+        name: "Diff added with subtraction, basic usage",
+        input: "testing23\n\ntesting123",
+        expectedOutput: "<span class='hl5'>1</span>",
+        recipeConfig: [
+            {
+                "op": "Diff",
+                "args": ["\\n\\n", "Character", true, true, true, false]
+            }
+        ],
+    },
+    {
+        name: "Diff removed with subtraction, basic usage",
+        input: "testing123\n\ntesting3",
+        expectedOutput: "<span class='hl3'>12</span>",
+        recipeConfig: [
+            {
+                "op": "Diff",
+                "args": ["\\n\\n", "Character", true, true, true, false]
             }
         ],
     },


### PR DESCRIPTION
    Adds "Show Subtraction" button to allow seeing only the difference
    between two texts.
    When selected and combined, user can see only the characters or
    words that were added. If not combined, with either removed or added
    but selected, then nothing is displayed.