### PR TITLE
To Case Insensitive Regex Operation improved.

### DIFF
--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -2858,7 +2858,7 @@ export function extractTAR(bytes, offset) {
         if (stream.getBytes(5).join("") !== [0x75, 0x73, 0x74, 0x61, 0x72].join("")) {
 
             // This is needed since if it were not here it relies on there being at least 0x106 padding of 0s at the end of the TAR
-            stream.moveBackwardsBy(0x101);
+            stream.moveBackwardsBy(0x106);
             break;
         }
 

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -2745,7 +2745,7 @@ export function extractMACHO(bytes, offset) {
      * @returns {bool}
      */
     function isMagic64(magic) {
-        return magic === MHCIGAM64 || magic === MHCIGAM64;
+        return magic === MHCIGAM64 || magic === MHMAGIC64;
     }
 
 
@@ -2821,16 +2821,16 @@ export function extractMACHO(bytes, offset) {
 
 
     const MHCIGAM64 = "207250237254";
+    const MHMAGIC64 = "254237250207";
     const MHCIGAM = "206250237254";
     const LCSEGEMENT64 = 0x19;
     const LCSEGEMENT = 0x1;
+
     const stream = new Stream(bytes.slice(offset));
     const magic = stream.getBytes(4).join("");
-    const is64 = isMagic64(magic);
-    const isSwap = shouldSwapBytes(magic) ? "le" : "be";
 
     // Move to the end of the final segment.
-    stream.moveTo(dumpMachHeader(stream, is64, isSwap));
+    stream.moveTo(dumpMachHeader(stream, isMagic64(magic), shouldSwapBytes(magic) ? "le" : "be"));
     return stream.carve();
 }
 

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -2737,6 +2737,11 @@ export function extractZIP(bytes, offset) {
  */
 export function extractMACHO(bytes, offset) {
 
+    // Magic bytes.
+    const MHCIGAM64 = "207250237254";
+    const MHMAGIC64 = "254237250207";
+    const MHCIGAM = "206250237254";
+
 
     /**
      * Checks to see if the file is 64-bit.
@@ -2771,6 +2776,9 @@ export function extractMACHO(bytes, offset) {
      */
     function dumpSegmentCommands(stream, offset, isSwap, ncmds) {
         let total = 0;
+        const LCSEGEMENT64 = 0x19;
+        const LCSEGEMENT = 0x1;
+
         for (let i = 0; i < ncmds; i++) {
 
             // Move to start of segment.
@@ -2819,12 +2827,6 @@ export function extractMACHO(bytes, offset) {
         return dumpSegmentCommands(stream, loadCommandsOffset, isSwap, ncmds);
     }
 
-
-    const MHCIGAM64 = "207250237254";
-    const MHMAGIC64 = "254237250207";
-    const MHCIGAM = "206250237254";
-    const LCSEGEMENT64 = 0x19;
-    const LCSEGEMENT = 0x1;
 
     const stream = new Stream(bytes.slice(offset));
     const magic = stream.getBytes(4).join("");

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -1302,7 +1302,7 @@ export const FILE_SIGNATURES = {
                     5: 0x00,
                     6: 0x00,
                     7: 0x00,
-                    8: 0x03
+                    8: [0x01, 0x02, 0x03]
                 }
             ],
             extractor: extractMACHO

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -1282,17 +1282,25 @@ export const FILE_SIGNATURES = {
             extension: "dylib",
             mime: "application/octet-stream",
             description: "",
-            signature: {
-                0: 0xca,
-                1: 0xfe,
-                2: 0xba,
-                3: 0xbe,
-                4: 0x00,
-                5: 0x00,
-                6: 0x00,
-                7: [0x01, 0x02, 0x03]
-            },
-            extractor: null
+            signature: [
+                {
+                    0: 0xca,
+                    1: 0xfe,
+                    2: 0xba,
+                    3: 0xbe,
+                    4: 0x00,
+                    5: 0x00,
+                    6: 0x00,
+                    7: [0x01, 0x02, 0x03]
+                },
+                {
+                    0: 0xce,
+                    1: 0xfa,
+                    2: 0xed,
+                    3: 0xfe
+                }
+            ],
+            extractor: extractMACHO
         },
         {
             name: "MacOS Mach-O 64-bit object",
@@ -1305,7 +1313,7 @@ export const FILE_SIGNATURES = {
                 2: 0xed,
                 3: 0xfe
             },
-            extractor: null
+            extractor: extractMACHO
         },
         {
             name: "Adobe Flash",
@@ -1404,7 +1412,7 @@ export const FILE_SIGNATURES = {
                 260: 0x61,
                 261: 0x72
             },
-            extractor: null
+            extractor: extractTAR
         },
         {
             name: "Roshal Archive",
@@ -2716,6 +2724,149 @@ export function extractZIP(bytes, offset) {
     const commentLength = stream.readInt(2, "le");
     stream.moveForwardsBy(commentLength);
 
+    return stream.carve();
+}
+
+
+/**
+ * MACHO extractor
+ *
+ * @param {Uint8Array} bytes
+ * @param {number} offset
+ * @returns {Uint8Array}
+ */
+export function extractMACHO(bytes, offset) {
+
+
+    /**
+     * Checks to see if the file is 64-bit.
+     *
+     * @param {string} magic
+     * @returns {bool}
+     */
+    function isMagic64(magic) {
+        return magic === MHCIGAM64 || magic === MHCIGAM64;
+    }
+
+
+    /**
+     * Checks the endianness of the file.
+     *
+     * @param {string} magic
+     * @returns {bool}
+     */
+    function shouldSwapBytes(magic) {
+        return magic === MHCIGAM || magic === MHCIGAM64;
+    }
+
+
+    /**
+     * Jumps through segment information and calculates the sum of the segement sizes.
+     *
+     * @param {Stream} stream
+     * @param {number} offset
+     * @param {string} isSwap
+     * @param {number} ncmds
+     * @returns {number}
+     */
+    function dumpSegmentCommands(stream, offset, isSwap, ncmds) {
+        let total = 0;
+        for (let i = 0; i < ncmds; i++) {
+
+            // Move to start of segment.
+            stream.moveTo(offset);
+            const cmd = stream.readInt(4, isSwap);
+            if (cmd === LCSEGEMENT64) {
+
+                // Move to size of segment field.
+                stream.moveTo(offset + 48);
+
+                // Extract size of segement.
+                total += stream.readInt(8, isSwap);
+                stream.moveTo(offset + 4);
+
+                // Move to offset of next segment.
+                offset += stream.readInt(4, isSwap);
+            } else if (cmd === LCSEGEMENT) {
+                stream.moveTo(offset + 36);
+
+                // Extract size of segement.
+                total += stream.readInt(4, isSwap);
+                stream.moveTo(offset + 4);
+                offset += stream.readInt(4, isSwap);
+            }
+        }
+        return total;
+    }
+
+
+    /**
+     * Reads the number of command segments.
+     *
+     * @param {Stream} stream
+     * @param {bool} is64
+     * @param {string} isSwap
+     * @returns {number}
+     */
+    function dumpMachHeader(stream, is64, isSwap) {
+        let loadCommandsOffset = 28;
+        if (is64)
+            loadCommandsOffset += 4;
+
+        // Move to number of commands field.
+        stream.moveTo(16);
+        const ncmds = stream.readInt(4, isSwap);
+        return dumpSegmentCommands(stream, loadCommandsOffset, isSwap, ncmds);
+    }
+
+
+    const MHCIGAM64 = "207250237254";
+    const MHCIGAM = "206250237254";
+    const LCSEGEMENT64 = 0x19;
+    const LCSEGEMENT = 0x1;
+    const stream = new Stream(bytes.slice(offset));
+    const magic = stream.getBytes(4).join("");
+    const is64 = isMagic64(magic);
+    const isSwap = shouldSwapBytes(magic) ? "le" : "be";
+
+    // Move to the end of the final segment.
+    stream.moveTo(dumpMachHeader(stream, is64, isSwap));
+    return stream.carve();
+}
+
+
+/**
+ * TAR extractor.
+ *
+ * @param {Uint8Array} bytes
+ * @param {number} offset
+ * @returns {Uint8Array}
+ */
+export function extractTAR(bytes, offset) {
+    const stream = new Stream(bytes.slice(offset));
+    while (stream.hasMore()) {
+
+        // Move to ustar identifier.
+        stream.moveForwardsBy(0x101);
+        if (stream.getBytes(5).join("") !== [0x75, 0x73, 0x74, 0x61, 0x72].join(""))
+            break;
+
+        // Move back to file size field.
+        stream.moveBackwardsBy(0x8a);
+        let fsize = 0;
+
+        // Read file size field.
+        stream.getBytes(11).forEach((element, index) => {
+            fsize += (element - 48).toString();
+        });
+
+        // Round number up from octet to nearest 512.
+        fsize = (Math.ceil(parseInt(fsize, 8) / 512) * 512);
+
+        // Move forwards to the end of that file.
+        stream.moveForwardsBy(fsize + 0x179);
+    }
+    stream.consumeWhile(0x00);
     return stream.carve();
 }
 

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -2857,7 +2857,7 @@ export function extractTAR(bytes, offset) {
         stream.moveForwardsBy(0x101);
         if (stream.getBytes(5).join("") !== [0x75, 0x73, 0x74, 0x61, 0x72].join("")) {
 
-            // Needed since if it were not here it relies on there being at least 0x106 padding of 0s at the end of the TAR.
+            // Needed since we cannot rely on there being at least 0x106 padding of 0s at the end of the TAR(even though there usually is).
             stream.moveBackwardsBy(0x106);
             break;
         }

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -1297,7 +1297,12 @@ export const FILE_SIGNATURES = {
                     0: 0xce,
                     1: 0xfa,
                     2: 0xed,
-                    3: 0xfe
+                    3: 0xfe,
+                    4: 0x07,
+                    5: 0x00,
+                    6: 0x00,
+                    7: 0x00,
+                    8: 0x03
                 }
             ],
             extractor: extractMACHO
@@ -2850,8 +2855,12 @@ export function extractTAR(bytes, offset) {
 
         // Move to ustar identifier.
         stream.moveForwardsBy(0x101);
-        if (stream.getBytes(5).join("") !== [0x75, 0x73, 0x74, 0x61, 0x72].join(""))
+        if (stream.getBytes(5).join("") !== [0x75, 0x73, 0x74, 0x61, 0x72].join("")) {
+
+            // This is needed since if it were not here it relies on there being at least 0x106 padding of 0s at the end of the TAR
+            stream.moveBackwardsBy(0x101);
             break;
+        }
 
         // Move back to file size field.
         stream.moveBackwardsBy(0x8a);

--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -2857,7 +2857,7 @@ export function extractTAR(bytes, offset) {
         stream.moveForwardsBy(0x101);
         if (stream.getBytes(5).join("") !== [0x75, 0x73, 0x74, 0x61, 0x72].join("")) {
 
-            // This is needed since if it were not here it relies on there being at least 0x106 padding of 0s at the end of the TAR
+            // Needed since if it were not here it relies on there being at least 0x106 padding of 0s at the end of the TAR.
             stream.moveBackwardsBy(0x106);
             break;
         }

--- a/src/core/operations/ToCaseInsensitiveRegex.mjs
+++ b/src/core/operations/ToCaseInsensitiveRegex.mjs
@@ -53,32 +53,32 @@ class ToCaseInsensitiveRegex extends Operation {
         // Example: [test] -> [[tT][eE][sS][tT]]
         return preProcess(input)
 
-        // Example: [A-Z] -> [A-Za-z]
-        .replace(/[A-Z]-[A-Z]/ig, m => `${m[0].toUpperCase()}-${m[2].toUpperCase()}${m[0].toLowerCase()}-${m[2].toLowerCase()}`)
+            // Example: [A-Z] -> [A-Za-z]
+            .replace(/[A-Z]-[A-Z]/ig, m => `${m[0].toUpperCase()}-${m[2].toUpperCase()}${m[0].toLowerCase()}-${m[2].toLowerCase()}`)
 
-        // Example: [H-d] -> [A-DH-dh-z]
-        .replace(/[A-Z]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}${m[0].toLowerCase()}-z`)
+            // Example: [H-d] -> [A-DH-dh-z]
+            .replace(/[A-Z]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}${m[0].toLowerCase()}-z`)
 
-        // Example: [!-D] -> [!-Da-d]
-        .replace(/\\?[ -@]-[A-Z]/g, m => `${m}a-${m[2].toLowerCase()}`)
+            // Example: [!-D] -> [!-Da-d]
+            .replace(/\\?[ -@]-[A-Z]/g, m => `${m}a-${m[2].toLowerCase()}`)
 
-        // Example: [%-^] -> [%-^a-z]
-        .replace(/\\?[ -@]-\\?[[-`]/g, m => `${m}a-z`)
+            // Example: [%-^] -> [%-^a-z]
+            .replace(/\\?[ -@]-\\?[[-`]/g, m => `${m}a-z`)
 
-        // Example: [K-`] -> [K-`k-z]
-        .replace(/[A-Z]-\\?[[-`]/g, m => `${m}${m[0].toLowerCase()}-z`)
+            // Example: [K-`] -> [K-`k-z]
+            .replace(/[A-Z]-\\?[[-`]/g, m => `${m}${m[0].toLowerCase()}-z`)
 
-        // Example: [[-}] -> [[-}A-Z]
-        .replace(/\\?[[-`]-\\?[{-~]/g, m => `${m}A-Z`)
+            // Example: [[-}] -> [[-}A-Z]
+            .replace(/\\?[[-`]-\\?[{-~]/g, m => `${m}A-Z`)
 
-        // Example: [b-}] -> [b-}B-Z]
-        .replace(/[a-z]-\\?[{-~]/g, m => `${m}${m[0].toUpperCase()}-Z`)
+            // Example: [b-}] -> [b-}B-Z]
+            .replace(/[a-z]-\\?[{-~]/g, m => `${m}${m[0].toUpperCase()}-Z`)
 
-        // Example: [<-j] -> [<-z]
-        .replace(/\\?[ -@]-[a-z]/g, m => `${m[0]}-z`)
+            // Example: [<-j] -> [<-z]
+            .replace(/\\?[ -@]-[a-z]/g, m => `${m[0]}-z`)
 
-        // Example: [^-j] -> [A-J^-j]
-        .replace(/\\?[[-`]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}`);
+            // Example: [^-j] -> [A-J^-j]
+            .replace(/\\?[[-`]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}`);
 
     }
 }

--- a/src/core/operations/ToCaseInsensitiveRegex.mjs
+++ b/src/core/operations/ToCaseInsensitiveRegex.mjs
@@ -50,37 +50,36 @@ class ToCaseInsensitiveRegex extends Operation {
             return result;
         }
 
+        // Example: [test] -> [[tT][eE][sS][tT]]
         input = preProcess(input);
 
-        // Example: [a-z] -> [a-zA-Z]
-        input = input.replace(/[a-z]-[a-z]/g, m => `${m}${m[0].toUpperCase()}-${m[2].toUpperCase()}`);
-
-        // Example: [a-z] -> [a-zA-Z]
-        input = input.replace(/[A-Z]-[A-Z]/g, m => `${m}${m[0].toLowerCase()}-${m[2].toLowerCase()}`);
+        // Example: [A-Z] -> [A-Za-z]
+        input = input.replace(/[A-Z]-[A-Z]/ig, m => `${m[0].toUpperCase()}-${m[2].toUpperCase()}${m[0].toLowerCase()}-${m[2].toLowerCase()}`);
 
         // Example: [H-d] -> [A-DH-dh-z]
         input = input.replace(/[A-Z]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}${m[0].toLowerCase()}-z`);
 
         // Example: [!-D] -> [!-Da-d]
-        input = input.replace(/[ -@]-[A-Z]/g, m => `${m}a-${m[2].toLowerCase()}`);
+        input = input.replace(/\\?[ -@]-[A-Z]/g, m => `${m}a-${m[2].toLowerCase()}`);
 
         // Example: [%-^] -> [%-^a-z]
-        input = input.replace(/[ -@]-[[-`]/g, m => `${m}a-z`);
+        input = input.replace(/\\?[ -@]-\\?[[-`]/g, m => `${m}a-z`);
 
         // Example: [K-`] -> [K-`k-z]
-        input = input.replace(/[A-Z]-[[-`]/g, m => `${m}${m[0].toLowerCase()}-z`);
+        input = input.replace(/[A-Z]-\\?[[-`]/g, m => `${m}${m[0].toLowerCase()}-z`);
 
         // Example: [[-}] -> [[-}A-Z]
-        input = input.replace(/[[-`]-[{-~]/g, m => `${m}A-Z`);
+        input = input.replace(/\\?[[-`]-\\?[{-~]/g, m => `${m}A-Z`);
 
         // Example: [b-}] -> [b-}B-Z]
-        input = input.replace(/[a-z]-[{-~]/g, m => `${m}${m[0].toUpperCase()}-Z`);
+        input = input.replace(/[a-z]-\\?[{-~]/g, m => `${m}${m[0].toUpperCase()}-Z`);
 
         // Example: [<-j] -> [<-z]
-        input = input.replace(/[ -@]-[a-z]/g, m => `${m[0]}-z`);
+        input = input.replace(/\\?[ -@]-[a-z]/g, m => `${m[0]}-z`);
 
         // Example: [^-j] -> [A-J^-j]
-        input = input.replace(/[[-`]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}`);
+        input = input.replace(/\\?[[-`]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}`);
+
         return input;
     }
 }

--- a/src/core/operations/ToCaseInsensitiveRegex.mjs
+++ b/src/core/operations/ToCaseInsensitiveRegex.mjs
@@ -51,11 +51,17 @@ class ToCaseInsensitiveRegex extends Operation {
             return result;
         }
 
+        try {
+            RegExp(input);
+        } catch (error) {
+            return "Invalid Regular Expression (Please note this version of node does not support look behinds).";
+        }
+
         // Example: [test] -> [[tT][eE][sS][tT]]
         return preProcess(input)
 
             // Example: [A-Z] -> [A-Za-z]
-            .replace(/[A-Z]-[A-Z]/ig, m => `${m[0].toUpperCase()}-${m[2].toUpperCase()}${m[0].toLowerCase()}-${m[2].toLowerCase()}`)
+            .replace(/([A-Z]-[A-Z]|[a-z]-[a-z])/g, m => `${m[0].toUpperCase()}-${m[2].toUpperCase()}${m[0].toLowerCase()}-${m[2].toLowerCase()}`)
 
             // Example: [H-d] -> [A-DH-dh-z]
             .replace(/[A-Z]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}${m[0].toLowerCase()}-z`)

--- a/src/core/operations/ToCaseInsensitiveRegex.mjs
+++ b/src/core/operations/ToCaseInsensitiveRegex.mjs
@@ -32,6 +32,7 @@ class ToCaseInsensitiveRegex extends Operation {
      * @returns {string}
      */
     run(input, args) {
+
         /**
          * Simulates look behind behaviour since javascript doesn't support it.
          *

--- a/src/core/operations/ToCaseInsensitiveRegex.mjs
+++ b/src/core/operations/ToCaseInsensitiveRegex.mjs
@@ -54,31 +54,31 @@ class ToCaseInsensitiveRegex extends Operation {
 
         // Example: [a-z] -> [a-zA-Z]
         input = input.replace(/[a-z]-[a-z]/g, m => `${m}${m[0].toUpperCase()}-${m[2].toUpperCase()}`);
-        
+
         // Example: [a-z] -> [a-zA-Z]
         input = input.replace(/[A-Z]-[A-Z]/g, m => `${m}${m[0].toLowerCase()}-${m[2].toLowerCase()}`);
-        
+
         // Example: [H-d] -> [A-DH-dh-z]
         input = input.replace(/[A-Z]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}${m[0].toLowerCase()}-z`);
-        
+
         // Example: [!-D] -> [!-Da-d]
         input = input.replace(/[ -@]-[A-Z]/g, m => `${m}a-${m[2].toLowerCase()}`);
-        
+
         // Example: [%-^] -> [%-^a-z]
         input = input.replace(/[ -@]-[[-`]/g, m => `${m}a-z`);
-        
+
         // Example: [K-`] -> [K-`k-z]
         input = input.replace(/[A-Z]-[[-`]/g, m => `${m}${m[0].toLowerCase()}-z`);
-        
+
         // Example: [[-}] -> [[-}A-Z]
         input = input.replace(/[[-`]-[{-~]/g, m => `${m}A-Z`);
-        
+
         // Example: [b-}] -> [b-}B-Z]
         input = input.replace(/[a-z]-[{-~]/g, m => `${m}${m[0].toUpperCase()}-Z`);
-        
+
         // Example: [<-j] -> [<-z]
         input = input.replace(/[ -@]-[a-z]/g, m => `${m[0]}-z`);
-        
+
         // Example: [^-j] -> [A-J^-j]
         input = input.replace(/[[-`]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}`);
         return input;

--- a/src/core/operations/ToCaseInsensitiveRegex.mjs
+++ b/src/core/operations/ToCaseInsensitiveRegex.mjs
@@ -32,7 +32,56 @@ class ToCaseInsensitiveRegex extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        return input.replace(/[a-z]/ig, m => `[${m.toLowerCase()}${m.toUpperCase()}]`);
+        /**
+         * Simulates look behind behaviour since javascript doesn't support it.
+         *
+         * @param {string} input
+         * @returns {string}
+         */
+        function preProcess(input) {
+            let result = "";
+            for (let i = 0; i < input.length; i++) {
+                const temp = input.charAt(i);
+                if (temp.match(/[a-zA-Z]/g) && (input.charAt(i-1) !== "-") && (input.charAt(i+1) !== "-"))
+                    result += "[" + temp.toLowerCase() + temp.toUpperCase() + "]";
+                else
+                    result += temp;
+            }
+            return result;
+        }
+
+        input = preProcess(input);
+
+        // Example: [a-z] -> [a-zA-Z]
+        input = input.replace(/[a-z]-[a-z]/g, m => `${m}${m[0].toUpperCase()}-${m[2].toUpperCase()}`);
+        
+        // Example: [a-z] -> [a-zA-Z]
+        input = input.replace(/[A-Z]-[A-Z]/g, m => `${m}${m[0].toLowerCase()}-${m[2].toLowerCase()}`);
+        
+        // Example: [H-d] -> [A-DH-dh-z]
+        input = input.replace(/[A-Z]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}${m[0].toLowerCase()}-z`);
+        
+        // Example: [!-D] -> [!-Da-d]
+        input = input.replace(/[ -@]-[A-Z]/g, m => `${m}a-${m[2].toLowerCase()}`);
+        
+        // Example: [%-^] -> [%-^a-z]
+        input = input.replace(/[ -@]-[[-`]/g, m => `${m}a-z`);
+        
+        // Example: [K-`] -> [K-`k-z]
+        input = input.replace(/[A-Z]-[[-`]/g, m => `${m}${m[0].toLowerCase()}-z`);
+        
+        // Example: [[-}] -> [[-}A-Z]
+        input = input.replace(/[[-`]-[{-~]/g, m => `${m}A-Z`);
+        
+        // Example: [b-}] -> [b-}B-Z]
+        input = input.replace(/[a-z]-[{-~]/g, m => `${m}${m[0].toUpperCase()}-Z`);
+        
+        // Example: [<-j] -> [<-z]
+        input = input.replace(/[ -@]-[a-z]/g, m => `${m[0]}-z`);
+        
+        // Example: [^-j] -> [A-J^-j]
+        input = input.replace(/[[-`]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}`);
+        return input;
     }
 }
 

--- a/src/core/operations/ToCaseInsensitiveRegex.mjs
+++ b/src/core/operations/ToCaseInsensitiveRegex.mjs
@@ -51,36 +51,35 @@ class ToCaseInsensitiveRegex extends Operation {
         }
 
         // Example: [test] -> [[tT][eE][sS][tT]]
-        input = preProcess(input);
+        return preProcess(input)
 
         // Example: [A-Z] -> [A-Za-z]
-        input = input.replace(/[A-Z]-[A-Z]/ig, m => `${m[0].toUpperCase()}-${m[2].toUpperCase()}${m[0].toLowerCase()}-${m[2].toLowerCase()}`);
+        .replace(/[A-Z]-[A-Z]/ig, m => `${m[0].toUpperCase()}-${m[2].toUpperCase()}${m[0].toLowerCase()}-${m[2].toLowerCase()}`)
 
         // Example: [H-d] -> [A-DH-dh-z]
-        input = input.replace(/[A-Z]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}${m[0].toLowerCase()}-z`);
+        .replace(/[A-Z]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}${m[0].toLowerCase()}-z`)
 
         // Example: [!-D] -> [!-Da-d]
-        input = input.replace(/\\?[ -@]-[A-Z]/g, m => `${m}a-${m[2].toLowerCase()}`);
+        .replace(/\\?[ -@]-[A-Z]/g, m => `${m}a-${m[2].toLowerCase()}`)
 
         // Example: [%-^] -> [%-^a-z]
-        input = input.replace(/\\?[ -@]-\\?[[-`]/g, m => `${m}a-z`);
+        .replace(/\\?[ -@]-\\?[[-`]/g, m => `${m}a-z`)
 
         // Example: [K-`] -> [K-`k-z]
-        input = input.replace(/[A-Z]-\\?[[-`]/g, m => `${m}${m[0].toLowerCase()}-z`);
+        .replace(/[A-Z]-\\?[[-`]/g, m => `${m}${m[0].toLowerCase()}-z`)
 
         // Example: [[-}] -> [[-}A-Z]
-        input = input.replace(/\\?[[-`]-\\?[{-~]/g, m => `${m}A-Z`);
+        .replace(/\\?[[-`]-\\?[{-~]/g, m => `${m}A-Z`)
 
         // Example: [b-}] -> [b-}B-Z]
-        input = input.replace(/[a-z]-\\?[{-~]/g, m => `${m}${m[0].toUpperCase()}-Z`);
+        .replace(/[a-z]-\\?[{-~]/g, m => `${m}${m[0].toUpperCase()}-Z`)
 
         // Example: [<-j] -> [<-z]
-        input = input.replace(/\\?[ -@]-[a-z]/g, m => `${m[0]}-z`);
+        .replace(/\\?[ -@]-[a-z]/g, m => `${m[0]}-z`)
 
         // Example: [^-j] -> [A-J^-j]
-        input = input.replace(/\\?[[-`]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}`);
+        .replace(/\\?[[-`]-[a-z]/g, m => `A-${m[2].toUpperCase()}${m}`);
 
-        return input;
     }
 }
 

--- a/tests/operations/tests/ToFromInsensitiveRegex.mjs
+++ b/tests/operations/tests/ToFromInsensitiveRegex.mjs
@@ -184,5 +184,5 @@ TestRegister.addTests([
                 args: [],
             },
         ],
-    },
+    }
 ]);

--- a/tests/operations/tests/ToFromInsensitiveRegex.mjs
+++ b/tests/operations/tests/ToFromInsensitiveRegex.mjs
@@ -53,4 +53,136 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "To Case Insensitive Regex: [A-Z] -> [A-Za-z]",
+        input: "[A-Z]",
+        expectedOutput: "[A-Za-z]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [a-z] -> [A-Za-z]",
+        input: "[a-z]",
+        expectedOutput: "[A-Za-z]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [H-d] -> [A-DH-dh-z]",
+        input: "[H-d]",
+        expectedOutput: "[A-DH-dh-z]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [!-D] -> [!-Da-d]",
+        input: "[!-D]",
+        expectedOutput: "[!-Da-d]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [%-^] -> [%-^a-z]",
+        input: "[%-^]",
+        expectedOutput: "[%-^a-z]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [K-`] -> [K-`k-z]",
+        input: "[K-`]",
+        expectedOutput: "[K-`k-z]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [[-}] -> [[-}A-Z]",
+        input: "[[-}]",
+        expectedOutput: "[[-}A-Z]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [b-}] -> [b-}B-Z]",
+        input: "[b-}]",
+        expectedOutput: "[b-}B-Z]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [<-j] -> [<-z]",
+        input: "[<-j]",
+        expectedOutput: "[<-z]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: [^-j] -> [A-J^-j]",
+        input: "[^-j]",
+        expectedOutput: "[A-J^-j]",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: not simple test",
+        input: "Mozilla[A-Z0-9]+[A-Z]Mozilla[0-9whatA-Z][H-d][!-H][a-~](.)+",
+        expectedOutput: "[mM][oO][zZ][iI][lL][lL][aA][A-Za-z0-9]+[A-Za-z][mM][oO][zZ][iI][lL][lL][aA][0-9[wW][hH][aA][tT]A-Za-z][A-DH-dh-z][!-Ha-h][a-~A-Z](.)+",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "To Case Insensitive Regex: erroneous test",
+        input: "Mozilla[A-Z",
+        expectedOutput: "Invalid Regular Expression (Please note this version of node does not support look behinds).",
+        recipeConfig: [
+            {
+                op: "To Case Insensitive Regex",
+                args: [],
+            },
+        ],
+    },
 ]);


### PR DESCRIPTION
Originally the ToCaseInsensitiveRegex operation on input [A-Z] would produce [[aA]-[zZ]] which is not the correct result.
I have added a few more rules and modified the original rule to allow this input and more.