### PR TITLE
Add magic check for base85

### DIFF
--- a/src/core/lib/Base85.mjs
+++ b/src/core/lib/Base85.mjs
@@ -1,3 +1,5 @@
+import Utils from "../Utils.mjs";
+
 /**
  * Base85 resources.
  *
@@ -32,13 +34,12 @@ export const ALPHABET_OPTIONS = [
  * @returns {string}
  */
 export function alphabetName(alphabet) {
-    alphabet = alphabet.replace("'", "&apos;");
-    alphabet = alphabet.replace("\"", "&quot;");
-    alphabet = alphabet.replace("\\", "&bsol;");
+    alphabet = escape(alphabet);
     let name;
 
     ALPHABET_OPTIONS.forEach(function(a) {
-        if (escape(alphabet) === escape(a.value)) name = a.name;
+        const expanded = Utils.expandAlphRange(a.value).join("");
+        if (alphabet === escape(expanded)) name = a.name;
     });
 
     return name;

--- a/src/core/operations/FromBase85.mjs
+++ b/src/core/operations/FromBase85.mjs
@@ -33,6 +33,23 @@ class FromBase85 extends Operation {
                 value: ALPHABET_OPTIONS
             },
         ];
+        this.checks = [
+            {
+                pattern: "^\\s*(?:<~)?(?:(?:\\s*[!-u]){5}|\\s*z)+[!-u\\s]*(?:~>)?\\s*$",
+                flags: "i",
+                args: ["!-u"]
+            },
+            {
+                pattern: "^(?:\\s*[0-9a-zA-Z.\\-:+=^!/*?&<>()[\\]{}@%$#])+\\s*$",
+                flags: "i",
+                args: ["0-9a-zA-Z.\\-:+=^!/*?&<>()[]{}@%$#"]
+            },
+            {
+                pattern: "^(?:\\s*[0-9A-Za-z!#$%&()*+\\-;<=>?@^_`{|}~])+\\s*$",
+                flags: "i",
+                args: ["0-9A-Za-z!#$%&()*+\\-;<=>?@^_`{|}~"]
+            },
+        ];
     }
 
     /**

--- a/src/core/operations/FromBase85.mjs
+++ b/src/core/operations/FromBase85.mjs
@@ -52,6 +52,8 @@ class FromBase85 extends Operation {
 
         if (input.length === 0) return [];
 
+        input = input.replace(/\s+/g, "");
+
         const matches = input.match(/<~(.+?)~>/);
         if (matches !== null) input = matches[1];
 


### PR DESCRIPTION
I also fixed the `alphabetName` name function since it currently doesn't work. (Can be checked by trying to use `FromBase85` on `z` which should produce 4 zeros if the encoding is `Standard` but currently doesn't because the alphabet/encoding name will be `undefined`.)

I also made `FromBase85` ignore whitespace since Ascii85 is supposed to ignore all whitespace according to [Wikipedia](https://en.wikipedia.org/wiki/Ascii85) (`History > Adobe version`).

I think usually this only applies to the Adobe version but I don't think there is a good reason to not always do it.