### PR TITLE
Improve RTF detection

### DIFF
--- a/src/core/lib/FileSignatures.mjs
+++ b/src/core/lib/FileSignatures.mjs
@@ -1008,8 +1008,7 @@ export const FILE_SIGNATURES = {
                 0: 0x7b,
                 1: 0x5c,
                 2: 0x72,
-                3: 0x74,
-                4: 0x66
+                3: 0x74
             },
             extractor: extractRTF
         },


### PR DESCRIPTION
Certain RTF files may attempt to thwart detection by having a malformed RTF header, such as **{\rt000**. Removing 0x66 will result in detecting these malformed yet valid RTFs as well.

Additional reading:
https://www.decalage.info/rtf_tricks#Trick_1:_Incomplete_RTF_Header