### PR TITLE
DNS over HTTP: Fix "validate" argument

### DIFF
--- a/src/core/operations/DNSOverHTTPS.mjs
+++ b/src/core/operations/DNSOverHTTPS.mjs
@@ -63,9 +63,9 @@ class DNSOverHTTPS extends Operation {
                 value: false
             },
             {
-                name: "Validate DNSSEC",
+                name: "Disable DNSSEC validation",
                 type: "boolean",
-                value: true
+                value: false
             }
         ];
     }


### PR DESCRIPTION
This argument sets the "cd" parameter on the request.
For both included providers, this flag disables validation ([1], [2]), so doing the exact opposite of the described action.

This changes the label to the correct name and also flips the default value to keep the old behavior.

[1] Google <https://developers.google.com/speed/public-dns/docs/doh/json#supported_parameters>
[2] Cloudflare <https://developers.cloudflare.com/1.1.1.1/dns-over-https/json-format/>