### PR TITLE
Base32 from Base16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 All major and minor version changes will be documented in this file. Details of patch-level version changes can be found in [commit messages](https://github.com/gchq/CyberChef/commits/master).
 
+### Unreleased
+- Add 'To Base32 (From Base16)' operation
 
 ### [9.21.0] - 2020-06-12
 - Node API now exports `magic` operation [@d98762625] | [#1049]

--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -22,6 +22,7 @@
             "From Base64",
             "Show Base64 offsets",
             "To Base32",
+	        "To Base32 (From Base16)",
             "From Base32",
             "To Base58",
             "From Base58",

--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -22,7 +22,7 @@
             "From Base64",
             "Show Base64 offsets",
             "To Base32",
-	        "To Base32 (From Base16)",
+            "To Base32 (From Base16)",
             "From Base32",
             "To Base58",
             "From Base58",

--- a/src/core/operations/ToBase32FromBase16.mjs
+++ b/src/core/operations/ToBase32FromBase16.mjs
@@ -1,0 +1,53 @@
+import Operation from "../Operation.mjs";
+import Utils from "../Utils.mjs";
+
+/**
+ * To Base32 operation
+ */
+class ToBase32FromBase16 extends Operation {
+
+    /**
+     * ToBase32 constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "To Base32 (From Base16)";
+        this.module = "Default";
+        this.description = "Converts Base16 to Base32 using Base2 as an intermediate and 5 bits at a time.";
+        this.infoURL = "https://wikipedia.org/wiki/Base32";
+        this.inputType = "ArrayBuffer";
+        this.outputType = "string";
+    }
+
+    /**
+     * @param {ArrayBuffer} input
+     * @returns {string}
+     */
+    run(input) {
+        if (!input) return "";
+        input = new Uint8Array(input);
+        const toStr = Utils.byteArrayToChars(input).toUpperCase();
+        const b16Regex = new RegExp("^[A-Fa-f0-9]+$");
+        if (b16Regex.test(toStr) === true) {
+            const b32Map = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+            let binary = "";
+            for (const c of toStr) {
+                const binRep = parseInt(c, 16).toString(2).padStart(4, "0");
+                binary += binRep;
+            }
+            let b32 = "";
+            for (let i = 0; i < binary.length; i+=5) {
+                const slice = binary.slice(i, i+5);
+                const toB32 = b32Map[parseInt(slice, 2)];
+                b32 += toB32;
+            }
+            return b32;
+        } else {
+            return "";
+        }
+    }
+
+}
+
+export default ToBase32FromBase16;


### PR DESCRIPTION
This adds a ToBase32FromBase16 operator in order to support clean conversions of SHA1 hashes into Base32 strings by interpreting the SHA1 (or any other similarly hex encoded string) as their bit representation instead of as a Unicode string.