### PR TITLE
fix import operations with special chars in them

### DIFF
--- a/src/node/apiUtils.mjs
+++ b/src/node/apiUtils.mjs
@@ -66,7 +66,7 @@ export function removeSubheadingsFromArray(array) {
  * @param str
  */
 export function sanitise(str) {
-    return str.replace(/ /g, "").toLowerCase();
+    return str.replace(/[/\s.-]/g, "").toLowerCase();
 }
 
 

--- a/tests/node/tests/nodeApi.mjs
+++ b/tests/node/tests/nodeApi.mjs
@@ -357,6 +357,33 @@ TestRegister.addApiTests([
         assert.strictEqual(result.toString(), "begin_something_aaaaaaaaaaaaaa_end_something");
     }),
 
+    it("chef.bake: should accept operation names from Chef Website which contain forward slash", () => {
+        const result = chef.bake("I'll have the test salmon", [
+            { "op": "Find / Replace",
+                "args": [{ "option": "Regex", "string": "test" }, "good", true, false, true, false]}
+        ]);
+        assert.strictEqual(result.toString(), "I'll have the good salmon");
+    }),
+
+    it("chef.bake: should accept operation names from Chef Website which contain a hyphen", () => {
+        const result = chef.bake("I'll have the test salmon", [
+            { "op": "Adler-32 Checksum",
+                "args": [] }
+        ]);
+        assert.strictEqual(result.toString(), "6e4208f8");
+    }),
+
+    it("chef.bake: should accept operation names from Chef Website which contain a period", () => {
+        const result = chef.bake("30 13 02 01 05 16 0e 41 6e 79 62 6f 64 79 20 74 68 65 72 65 3f", [
+            { "op": "Parse ASN.1 hex string",
+                "args": [0, 32] }
+        ]);
+        assert.strictEqual(result.toString(), `SEQUENCE
+  INTEGER 05..(total 1bytes)..05
+  IA5String 'Anybody there?'
+`);
+    }),
+
     it("Excluded operations: throw a sensible error when you try and call one", () => {
         try {
             chef.fork();


### PR DESCRIPTION
From #956

Operations imported from chef UI where the operations contain characters other than letters, numbers or spaces are not found.

This PR adds `.`,`/` and `-` to the sanitise function so operations with those chars in their display name match too. Those were the only special chars I could find in existing operations.