### PR TITLE
Add ObjectId timestamp parser operation

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -247,7 +247,8 @@
             "Escape string",
             "Unescape string",
             "Pseudo-Random Number Generator",
-            "Sleep"
+            "Sleep",
+            "Parse ObjectId timestamp"
         ]
     },
     {

--- a/src/core/operations/ParseObjectIdTimestamp.mjs
+++ b/src/core/operations/ParseObjectIdTimestamp.mjs
@@ -1,0 +1,47 @@
+/**
+ * @author dmfj [dominic@dmfj.io]
+ * @copyright Crown Copyright 2020
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import BSON from "bson";
+
+/**
+ * Parse ObjectId timestamp operation
+ */
+class ParseObjectIdTimestamp extends Operation {
+
+    /**
+     * ParseObjectIdTimestamp constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Parse ObjectId timestamp";
+        this.module = "Default";
+        this.description = "Parse timestamp from MongoDB/BSON ObjectId hex string.";
+        this.infoURL = "https://docs.mongodb.com/manual/reference/method/ObjectId.getTimestamp/";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        try {
+            const objectId = new BSON.ObjectID(input);
+            return objectId.getTimestamp().toISOString();
+        } catch (err) {
+            throw new OperationError(err);
+        }
+    }
+
+}
+
+export default ParseObjectIdTimestamp;

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -100,6 +100,7 @@ import "./tests/Lorenz.mjs";
 import "./tests/LuhnChecksum.mjs";
 import "./tests/CipherSaber2.mjs";
 import "./tests/Colossus.mjs";
+import "./tests/ParseObjectIdTimestamp.mjs";
 
 
 // Cannot test operations that use the File type yet
@@ -120,4 +121,3 @@ const logOpsTestReport = logTestReport.bind(null, testStatus);
     const results = await TestRegister.runTests();
     logOpsTestReport(results);
 })();
-

--- a/tests/operations/tests/ParseObjectIdTimestamp.mjs
+++ b/tests/operations/tests/ParseObjectIdTimestamp.mjs
@@ -1,0 +1,24 @@
+/**
+ * Parse ObjectId timestamp tests
+ *
+ * @author dmfj [dominic@dmfj.io]
+ *
+ * @copyright Crown Copyright 2018
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+
+TestRegister.addTests([
+    {
+        name: "Parse ISO timestamp from ObjectId",
+        input: "000000000000000000000000",
+        expectedOutput: "1970-01-01T00:00:00.000Z",
+        recipeConfig: [
+            {
+                op: "Parse ObjectId timestamp",
+                args: [],
+            }
+        ],
+    }
+]);


### PR DESCRIPTION
This PR adds a new operation to parse the timestamp from [MongoDB ObjectId](https://docs.mongodb.com/manual/reference/method/ObjectId/) hex strings.