### PR TITLE
Grunt npm tests changed to npm test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
         ]);
 
     grunt.registerTask("configTests",
-        "A task which configures config files in preparation for tests to be run. Use `npm tests` to run tests.",
+        "A task which configures config files in preparation for tests to be run. Use `npm test` to run tests.",
         [
             "clean:config", "clean:nodeConfig", "exec:generateConfig", "exec:generateNodeIndex"
         ]);


### PR DESCRIPTION
This threw me off for a few minutes. The Gruntfile says `npm tests` will run the tests but it is actually implemented as `npm test`.