### PR TITLE
Updated the links to forensic wiki website

### DIFF
--- a/src/core/operations/CTPH.mjs
+++ b/src/core/operations/CTPH.mjs
@@ -21,7 +21,7 @@ class CTPH extends Operation {
         this.name = "CTPH";
         this.module = "Crypto";
         this.description = "Context Triggered Piecewise Hashing, also called Fuzzy Hashing, can match inputs that have homologies. Such inputs have sequences of identical bytes in the same order, although bytes in between these sequences may be different in both content and length.<br><br>CTPH was originally based on the work of Dr. Andrew Tridgell and a spam email detector called SpamSum. This method was adapted by Jesse Kornblum and published at the DFRWS conference in 2006 in a paper 'Identifying Almost Identical Files Using Context Triggered Piecewise Hashing'.";
-        this.infoURL = "https://forensicswiki.org/wiki/Context_Triggered_Piecewise_Hashing";
+        this.infoURL = "https://forensicswiki.xyz/wiki/index.php?title=Context_Triggered_Piecewise_Hashing";
         this.inputType = "string";
         this.outputType = "string";
         this.args = [];

--- a/src/core/operations/CompareCTPHHashes.mjs
+++ b/src/core/operations/CompareCTPHHashes.mjs
@@ -24,7 +24,7 @@ class CompareCTPHHashes extends Operation {
         this.name = "Compare CTPH hashes";
         this.module = "Crypto";
         this.description = "Compares two Context Triggered Piecewise Hashing (CTPH) fuzzy hashes to determine the similarity between them on a scale of 0 to 100.";
-        this.infoURL = "https://forensicswiki.org/wiki/Context_Triggered_Piecewise_Hashing";
+        this.infoURL = "https://forensicswiki.xyz/wiki/index.php?title=Context_Triggered_Piecewise_Hashing";
         this.inputType = "string";
         this.outputType = "Number";
         this.args = [

--- a/src/core/operations/CompareSSDEEPHashes.mjs
+++ b/src/core/operations/CompareSSDEEPHashes.mjs
@@ -24,7 +24,7 @@ class CompareSSDEEPHashes extends Operation {
         this.name = "Compare SSDEEP hashes";
         this.module = "Crypto";
         this.description = "Compares two SSDEEP fuzzy hashes to determine the similarity between them on a scale of 0 to 100.";
-        this.infoURL = "https://forensicswiki.org/wiki/Ssdeep";
+        this.infoURL = "https://forensicswiki.xyz/wiki/index.php?title=Ssdeep";
         this.inputType = "string";
         this.outputType = "Number";
         this.args = [

--- a/src/core/operations/ExtractFiles.mjs
+++ b/src/core/operations/ExtractFiles.mjs
@@ -24,7 +24,7 @@ class ExtractFiles extends Operation {
         this.name = "Extract Files";
         this.module = "Default";
         this.description = "Performs file carving to attempt to extract files from the input.<br><br>This operation is currently capable of carving out the following formats:<ul><li>JPG</li><li>EXE</li><li>ZIP</li><li>PDF</li><li>PNG</li><li>BMP</li><li>FLV</li><li>RTF</li><li>DOCX, PPTX, XLSX</li><li>EPUB</li><li>GZIP</li><li>ZLIB</li><li>ELF, BIN, AXF, O, PRX, SO</li></ul>";
-        this.infoURL = "https://forensicswiki.org/wiki/File_Carving";
+        this.infoURL = "https://forensicswiki.xyz/wiki/index.php?title=File_Carving";
         this.inputType = "ArrayBuffer";
         this.outputType = "List<File>";
         this.presentType = "html";

--- a/src/core/operations/SSDEEP.mjs
+++ b/src/core/operations/SSDEEP.mjs
@@ -21,7 +21,7 @@ class SSDEEP extends Operation {
         this.name = "SSDEEP";
         this.module = "Crypto";
         this.description = "SSDEEP is a program for computing context triggered piecewise hashes (CTPH). Also called fuzzy hashes, CTPH can match inputs that have homologies. Such inputs have sequences of identical bytes in the same order, although bytes in between these sequences may be different in both content and length.<br><br>SSDEEP hashes are now widely used for simple identification purposes (e.g. the 'Basic Properties' section in VirusTotal). Although 'better' fuzzy hashes are available, SSDEEP is still one of the primary choices because of its speed and being a de facto standard.<br><br>This operation is fundamentally the same as the CTPH operation, however their outputs differ in format.";
-        this.infoURL = "https://forensicswiki.org/wiki/Ssdeep";
+        this.infoURL = "https://forensicswiki.xyz/wiki/index.php?title=Ssdeep";
         this.inputType = "string";
         this.outputType = "string";
         this.args = [];


### PR DESCRIPTION
Updating the links to the ForensicsWiki website as forensicswiki.org has moved to forensicswiki.xyz.