### PR TITLE
Use proper booleans instead of relying on truthy/falsy values

### DIFF
--- a/src/core/operations/Colossus.mjs
+++ b/src/core/operations/Colossus.mjs
@@ -125,7 +125,8 @@ class Colossus extends Operation {
             },
             {
                 name: "R1-Negate",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "R1-Counter",
@@ -164,7 +165,8 @@ class Colossus extends Operation {
             },
             {
                 name: "R2-Negate",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "R2-Counter",
@@ -203,7 +205,8 @@ class Colossus extends Operation {
             },
             {
                 name: "R3-Negate",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "R3-Counter",
@@ -212,7 +215,8 @@ class Colossus extends Operation {
             },
             {
                 name: "Negate All",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "K Rack: Addition",
@@ -220,23 +224,28 @@ class Colossus extends Operation {
             },
             {
                 name: "Add-Q1",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "Add-Q2",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "Add-Q3",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "Add-Q4",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "Add-Q5",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "Add-Equals",
@@ -246,11 +255,13 @@ class Colossus extends Operation {
             },
             {
                 name: "Add-Counter1",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "Add Negate All",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "Total Motor",

--- a/src/core/operations/ExtractDomains.mjs
+++ b/src/core/operations/ExtractDomains.mjs
@@ -27,7 +27,7 @@ class ExtractDomains extends Operation {
             {
                 "name": "Display total",
                 "type": "boolean",
-                "value": "Extract.DISPLAY_TOTAL"
+                "value": true
             }
         ];
     }

--- a/src/core/operations/ExtractFiles.mjs
+++ b/src/core/operations/ExtractFiles.mjs
@@ -38,7 +38,7 @@ class ExtractFiles extends Operation {
             {
                 name: "Ignore failed extractions",
                 type: "boolean",
-                value: "true"
+                value: true
             }
         ]);
     }

--- a/src/core/operations/FrequencyDistribution.mjs
+++ b/src/core/operations/FrequencyDistribution.mjs
@@ -30,7 +30,7 @@ class FrequencyDistribution extends Operation {
             {
                 "name": "Show 0%s",
                 "type": "boolean",
-                "value": "Entropy.FREQ_ZEROS"
+                "value": true
             }
         ];
     }

--- a/src/core/operations/Lorenz.mjs
+++ b/src/core/operations/Lorenz.mjs
@@ -60,7 +60,8 @@ class Lorenz extends Operation {
             },
             {
                 name: "KT-Schalter",
-                type: "boolean"
+                type: "boolean",
+                value: false
             },
             {
                 name: "Mode",


### PR DESCRIPTION
I noticed in `OperationConfig.json` that some boolean arguments didn't look right