### PR TITLE
Extract bits

### DIFF
--- a/src/core/lib/FileType.mjs
+++ b/src/core/lib/FileType.mjs
@@ -44,6 +44,7 @@ function signatureMatches(sig, buf, offset=0) {
  * @param {Uint8Array} buf
  * @param {number} offset
  * @param {number} bitOffset
+ * @returns {boolean}
  */
 function bitsMatch(sig, buf, offset, bitOffset) {
 

--- a/src/core/operations/ScanForEmbeddedFiles.mjs
+++ b/src/core/operations/ScanForEmbeddedFiles.mjs
@@ -32,7 +32,11 @@ class ScanForEmbeddedFiles extends Operation {
                 type: "boolean",
                 value: cat === "Miscellaneous" ? false : true
             };
-        });
+        }).concat([{
+            name: "Scan for Offset Files",
+            type: "boolean",
+            value: false
+        }]);
     }
 
     /**
@@ -46,16 +50,19 @@ class ScanForEmbeddedFiles extends Operation {
         const categories = [],
             data = new Uint8Array(input);
 
+        const scanForBits = args.pop();
+
         args.forEach((cat, i) => {
             if (cat) categories.push(Object.keys(FILE_SIGNATURES)[i]);
         });
 
-        const types = scanForFileTypes(data, categories);
+        const types = scanForFileTypes(data, scanForBits, categories);
 
         if (types.length) {
             types.forEach(type => {
                 numFound++;
                 output += `\nOffset ${type.offset} (0x${Utils.hex(type.offset)}):
+  BitOffset:   ${type.bitOffset}
   File type:   ${type.fileDetails.name}
   Extension:   ${type.fileDetails.extension}
   MIME type:   ${type.fileDetails.mime}\n`;


### PR DESCRIPTION
An argument added to Extract Files/Scan For Embedded Files. 
These Scanners/Extractors operate on the byte level currently.
Scan for embedded files fails to detect magic bytes if they are offset by even 1 bit.
Extract Files relies on the scanForFileTypes function.
In this PR I have modified the function to have a flag that enables it to scan on the bit level as well as on the byte level. Meaning that even if the Magic Bytes are offset they will still be detected and then hopefully extracted to a file.