### PR TITLE
Option structures added for hashing algorithms

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -313,6 +313,7 @@
             "SHA1",
             "SHA2",
             "SHA3",
+            "SM3",
             "Keccak",
             "Shake",
             "RIPEMD",

--- a/src/core/operations/HAS160.mjs
+++ b/src/core/operations/HAS160.mjs
@@ -20,11 +20,17 @@ class HAS160 extends Operation {
 
         this.name = "HAS-160";
         this.module = "Crypto";
-        this.description = "HAS-160 is a cryptographic hash function designed for use with the Korean KCDSA digital signature algorithm. It is derived from SHA-1, with assorted changes intended to increase its security. It produces a 160-bit output.<br><br>HAS-160 is used in the same way as SHA-1. First it divides input in blocks of 512 bits each and pads the final block. A digest function updates the intermediate hash value by processing the input blocks in turn.<br><br>The message digest algorithm consists of 80 rounds.";
+        this.description = "HAS-160 is a cryptographic hash function designed for use with the Korean KCDSA digital signature algorithm. It is derived from SHA-1, with assorted changes intended to increase its security. It produces a 160-bit output.<br><br>HAS-160 is used in the same way as SHA-1. First it divides input in blocks of 512 bits each and pads the final block. A digest function updates the intermediate hash value by processing the input blocks in turn.<br><br>The message digest algorithm consists, by default, of 80 rounds.";
         this.infoURL = "https://wikipedia.org/wiki/HAS-160";
         this.inputType = "ArrayBuffer";
         this.outputType = "string";
-        this.args = [];
+        this.args = [
+            {
+                name: "Rounds",
+                type: "number",
+                value: 80
+            }
+        ];
     }
 
     /**
@@ -33,7 +39,7 @@ class HAS160 extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        return runHash("has160", input);
+        return runHash("has160", input, {rounds: args[0]});
     }
 
 }

--- a/src/core/operations/MD2.mjs
+++ b/src/core/operations/MD2.mjs
@@ -20,11 +20,17 @@ class MD2 extends Operation {
 
         this.name = "MD2";
         this.module = "Crypto";
-        this.description = "The MD2 (Message-Digest 2) algorithm is a cryptographic hash function developed by Ronald Rivest in 1989. The algorithm is optimized for 8-bit computers.<br><br>Although MD2 is no longer considered secure, even as of 2014, it remains in use in public key infrastructures as part of certificates generated with MD2 and RSA.";
+        this.description = "The MD2 (Message-Digest 2) algorithm is a cryptographic hash function developed by Ronald Rivest in 1989. The algorithm is optimized for 8-bit computers.<br><br>Although MD2 is no longer considered secure, even as of 2014, it remains in use in public key infrastructures as part of certificates generated with MD2 and RSA. The message digest algorithm consists, by default, of 18 rounds.";
         this.infoURL = "https://wikipedia.org/wiki/MD2_(cryptography)";
         this.inputType = "ArrayBuffer";
         this.outputType = "string";
-        this.args = [];
+        this.args = [
+            {
+                name: "Rounds",
+                type: "number",
+                value: 18
+            }
+        ];
     }
 
     /**
@@ -33,7 +39,7 @@ class MD2 extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        return runHash("md2", input);
+        return runHash("md2", input, {rounds: args[0]});
     }
 
 }

--- a/src/core/operations/SHA0.mjs
+++ b/src/core/operations/SHA0.mjs
@@ -20,11 +20,17 @@ class SHA0 extends Operation {
 
         this.name = "SHA0";
         this.module = "Crypto";
-        this.description = "SHA-0 is a retronym applied to the original version of the 160-bit hash function published in 1993 under the name 'SHA'. It was withdrawn shortly after publication due to an undisclosed 'significant flaw' and replaced by the slightly revised version SHA-1.";
+        this.description = "SHA-0 is a retronym applied to the original version of the 160-bit hash function published in 1993 under the name 'SHA'. It was withdrawn shortly after publication due to an undisclosed 'significant flaw' and replaced by the slightly revised version SHA-1. The message digest algorithm consists, by default, of 80 rounds.";
         this.infoURL = "https://wikipedia.org/wiki/SHA-1#SHA-0";
         this.inputType = "ArrayBuffer";
         this.outputType = "string";
-        this.args = [];
+        this.args = [
+            {
+                name: "Rounds",
+                type: "number",
+                value: 80
+            }
+        ];
     }
 
     /**
@@ -33,7 +39,7 @@ class SHA0 extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        return runHash("sha0", input);
+        return runHash("sha0", input, {rounds: args[0]});
     }
 
 }

--- a/src/core/operations/SHA1.mjs
+++ b/src/core/operations/SHA1.mjs
@@ -20,11 +20,17 @@ class SHA1 extends Operation {
 
         this.name = "SHA1";
         this.module = "Crypto";
-        this.description = "The SHA (Secure Hash Algorithm) hash functions were designed by the NSA. SHA-1 is the most established of the existing SHA hash functions and it is used in a variety of security applications and protocols.<br><br>However, SHA-1's collision resistance has been weakening as new attacks are discovered or improved.";
+        this.description = "The SHA (Secure Hash Algorithm) hash functions were designed by the NSA. SHA-1 is the most established of the existing SHA hash functions and it is used in a variety of security applications and protocols.<br><br>However, SHA-1's collision resistance has been weakening as new attacks are discovered or improved. The message digest algorithm consists, by default, of 80 rounds.";
         this.infoURL = "https://wikipedia.org/wiki/SHA-1";
         this.inputType = "ArrayBuffer";
         this.outputType = "string";
-        this.args = [];
+        this.args = [
+            {
+                name: "Rounds",
+                type: "number",
+                value: 80
+            }
+        ];
     }
 
     /**
@@ -33,7 +39,7 @@ class SHA1 extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        return runHash("sha1", input);
+        return runHash("sha1", input, {rounds: args[0]});
     }
 
 }

--- a/src/core/operations/SHA2.mjs
+++ b/src/core/operations/SHA2.mjs
@@ -20,7 +20,7 @@ class SHA2 extends Operation {
 
         this.name = "SHA2";
         this.module = "Crypto";
-        this.description = "The SHA-2 (Secure Hash Algorithm 2) hash functions were designed by the NSA. SHA-2 includes significant changes from its predecessor, SHA-1. The SHA-2 family consists of hash functions with digests (hash values) that are 224, 256, 384 or 512 bits: SHA224, SHA256, SHA384, SHA512.<br><br><ul><li>SHA-512 operates on 64-bit words.</li><li>SHA-256 operates on 32-bit words.</li><li>SHA-384 is largely identical to SHA-512 but is truncated to 384 bytes.</li><li>SHA-224 is largely identical to SHA-256 but is truncated to 224 bytes.</li><li>SHA-512/224 and SHA-512/256 are truncated versions of SHA-512, but the initial values are generated using the method described in Federal Information Processing Standards (FIPS) PUB 180-4.</li></ul>";
+        this.description = "The SHA-2 (Secure Hash Algorithm 2) hash functions were designed by the NSA. SHA-2 includes significant changes from its predecessor, SHA-1. The SHA-2 family consists of hash functions with digests (hash values) that are 224, 256, 384 or 512 bits: SHA224, SHA256, SHA384, SHA512.<br><br><ul><li>SHA-512 operates on 64-bit words.</li><li>SHA-256 operates on 32-bit words.</li><li>SHA-384 is largely identical to SHA-512 but is truncated to 384 bytes.</li><li>SHA-224 is largely identical to SHA-256 but is truncated to 224 bytes.</li><li>SHA-512/224 and SHA-512/256 are truncated versions of SHA-512, but the initial values are generated using the method described in Federal Information Processing Standards (FIPS) PUB 180-4.</li></ul> The message digest algorithm consists, by default, of 64 rounds.";
         this.infoURL = "https://wikipedia.org/wiki/SHA-2";
         this.inputType = "ArrayBuffer";
         this.outputType = "string";
@@ -29,6 +29,11 @@ class SHA2 extends Operation {
                 "name": "Size",
                 "type": "option",
                 "value": ["512", "256", "384", "224", "512/256", "512/224"]
+            },
+            {
+                name: "Rounds",
+                type: "number",
+                value: 64
             }
         ];
     }
@@ -40,7 +45,7 @@ class SHA2 extends Operation {
      */
     run(input, args) {
         const size = args[0];
-        return runHash("sha" + size, input);
+        return runHash("sha" + size, input, {rounds: args[1]});
     }
 
 }

--- a/src/core/operations/SM3.mjs
+++ b/src/core/operations/SM3.mjs
@@ -23,7 +23,7 @@ class SM3 extends Operation {
         this.name = "SM3";
         this.module = "Crypto";
         this.description = "SM3 is a cryptographic hash function used in the Chinese National Standard. SM3 is mainly used in digital signatures, message authentication codes, and pseudorandom number generators. The message digest algorithm consists, by default, of 64 rounds and length of 256.";
-        this.infoURL = "";
+        this.infoURL = "https://wikipedia.org/wiki/SM3_(hash_function)";
         this.inputType = "ArrayBuffer";
         this.outputType = "string";
         this.args = [

--- a/src/core/operations/SM3.mjs
+++ b/src/core/operations/SM3.mjs
@@ -1,0 +1,56 @@
+/**
+ * @author n1073645 [n1073645@gmail.com]
+ * @copyright Crown Copyright 2020
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import Utils from "../Utils.mjs";
+import Sm3 from "crypto-api/src/hasher/sm3";
+import {toHex} from "crypto-api/src/encoder/hex";
+
+/**
+ * SM3 operation
+ */
+class SM3 extends Operation {
+
+    /**
+     * SM3 constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "SM3";
+        this.module = "Crypto";
+        this.description = "SM3 is a cryptographic hash function used in the Chinese National Standard. SM3 is mainly used in digital signatures, message authentication codes, and pseudorandom number generators. The message digest algorithm consists, by default, of 64 rounds and length of 256.";
+        this.infoURL = "";
+        this.inputType = "ArrayBuffer";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Length",
+                type: "number",
+                value: 256
+            },
+            {
+                name: "Rounds",
+                type: "number",
+                value: 64
+            }
+        ];
+    }
+
+    /**
+     * @param {ArrayBuffer} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const msg = Utils.arrayBufferToStr(input, false);
+        const hasher = new Sm3({length: args[0], rounds: args[1]});
+        hasher.update(msg);
+        return toHex(hasher.finalize());
+    }
+}
+
+export default SM3;


### PR DESCRIPTION
In the crypto-api library there is an options structure for hashing algorithms that allows a different number of rounds to be performed. Contained in this PR is arguments added to the relevant operations. 