### PR TITLE
Remember text highlighting and restore on tab switch

### DIFF
--- a/src/web/waiters/HighlighterWaiter.mjs
+++ b/src/web/waiters/HighlighterWaiter.mjs
@@ -302,6 +302,13 @@ class HighlighterWaiter {
         }
     }
 
+    /**
+     * Resets mouse variable to up position.
+     * Used on tab change.
+     */
+    mouseUp(){
+        this.mouseButtonDown = false;
+    }
 
     /**
      * Given start and end offsets, writes the HTML for the selection info element with the correct
@@ -376,9 +383,10 @@ class HighlighterWaiter {
      * @param {string} direction
      */
     displayHighlights(pos, direction) {
-        if (!pos) return;
+        if (!pos || pos.length === 0) return;
 
-        if (this.manager.tabs.getActiveInputTab() !== this.manager.tabs.getActiveOutputTab()) return;
+        const inputNum = this.manager.tabs.getActiveInputTab();
+        if (inputNum !== this.manager.tabs.getActiveOutputTab()) return;
 
         const io = direction === "forward" ? "output" : "input";
 
@@ -387,6 +395,13 @@ class HighlighterWaiter {
             document.getElementById(io + "-text"),
             document.getElementById(io + "-highlighter"),
             pos);
+
+        if (direction === "forward"){
+            this.highlightInput(pos);
+        }
+        else{
+            this.manager.input.updateInputHighlight(inputNum, pos)
+        }
     }
 
 

--- a/src/web/waiters/HighlighterWaiter.mjs
+++ b/src/web/waiters/HighlighterWaiter.mjs
@@ -306,7 +306,7 @@ class HighlighterWaiter {
      * Resets mouse variable to up position.
      * Used on tab change.
      */
-    mouseUp(){
+    mouseUp() {
         this.mouseButtonDown = false;
     }
 
@@ -396,11 +396,10 @@ class HighlighterWaiter {
             document.getElementById(io + "-highlighter"),
             pos);
 
-        if (direction === "forward"){
+        if (direction === "forward") {
             this.highlightInput(pos);
-        }
-        else{
-            this.manager.input.updateInputHighlight(inputNum, pos)
+        } else {
+            this.manager.input.updateInputHighlight(inputNum, pos);
         }
     }
 

--- a/src/web/waiters/InputWaiter.mjs
+++ b/src/web/waiters/InputWaiter.mjs
@@ -373,7 +373,7 @@ class InputWaiter {
                     });
                 }
 
-                //Restore highlighting
+                // Restore highlighting
                 this.updateInputHighlight(inputData.inputNum, inputData.pos);
                 this.restoreHighlighting();
 

--- a/src/web/waiters/OutputWaiter.mjs
+++ b/src/web/waiters/OutputWaiter.mjs
@@ -1292,6 +1292,7 @@ class OutputWaiter {
     inputSwitch(switchData) {
         this.switchOrigData = switchData;
         document.getElementById("undo-switch").disabled = false;
+        this.manager.highlighter.removeHighlights();
 
         this.resetSwitchButton();
 

--- a/src/web/workers/InputWorker.mjs
+++ b/src/web/workers/InputWorker.mjs
@@ -53,6 +53,9 @@ self.addEventListener("message", function(e) {
         case "updateInputValue":
             self.updateInputValue(r.data);
             break;
+        case "updateInputHighlight":
+            self.updateInputHighlight(r.data);
+            break;
         case "updateInputObj":
             self.updateInputObj(r.data);
             break;
@@ -451,9 +454,11 @@ self.setInput = function(inputData) {
     if (input === undefined || input === null) return;
 
     let inputVal = input.data;
+    let highlight = input.highlight;
     const inputObj = {
         inputNum: inputNum,
-        input: inputVal
+        input: inputVal,
+        pos: highlight
     };
     if (typeof inputVal !== "string") {
         inputObj.name = inputVal.name;
@@ -553,7 +558,7 @@ self.updateInputValue = function(inputData) {
     const inputNum = inputData.inputNum;
     if (inputNum < 1) return;
     if (Object.prototype.hasOwnProperty.call(self.inputs[inputNum].data, "fileBuffer") &&
-    typeof inputData.value === "string" && !inputData.force) return;
+        typeof inputData.value === "string" && !inputData.force) return;
     const value = inputData.value;
     if (self.inputs[inputNum] !== undefined) {
         if (typeof value === "string") {
@@ -578,6 +583,21 @@ self.updateInputValue = function(inputData) {
         });
     }
 };
+
+/**
+ * Update the stored highlight object of an input.
+ *
+ * @param {object} inputData
+ * @param {number} inputData.inputNum - The input that's having its value updated
+ * @param {Object} inputData.pos - The position object for the highlight.
+ */
+self.updateInputHighlight = function(inputData) {
+    const inputNum = inputData.inputNum;
+    const pos = inputData.pos;
+
+    if (inputNum < 1) return;
+    self.inputs[inputNum].highlight = pos;
+}
 
 /**
  * Update the stored data object for an input.
@@ -825,6 +845,7 @@ self.addInput = function(
             newInputObj.data = "";
             newInputObj.status = "loaded";
             newInputObj.progress = 100;
+            newInputObj.highlight = [{"start":0,"end":0}];
             break;
         case "file":
             newInputObj.data = {

--- a/src/web/workers/InputWorker.mjs
+++ b/src/web/workers/InputWorker.mjs
@@ -454,7 +454,7 @@ self.setInput = function(inputData) {
     if (input === undefined || input === null) return;
 
     let inputVal = input.data;
-    let highlight = input.highlight;
+    const highlight = input.highlight;
     const inputObj = {
         inputNum: inputNum,
         input: inputVal,
@@ -597,7 +597,7 @@ self.updateInputHighlight = function(inputData) {
 
     if (inputNum < 1) return;
     self.inputs[inputNum].highlight = pos;
-}
+};
 
 /**
  * Update the stored data object for an input.
@@ -845,7 +845,7 @@ self.addInput = function(
             newInputObj.data = "";
             newInputObj.status = "loaded";
             newInputObj.progress = 100;
-            newInputObj.highlight = [{"start":0,"end":0}];
+            newInputObj.highlight = [{"start": 0, "end": 0}];
             break;
         case "file":
             newInputObj.data = {


### PR DESCRIPTION
closes #874 

**Overview of new feature:**
- Highlight positioning for the input is now stored in the input tab objects (an addition to data, status, and progress)
- When output text is highlighted, the result is sent back through the highlight chain in order to keep the corresponding input text highlighted as well (convenient even without multiple tabs!)
- Upon changing tabs, previous highlighting for both the input and output texts will be looked up and restored

**Notes:**
- I found an issue in the original CyberChef in which if you select text and then unclick, a mouseDown event is immediately triggered after the mouseUp event. This causes the program to think the mouse is constantly down, and results in the program silently running through the highlight chain of commands on every Mousemove event (i.e. making a very large number of unnecessary calls that don't actually do anything). I added the `mouseUp` function and call in on tab change so that this bug stops once you've changed tabs at least once (was necessary to quick fix this issue for my feature to work). However, the bug does persist if you never change tabs, and should be looked into.
- Output highlighting may be misaligned upon recipe change with autobake on. Clicking the input clears this, or switching to a different tab and then back again fixes it. Note that this issue is semi-present in the current CyberChef build
- Retaining highlights does not work in the Edge browser (no errors at least though). However, there exist other issues with the Edge browser in the current CyberChef, so this shouldn't be an issue. And the new highlighting of both input and output at least works
  
<BR><BR>

If there are any issues or further desires, feel free to request a change