### PR TITLE
Allow custom ports for Grunt dev task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -219,6 +219,7 @@ module.exports = function (grunt) {
             options: {
                 webpack: webpackConfig,
                 host: "0.0.0.0",
+                port: grunt.option("port") || 8080,
                 disableHostCheck: true,
                 overlay: true,
                 inline: false,
@@ -275,7 +276,7 @@ module.exports = function (grunt) {
         connect: {
             prod: {
                 options: {
-                    port: 8000,
+                    port: grunt.option("port") || 8000,
                     base: "build/prod/"
                 }
             }


### PR DESCRIPTION
Currently there is no way to run CyberChef on a custom port, i.e. other than 8000/8080. This change allows you to specify `--port=1234` when running `grunt dev` or `npm run start -- --port=1234`.

Source: https://github.com/gruntjs/grunt/issues/534