### PR TITLE
Fixed typo in IPV6 alphabet

### DIFF
--- a/src/core/lib/Base85.mjs
+++ b/src/core/lib/Base85.mjs
@@ -20,7 +20,7 @@ export const ALPHABET_OPTIONS = [
     },
     {
         name: "IPv6",
-        value: "0-9A-Za-z!#$%&()*+\\-;<=>?@^_`{|~}",
+        value: "0-9A-Za-z!#$%&()*+\\-;<=>?@^_`{|}~",
     }
 ];
 


### PR DESCRIPTION
According to python3 base64.b85decode module https://github.com/python/cpython/blob/3.8/Lib/base64.py