### PR TITLE
Improved continueUntil, added consumeWhile and made the EVTX extractor more complete

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,7 @@
         "block-spacing": "error",
         "array-bracket-spacing": "error",
         "comma-spacing": "error",
+	"spaced-comment": ["error", "always"],
         "comma-style": "error",
         "computed-property-spacing": "error",
         "no-trailing-spaces": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,6 @@
         "block-spacing": "error",
         "array-bracket-spacing": "error",
         "comma-spacing": "error",
-	"spaced-comment": ["error", "always"],
         "comma-style": "error",
         "computed-property-spacing": "error",
         "no-trailing-spaces": "warn",

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -3349,7 +3349,7 @@ export function extractEVTX(bytes, offset) {
 
         // Loop through ELFCHNKs.
         if (stream.getBytes(7).join("") !== [0x45, 0x6c, 0x66, 0x43, 0x68, 0x6e, 0x6b].join(""))
-            break;    
+            break;
         stream.moveForwardsBy(0xfff9);
     }
     stream.consumeWhile(0x00);

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -3348,11 +3348,11 @@ export function extractEVTX(bytes, offset) {
     while (stream.hasMore()) {
 
         // Loop through ELFCHNKs.
-        if (stream.getBytes(7).join("") === [0x45, 0x6c, 0x66, 0x43, 0x68, 0x6e, 0x6b].join(""))
-            stream.moveForwardsBy(0xfff9);
-        else
-            break;
+        if (stream.getBytes(7).join("") !== [0x45, 0x6c, 0x66, 0x43, 0x68, 0x6e, 0x6b].join(""))
+            break;    
+        stream.moveForwardsBy(0xfff9);
     }
+    stream.consumeWhile(0x00);
     return stream.carve();
 }
 

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -2577,21 +2577,21 @@ export function extractJPEG(bytes, offset) {
 export function extractGIF(bytes, offset) {
     const stream = new Stream(bytes.slice(offset));
 
-    //Move to application extension block.
+    // Move to application extension block.
     stream.continueUntil([0x21, 0xff]);
 
-    //Move to Graphic Control Extension for frame #1.
+    // Move to Graphic Control Extension for frame #1.
     stream.continueUntil([0x21, 0xf9]);
     stream.moveForwardsBy(2);
     while (stream.hasMore()) {
 
-        //Move to Image descriptor.
+        // Move to Image descriptor.
         stream.moveForwardsBy(stream.getBytes(1)[0]+1);
 
-        //Move past Image descriptor to the image data.
+        // Move past Image descriptor to the image data.
         stream.moveForwardsBy(11);
 
-        //Loop until next Graphic Control Extension.
+        // Loop until next Graphic Control Extension.
         while (stream.getBytes(2) !== [0x21, 0xf9]) {
             stream.moveBackwardsBy(2);
             stream.moveForwardsBy(stream.getBytes(1)[0]);
@@ -2599,7 +2599,7 @@ export function extractGIF(bytes, offset) {
                 break;
             stream.moveBackwardsBy(1);
         }
-        //When the end of the file is [0x00, 0x3b], end.
+        // When the end of the file is [0x00, 0x3b], end.
         if (stream.getBytes(1)[0] === 0x3b)
             break;
         stream.moveForwardsBy(1);
@@ -3000,7 +3000,7 @@ export function extractGZIP(bytes, offset) {
 export function extractBZIP2(bytes, offset) {
     const stream = new Stream(bytes.slice(offset));
 
-    //The EOFs shifted between all possible combinations.
+    // The EOFs shifted between all possible combinations.
     const lookingfor = [
         [0x77, 0x24, 0x53, 0x85, 0x09],
         [0xee, 0x48, 0xa7, 0x0a, 0x12],
@@ -3014,12 +3014,12 @@ export function extractBZIP2(bytes, offset) {
 
     for (let i = 0; i < lookingfor.length; i++) {
 
-        //Continue until an EOF.
+        // Continue until an EOF.
         stream.continueUntil(lookingfor[i]);
         if (stream.getBytes(5).join("") === lookingfor[i].join(""))
             break;
 
-        //Jump back to the start if invalid EOF.
+        // Jump back to the start if invalid EOF.
         stream.moveTo(0);
     }
     stream.moveForwardsBy(4);

--- a/src/core/lib/Stream.mjs
+++ b/src/core/lib/Stream.mjs
@@ -213,8 +213,8 @@ export default class Stream {
      * @param {Number} val
      */
     consumeWhile(val) {
-        while (this.position < this.length){
-            if (this.bytes[this.position] !== val){
+        while (this.position < this.length) {
+            if (this.bytes[this.position] !== val) {
                 break;
             }
             this.position++;

--- a/src/core/lib/Stream.mjs
+++ b/src/core/lib/Stream.mjs
@@ -189,7 +189,7 @@ export default class Stream {
             found = true;
 
             // Loop through the elements comparing them to val.
-            for (let x = length-1; x !== -1; x--) {
+            for (let x = length-1; x+1; x--) {
                 if (this.bytes[(this.position-length) + x] !== val[x]) {
                     found = false;
 

--- a/src/core/lib/Stream.mjs
+++ b/src/core/lib/Stream.mjs
@@ -213,8 +213,7 @@ export default class Stream {
      * @param {Number} val
      */
     consumeWhile(val) {
-        while ((this.position < this.length) && (this.bytes[(this.position++)] === val))
-        this.position--;
+        while ((++this.position < this.length) && (this.bytes[(this.position)] === val));
     }
 
     /**

--- a/src/core/lib/Stream.mjs
+++ b/src/core/lib/Stream.mjs
@@ -189,7 +189,7 @@ export default class Stream {
             found = true;
 
             // Loop through the elements comparing them to val.
-            for (let x = length-1; x != -1; x--) {
+            for (let x = length-1; x !== -1; x--) {
                 if (this.bytes[(this.position-length) + x] !== val[x]) {
                     found = false;
 

--- a/src/core/lib/Stream.mjs
+++ b/src/core/lib/Stream.mjs
@@ -158,14 +158,15 @@ export default class Stream {
 
 
         /**
-         * Build's the skip forward table from the value to be searched.
+         * Builds the skip forward table from the value to be searched.
          *
-         * @param val
-         * @param len
+         * @param {Uint8Array} val
+         * @param {Number} len
+         * @returns {Uint8Array}
          */
         function preprocess(val, len) {
             const skiptable = new Array();
-            val.forEach(function(element, index) {
+            val.forEach((element, index) => {
                 skiptable[element] = len - index;
             });
             return skiptable;
@@ -189,8 +190,8 @@ export default class Stream {
             found = true;
 
             // Loop through the elements comparing them to val.
-            for (let x = length-1; x+1; x--) {
-                if (this.bytes[(this.position-length) + x] !== val[x]) {
+            for (let x = length-1; x > -1; x--) {
+                if (this.bytes[this.position-length + x] !== val[x]) {
                     found = false;
 
                     // If element is not equal to val's element then jump forward by the correct amount.
@@ -199,7 +200,7 @@ export default class Stream {
                 }
             }
             if (found) {
-                this.position = (this.position - length);
+                this.position -= length;
                 break;
             }
         }
@@ -209,10 +210,11 @@ export default class Stream {
     /**
      * Consume bytes if it matches the supplied value.
      *
-     * @param val
+     * @param {Number} val
      */
     consumeWhile(val) {
-        while ((this.position < this.length) && (this.bytes[this.position++] === val));
+        while ((this.position < this.length) && (this.bytes[(this.position++)] === val))
+        this.position--;
     }
 
     /**

--- a/src/core/lib/Stream.mjs
+++ b/src/core/lib/Stream.mjs
@@ -190,7 +190,7 @@ export default class Stream {
             found = true;
 
             // Loop through the elements comparing them to val.
-            for (let x = length-1; x > -1; x--) {
+            for (let x = length-1; x >= 0; x--) {
                 if (this.bytes[this.position-length + x] !== val[x]) {
                     found = false;
 
@@ -213,7 +213,12 @@ export default class Stream {
      * @param {Number} val
      */
     consumeWhile(val) {
-        while ((++this.position < this.length) && (this.bytes[(this.position)] === val));
+        while (this.position < this.length){
+            if (this.bytes[this.position] !== val){
+                break;
+            }
+            this.position++;
+        }
     }
 
     /**


### PR DESCRIPTION
continueUntil now uses the Boyer-moore string search algorithm. 
consumeWhile consumes bytes while the byte is equal to the given value.
EVTX extractor can now extract all of the file, thanks to consumeWhile.