### PR TITLE
Fix bug in Normalise Unicode operation: replace nfc by nfkc

### DIFF
--- a/src/core/operations/NormaliseUnicode.mjs
+++ b/src/core/operations/NormaliseUnicode.mjs
@@ -51,7 +51,7 @@ class NormaliseUnicode extends Operation {
             case "NFKD":
                 return unorm.nfkd(input);
             case "NFKC":
-                return unorm.nfc(input);
+                return unorm.nfkc(input);
             default:
                 throw new OperationError("Unknown Normalisation Form");
         }

--- a/tests/operations/tests/NormaliseUnicode.mjs
+++ b/tests/operations/tests/NormaliseUnicode.mjs
@@ -42,7 +42,7 @@ TestRegister.addTests([
     }, {
         name: "Normalise Unicode - NFKC",
         input: "\u00c7\u0043\u0327\u2160",
-        expectedMatch: /\u00C7\u00C7\u2160/,
+        expectedMatch: /\u00C7\u00C7I/,
         recipeConfig: [
             {
                 op: "Normalise Unicode",


### PR DESCRIPTION
Simple bug fix.

Related: #872 #912