### PR TITLE
Added raw output argument for "JPath expression" operation

### DIFF
--- a/src/core/operations/JPathExpression.mjs
+++ b/src/core/operations/JPathExpression.mjs
@@ -35,6 +35,11 @@ class JPathExpression extends Operation {
                 "name": "Result delimiter",
                 "type": "binaryShortString",
                 "value": "\\n"
+            },
+            {
+                "name": "Raw output(if result is a string)",
+                "type": "boolean",
+                "value": false
             }
         ];
     }
@@ -45,7 +50,7 @@ class JPathExpression extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const [query, delimiter] = args;
+        const [query, delimiter, rawOutput] = args;
         let results,
             obj;
 
@@ -59,6 +64,10 @@ class JPathExpression extends Operation {
             results = jpath.query(obj, query);
         } catch (err) {
             throw new OperationError(`Invalid JPath expression: ${err.message}`);
+        }
+
+        if (rawOutput) {
+            return results.map(result => typeof result === "string" ? result : JSON.stringify(result)).join(delimiter);
         }
 
         return results.map(result => JSON.stringify(result)).join(delimiter);

--- a/tests/operations/tests/Code.mjs
+++ b/tests/operations/tests/Code.mjs
@@ -178,7 +178,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["", "\n"]
+                "args": ["", "\n", false]
             }
         ],
     },
@@ -189,7 +189,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["", "\n"]
+                "args": ["", "\n", false]
             }
         ],
     },
@@ -205,7 +205,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["$.store.book[*].author", "\n"]
+                "args": ["$.store.book[*].author", "\n", false]
             }
         ],
     },
@@ -223,7 +223,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["$..title", "\n"]
+                "args": ["$..title", "\n", false]
             }
         ],
     },
@@ -238,7 +238,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["$.store.*", "\n"]
+                "args": ["$.store.*", "\n", false]
             }
         ],
     },
@@ -249,7 +249,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["$..book[-1:]", "\n"]
+                "args": ["$..book[-1:]", "\n", false]
             }
         ],
     },
@@ -263,7 +263,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["$..book[:2]", "\n"]
+                "args": ["$..book[:2]", "\n", false]
             }
         ],
     },
@@ -277,7 +277,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["$..book[?(@.isbn)]", "\n"]
+                "args": ["$..book[?(@.isbn)]", "\n", false]
             }
         ],
     },
@@ -292,7 +292,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["$..book[?(@.price<30 && @.category==\"fiction\")]", "\n"]
+                "args": ["$..book[?(@.price<30 && @.category==\"fiction\")]", "\n", false]
             }
         ],
     },
@@ -306,7 +306,25 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "JPath expression",
-                "args": ["$..book[?(@.price<10)]", "\n"]
+                "args": ["$..book[?(@.price<10)]", "\n", false]
+            }
+        ],
+    },
+    {
+        name: "JPath Expression: Fetch raw output of all values with matching key",
+        input: JSON.stringify(JSON_TEST_DATA),
+        expectedOutput: [
+            "Sayings of the Century",
+            "Sword of Honour",
+            "Moby Dick",
+            "The Lord of the Rings",
+            "Financial Times",
+            "The Guardian"
+        ].join("\n"),
+        recipeConfig: [
+            {
+                "op": "JPath expression",
+                "args": ["$..title", "\n", true]
             }
         ],
     },


### PR DESCRIPTION
if the result is a string then it will be directly output rather than being formatted as a JSON string with quotes. 