### PR TITLE
Correct stack order of dropup menus

### DIFF
--- a/src/web/waiters/RecipeWaiter.mjs
+++ b/src/web/waiters/RecipeWaiter.mjs
@@ -51,7 +51,6 @@ class RecipeWaiter {
                 }
             }.bind(this),
             onSort: function(evt) {
-                this.updateZIndices();
                 if (evt.from.id === "rec-list") {
                     document.dispatchEvent(this.manager.statechange);
                 }
@@ -147,19 +146,6 @@ class RecipeWaiter {
 
         this.buildRecipeOperation(evt.item);
         evt.item.dispatchEvent(this.manager.operationadd);
-    }
-
-
-    /**
-     * Sets the z-index property on each operation to make sure that operations higher in the list
-     * have a higher index, meaning dropdowns are not hidden underneath subsequent operations.
-     */
-    updateZIndices() {
-        const operations = document.getElementById("rec-list").children;
-        for (let i = 0; i < operations.length; i++) {
-            const operation = operations[i];
-            operation.style.zIndex = 100 + operations.length - i;
-        }
     }
 
 
@@ -480,7 +466,6 @@ class RecipeWaiter {
         log.debug(`'${e.target.querySelector(".op-title").textContent}' added to recipe`);
 
         this.triggerArgEvents(e.target);
-        this.updateZIndices();
         window.dispatchEvent(this.manager.statechange);
     }
 


### PR DESCRIPTION
Currently, operations in Recipe section have descending z-indices, so that dropdown menus from an operation above doesn't get covered by the operations below it:
![image](https://user-images.githubusercontent.com/7034308/77704040-26902a00-6fb4-11ea-8603-6b2da4e8340d.png)

But when the menu becomes a "dropup" menu, all its items are covered by operations above it:
![image](https://user-images.githubusercontent.com/7034308/77704134-550e0500-6fb4-11ea-9d8d-2639aafd0cd3.png)

This pull request removes the z-index setter, and the menu appears correctly as the topmost element in both cases.