### PR TITLE
Allow variable key sizes for Blowfish

### DIFF
--- a/src/core/operations/BlowfishDecrypt.mjs
+++ b/src/core/operations/BlowfishDecrypt.mjs
@@ -70,10 +70,14 @@ class BlowfishDecrypt extends Operation {
             inputType = args[3],
             outputType = args[4];
 
-        if (key.length !== 8) {
+        if (key.length < 4 || key.length > 56) {
             throw new OperationError(`Invalid key length: ${key.length} bytes
 
-Blowfish uses a key length of 8 bytes (64 bits).`);
+Blowfish's key length needs to between 4 and 56 bytes (32-448 bits).`);
+        }
+
+        if (iv.length !== 8) {
+            throw new OperationError(`Invalid IV length: ${iv.length} bytes. Expected 8 bytes`);
         }
 
         input = Utils.convertToByteString(input, inputType);

--- a/src/core/operations/BlowfishDecrypt.mjs
+++ b/src/core/operations/BlowfishDecrypt.mjs
@@ -73,7 +73,7 @@ class BlowfishDecrypt extends Operation {
         if (key.length < 4 || key.length > 56) {
             throw new OperationError(`Invalid key length: ${key.length} bytes
 
-Blowfish's key length needs to between 4 and 56 bytes (32-448 bits).`);
+Blowfish's key length needs to be between 4 and 56 bytes (32-448 bits).`);
         }
 
         if (iv.length !== 8) {

--- a/src/core/operations/BlowfishEncrypt.mjs
+++ b/src/core/operations/BlowfishEncrypt.mjs
@@ -73,7 +73,7 @@ class BlowfishEncrypt extends Operation {
         if (key.length < 4 || key.length > 56) {
             throw new OperationError(`Invalid key length: ${key.length} bytes
     
-Blowfish's key length needs to between 4 and 56 bytes (32-448 bits).`);
+Blowfish's key length needs to be between 4 and 56 bytes (32-448 bits).`);
         }
 
         if (iv.length !== 8) {

--- a/src/core/operations/BlowfishEncrypt.mjs
+++ b/src/core/operations/BlowfishEncrypt.mjs
@@ -70,10 +70,14 @@ class BlowfishEncrypt extends Operation {
             inputType = args[3],
             outputType = args[4];
 
-        if (key.length !== 8) {
+        if (key.length < 4 || key.length > 56) {
             throw new OperationError(`Invalid key length: ${key.length} bytes
+    
+Blowfish's key length needs to between 4 and 56 bytes (32-448 bits).`);
+        }
 
-Blowfish uses a key length of 8 bytes (64 bits).`);
+        if (iv.length !== 8) {
+            throw new OperationError(`Invalid IV length: ${iv.length} bytes. Expected 8 bytes`);
         }
 
         input = Utils.convertToByteString(input, inputType);

--- a/tests/operations/tests/Crypt.mjs
+++ b/tests/operations/tests/Crypt.mjs
@@ -1751,4 +1751,38 @@ DES uses a key length of 8 bytes (64 bits).`,
             }
         ],
     },
+    {
+        name: "Blowfish Encrypt with variable key length: CBC, ASCII, 4 bytes",
+        input: "The quick brown fox jumps over the lazy dog.",
+        expectedOutput: "823f337a53ecf121aa9ec1b111bd5064d1d7586abbdaaa0c8fd0c6cc43c831c88bf088ee3e07287e3f36cf2e45f9c7e6",
+        recipeConfig: [
+            {
+                "op": "Blowfish Encrypt",
+                "args": [
+                    {"option": "Hex", "string": "00112233"}, // Key
+                    {"option": "Hex", "string": "0000000000000000"}, // IV
+                    "CBC", // Mode
+                    "Raw", // Input
+                    "Hex" // Output
+                ]
+            }
+        ],
+    },
+    {
+        name: "Blowfish Encrypt with variable key length: CBC, ASCII, 42 bytes",
+        input: "The quick brown fox jumps over the lazy dog.",
+        expectedOutput: "19f5a68145b34321cfba72226b0f33922ce44dd6e7869fe328db64faae156471216f12ed2a37fd0bdd7cebf867b3cff0",
+        recipeConfig: [
+            {
+                "op": "Blowfish Encrypt",
+                "args": [
+                    {"option": "Hex", "string": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"}, // Key
+                    {"option": "Hex", "string": "0000000000000000"}, // IV
+                    "CBC", // Mode
+                    "Raw", // Input
+                    "Hex" // Output
+                ]
+            }
+        ],
+    }
 ]);


### PR DESCRIPTION
This fixes https://github.com/gchq/CyberChef/issues/930 by correcting the key size validation. Tests have also been added for key sizes other than 8 bytes. 