### PR TITLE
Added an icon-button to remove an operation from the recipe

### DIFF
--- a/src/web/HTMLOperation.mjs
+++ b/src/web/HTMLOperation.mjs
@@ -81,6 +81,7 @@ class HTMLOperation {
 
         html += `</div>
         <div class="recip-icons">
+            <i class="material-icons remove-icon" title="Remove operation" disabled="false">delete</i>
             <i class="material-icons breakpoint" title="Set breakpoint" break="false">pause</i>
             <i class="material-icons disable-icon" title="Disable operation" disabled="false">not_interested</i>
         </div>

--- a/src/web/Manager.mjs
+++ b/src/web/Manager.mjs
@@ -137,6 +137,7 @@ class Manager {
         this.addDynamicListener(".arg[type=checkbox], .arg[type=radio], select.arg", "change", this.recipe.ingChange, this.recipe);
         this.addDynamicListener(".disable-icon", "click", this.recipe.disableClick, this.recipe);
         this.addDynamicListener(".breakpoint", "click", this.recipe.breakpointClick, this.recipe);
+        this.addDynamicListener(".remove-icon", "click", this.recipe.removeClick, this.recipe);
         this.addDynamicListener("#rec-list li.operation", "dblclick", this.recipe.operationDblclick, this.recipe);
         this.addDynamicListener("#rec-list li.operation > div", "dblclick", this.recipe.operationChildDblclick, this.recipe);
         this.addDynamicListener("#rec-list .dropdown-menu.toggle-dropdown a", "click", this.recipe.dropdownToggleClick, this.recipe);

--- a/src/web/stylesheets/components/_operation.css
+++ b/src/web/stylesheets/components/_operation.css
@@ -252,6 +252,10 @@ div.toggle-string {
     color: var(--breakpoint-icon-selected-colour);
 }
 
+.remove-icon {
+    color: var(--remove-icon-colour);
+}
+
 .break {
     color: var(--breakpoint-font-colour) !important;
     background-color: var(--breakpoint-bg-colour) !important;

--- a/src/web/stylesheets/themes/_classic.css
+++ b/src/web/stylesheets/themes/_classic.css
@@ -89,6 +89,7 @@
     --disable-icon-selected-colour: #f44336;
     --breakpoint-icon-colour: #9e9e9e;
     --breakpoint-icon-selected-colour: #f44336;
+    --remove-icon-colour: #9e9e9e;
 
 
     /* Buttons */

--- a/src/web/stylesheets/themes/_dark.css
+++ b/src/web/stylesheets/themes/_dark.css
@@ -85,6 +85,7 @@
     --disable-icon-selected-colour: #f44336;
     --breakpoint-icon-colour: #9e9e9e;
     --breakpoint-icon-selected-colour: #f44336;
+    --remove-icon-colour: #9e9e9e;
 
 
     /* Buttons */

--- a/src/web/stylesheets/themes/_geocities.css
+++ b/src/web/stylesheets/themes/_geocities.css
@@ -85,6 +85,7 @@
     --disable-icon-selected-colour: yellow;
     --breakpoint-icon-colour: #0f0;
     --breakpoint-icon-selected-colour: yellow;
+    --remove-icon-colour: #0f0;
 
 
     /* Buttons */

--- a/src/web/stylesheets/themes/_solarizedDark.css
+++ b/src/web/stylesheets/themes/_solarizedDark.css
@@ -104,6 +104,7 @@
     --disable-icon-selected-colour: var(--sol-red);
     --breakpoint-icon-colour: var(--base00);
     --breakpoint-icon-selected-colour: var(--sol-red);
+    --remove-icon-colour: var(--base00);
 
     /* Buttons */
     --btn-default-font-colour: var(--base0);

--- a/src/web/stylesheets/themes/_solarizedLight.css
+++ b/src/web/stylesheets/themes/_solarizedLight.css
@@ -104,6 +104,7 @@
     --disable-icon-selected-colour: #f44336;
     --breakpoint-icon-colour: #9e9e9e;
     --breakpoint-icon-selected-colour: #f44336;
+    --remove-icon-colour: #9e9e9e;
 
 
     /* Buttons */

--- a/src/web/waiters/RecipeWaiter.mjs
+++ b/src/web/waiters/RecipeWaiter.mjs
@@ -263,6 +263,19 @@ class RecipeWaiter {
 
 
     /**
+     * Handler for remove click events.
+     * Removes the operation from the recipe and auto bakes.
+     *
+     * @fires Manager#statechange
+     * @param {event} e
+     */
+    removeClick(e) {
+        e.target.closest(".operation").remove();
+        this.opRemove(e);
+    }
+
+
+    /**
      * Handler for operation doubleclick events.
      * Removes the operation from the recipe and auto bakes.
      *


### PR DESCRIPTION
This has bugged me from day one that the only way to remove an operation was to drag it back into the list. I just learned 20 minutes ago via the source code that you can also double click an operation to remove it. Both are really odd choices from a UX stand point. I just added a simple button. It's also in the top right corner where you'd usually expect stuff like a "close" button.

I also wanted to enable `data-toggle` for these icons to be consistent with the rest of the app. But that breaks when the operation is removed (the tooltip will still render).