### PR TITLE
Fix output highlighting for non-classic themes

### DIFF
--- a/src/web/stylesheets/layout/_io.css
+++ b/src/web/stylesheets/layout/_io.css
@@ -211,7 +211,7 @@
     letter-spacing: normal;
     white-space: pre-wrap;
     word-wrap: break-word;
-    color: #fff;
+    color: transparent;
     background-color: transparent;
     border: none;
     pointer-events: none;


### PR DESCRIPTION
The text highlighting has some problems with themes other than the classic one. There are two overlapping texts and the result is illegible. 
![imagen](https://user-images.githubusercontent.com/50824094/69527229-2af7f800-0f6c-11ea-9aaa-f4edc3fe2ce8.png)
