### PR TITLE
Add option to parse non-varint Protobuf fields as floats

### DIFF
--- a/src/core/operations/ProtobufDecode.mjs
+++ b/src/core/operations/ProtobufDecode.mjs
@@ -25,7 +25,13 @@ class ProtobufDecode extends Operation {
         this.infoURL = "https://wikipedia.org/wiki/Protocol_Buffers";
         this.inputType = "ArrayBuffer";
         this.outputType = "JSON";
-        this.args = [];
+        this.args = [
+            {
+                "name": "Decode non-varints as floats",
+                "type": "boolean",
+                "value": false
+            }
+        ];
     }
 
     /**
@@ -36,7 +42,7 @@ class ProtobufDecode extends Operation {
     run(input, args) {
         input = new Uint8Array(input);
         try {
-            return Protobuf.decode(input);
+            return Protobuf.decode(input, args[0]);
         } catch (err) {
             throw new OperationError(err);
         }

--- a/tests/operations/tests/Protobuf.mjs
+++ b/tests/operations/tests/Protobuf.mjs
@@ -33,4 +33,106 @@ TestRegister.addTests([
             }
         ]
     },
+    /**
+     * Input generated from:
+     * ```
+       $ cat test.proto
+       syntax = "proto3";
+
+       message Test {
+         float a = 1;
+       }
+
+       $ protoc --version
+       libprotoc 3.11.1
+
+       $ echo a:1 | protoc --encode=Test test.proto | xxd -p
+       0d0000803f
+       ```
+     */
+    {
+        name: "Protobuf Decode - parse fixed32 as integer",
+        input: "0d0000803f",
+        expectedOutput: JSON.stringify({
+            "1": 32831,
+        }, null, 4),
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["Auto"]
+            },
+            {
+                "op": "Protobuf Decode",
+                "args": [false]
+            }
+        ]
+    },
+    {
+        name: "Protobuf Decode - parse fixed32 as float32",
+        input: "0d0000803f",
+        expectedOutput: JSON.stringify({
+            "1": 1,
+        }, null, 4),
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["Auto"]
+            },
+            {
+                "op": "Protobuf Decode",
+                "args": [true]
+            }
+        ]
+    },
+    /**
+     * Input generated from:
+     * ```
+       $ cat test.proto
+       syntax = "proto3";
+
+       message Test {
+         double a = 1;
+       }
+
+       $ protoc --version
+       libprotoc 3.11.1
+
+       $ echo a:1 | protoc --encode=Test test.proto | xxd -p
+       09000000000000f03f
+       ```
+     */
+    {
+        name: "Protobuf Decode - parse fixed64 as integer",
+        input: "09000000000000f03f",
+        expectedOutput: JSON.stringify({
+            "1": 61503,
+        }, null, 4),
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["Auto"]
+            },
+            {
+                "op": "Protobuf Decode",
+                "args": [false]
+            }
+        ]
+    },
+    {
+        name: "Protobuf Decode - parse fixed64 as float64",
+        input: "09000000000000f03f",
+        expectedOutput: JSON.stringify({
+            "1": 1,
+        }, null, 4),
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["Auto"]
+            },
+            {
+                "op": "Protobuf Decode",
+                "args": [true]
+            }
+        ]
+    }
 ]);


### PR DESCRIPTION
Protobuf wire types 1 and 5 represent fixed-sized 64-bit and 32-bit values, respectively (see [docs](https://developers.google.com/protocol-buffers/docs/encoding#non-varint_numbers)). However the representation on the wire contains no way to differentiate encoded integers from floating point values.

The current implementation can be confusing to users who are attempting to decode a Protobuf messages that contains `float` or `double` fields since they will always be decoded as integers.

This PR introduces a new argument to the _Protobuf Decode_ operation that allows users to opt-in to parsing fields of wire types 1 and 5 as floats.