### PR TITLE
Fixed bug in rendering related to Comment blocks

### DIFF
--- a/src/core/Recipe.mjs
+++ b/src/core/Recipe.mjs
@@ -190,7 +190,6 @@ class Recipe  {
         for (let i = startFrom; i < this.opList.length; i++) {
             op = this.opList[i];
             log.debug(`[${i}] ${op.name} ${JSON.stringify(op.ingValues)}`);
-
             if (op.disabled) {
                 log.debug("Operation is disabled, skipping");
                 continue;
@@ -201,7 +200,6 @@ class Recipe  {
             }
 
             try {
-
                 if (op.name != "Comment") {
                     input = await dish.get(op.inputType);
                 }
@@ -234,12 +232,10 @@ class Recipe  {
                     output = await op.run(input, op.ingValues);
                     dish.set(output, op.outputType);
                 }
-
                 // if comment is the lastRunOp, the output we want is the previous command, not necessarily a String
                 if (op.name != "Comment"){
                     this.lastRunOp = op;
                 }
-
             } catch (err) {
                 // Return expected errors as output
                 if (err instanceof OperationError ||

--- a/src/core/Recipe.mjs
+++ b/src/core/Recipe.mjs
@@ -190,6 +190,7 @@ class Recipe  {
         for (let i = startFrom; i < this.opList.length; i++) {
             op = this.opList[i];
             log.debug(`[${i}] ${op.name} ${JSON.stringify(op.ingValues)}`);
+
             if (op.disabled) {
                 log.debug("Operation is disabled, skipping");
                 continue;
@@ -200,7 +201,13 @@ class Recipe  {
             }
 
             try {
-                input = await dish.get(op.inputType);
+
+                if (op.name != "Comment") {
+                    input = await dish.get(op.inputType);
+                }
+                else {
+                    input = dish.value ;
+                }
                 log.debug(`Executing operation '${op.name}'`);
 
                 if (isWorkerEnvironment()) {
@@ -227,7 +234,12 @@ class Recipe  {
                     output = await op.run(input, op.ingValues);
                     dish.set(output, op.outputType);
                 }
-                this.lastRunOp = op;
+
+                // if comment is the lastRunOp, the output we want is the previous command, not necessarily a String
+                if (op.name != "Comment"){
+                    this.lastRunOp = op;
+                }
+
             } catch (err) {
                 // Return expected errors as output
                 if (err instanceof OperationError ||
@@ -273,6 +285,7 @@ class Recipe  {
             await dish.get(this.lastRunOp.outputType),
             this.lastRunOp.ingValues
         );
+
         dish.set(output, this.lastRunOp.presentType);
     }
 


### PR DESCRIPTION
Fixes #1126 

The issue was that as Comment takes strings as inputs and outputs strings, `dish.get(op.inputType)` was removing the HTML formatting from the table. To fix this I have avoided this call if the operation is a Comment, and also the one that sets the output type after it completes, as the output of a Comment block should be whatever the input was.

This fixes the given bug but it might be better to simply not execute comment blocks at all and treat them as if they are disabled.