### PR TITLE
Add file extensions which are mandatory for the latest Node 12.x.

### DIFF
--- a/src/core/operations/BaconCipherDecode.mjs
+++ b/src/core/operations/BaconCipherDecode.mjs
@@ -4,12 +4,12 @@
  * @license Apache-2.0
  */
 
-import Operation from "../Operation";
+import Operation from "../Operation.mjs";
 import {
     BACON_ALPHABETS,
     BACON_TRANSLATION_CASE, BACON_TRANSLATION_AMNZ, BACON_TRANSLATIONS, BACON_CLEARER_MAP, BACON_NORMALIZE_MAP,
     swapZeroAndOne
-} from "../lib/Bacon";
+} from "../lib/Bacon.mjs";
 
 /**
  * Bacon Cipher Decode operation

--- a/src/core/operations/BaconCipherEncode.mjs
+++ b/src/core/operations/BaconCipherEncode.mjs
@@ -4,12 +4,12 @@
  * @license Apache-2.0
  */
 
-import Operation from "../Operation";
+import Operation from "../Operation.mjs";
 import {
     BACON_ALPHABETS,
     BACON_TRANSLATIONS_FOR_ENCODING, BACON_TRANSLATION_AB,
     swapZeroAndOne
-} from "../lib/Bacon";
+} from "../lib/Bacon.mjs";
 
 /**
  * Bacon Cipher Encode operation

--- a/src/core/operations/DefangIPAddresses.mjs
+++ b/src/core/operations/DefangIPAddresses.mjs
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  */
 
-import Operation from "../Operation";
+import Operation from "../Operation.mjs";
 
 
 /**

--- a/src/core/operations/ParseSSHHostKey.mjs
+++ b/src/core/operations/ParseSSHHostKey.mjs
@@ -4,11 +4,11 @@
  * @license Apache-2.0
  */
 
-import Operation from "../Operation";
-import OperationError from "../errors/OperationError";
-import Utils from "../Utils";
-import { fromBase64 } from "../lib/Base64";
-import { fromHex, toHexFast } from "../lib/Hex";
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import Utils from "../Utils.mjs";
+import { fromBase64 } from "../lib/Base64.mjs";
+import { fromHex, toHexFast } from "../lib/Hex.mjs";
 
 /**
  * Parse SSH Host Key operation


### PR DESCRIPTION
While this doesn't solve the upstream import's which don't comply to the mandatory file extensions it preps CyberChef for it.