### PR TITLE
Add file extensions which are mandatory for the latest Node 12.x.

### DIFF
--- a/src/core/operations/GenerateImage.mjs
+++ b/src/core/operations/GenerateImage.mjs
@@ -7,10 +7,10 @@
 import Operation from "../Operation.mjs";
 import OperationError from "../errors/OperationError.mjs";
 import Utils from "../Utils.mjs";
-import {isImage} from "../lib/FileType";
-import {toBase64} from "../lib/Base64";
+import {isImage} from "../lib/FileType.mjs";
+import {toBase64} from "../lib/Base64.mjs";
 import jimp from "jimp";
-import {isWorkerEnvironment} from "../Utils";
+import {isWorkerEnvironment} from "../Utils.mjs";
 
 /**
  * Generate Image operation


### PR DESCRIPTION
Note: This doesn't solve the upstream import's which still don't comply but it preps CyberChef for it.
