### PR TITLE
JWT Algorithms file to fix JWT sign/verify inconsistency

### DIFF
--- a/src/core/lib/JWT.mjs
+++ b/src/core/lib/JWT.mjs
@@ -1,0 +1,24 @@
+/**
+ * DateTime resources.
+ *
+ * @author mt3571 [mt3571@protonmail.com]
+ * @copyright Crown Copyright 2020
+ * @license Apache-2.0
+ */
+
+
+/**
+ * List of the JWT algorithms that can be used
+ */
+export const JWT_ALGORITHMS = [
+    "HS256",
+    "HS384",
+    "HS512",
+    "RS256",
+    "RS384",
+    "RS512",
+    "ES256",
+    "ES384",
+    "ES512",
+    "None"
+];

--- a/src/core/lib/JWT.mjs
+++ b/src/core/lib/JWT.mjs
@@ -1,5 +1,5 @@
 /**
- * DateTime resources.
+ * JWT resources
  *
  * @author mt3571 [mt3571@protonmail.com]
  * @copyright Crown Copyright 2020

--- a/src/core/operations/JWTSign.mjs
+++ b/src/core/operations/JWTSign.mjs
@@ -8,6 +8,9 @@ import Operation from "../Operation.mjs";
 import jwt from "jsonwebtoken";
 import OperationError from "../errors/OperationError.mjs";
 
+import {JWT_ALGORITHMS} from "../lib/JWT.mjs";
+
+
 /**
  * JWT Sign operation
  */
@@ -34,18 +37,7 @@ class JWTSign extends Operation {
             {
                 name: "Signing algorithm",
                 type: "option",
-                value: [
-                    "HS256",
-                    "HS384",
-                    "HS512",
-                    "RS256",
-                    "RS384",
-                    "RS512",
-                    "ES256",
-                    "ES384",
-                    "ES512",
-                    "None"
-                ]
+                value: JWT_ALGORITHMS
             }
         ];
     }

--- a/src/core/operations/JWTVerify.mjs
+++ b/src/core/operations/JWTVerify.mjs
@@ -8,6 +8,9 @@ import Operation from "../Operation.mjs";
 import jwt from "jsonwebtoken";
 import OperationError from "../errors/OperationError.mjs";
 
+
+import {JWT_ALGORITHMS} from "../lib/JWT.mjs";
+
 /**
  * JWT Verify operation
  */
@@ -43,12 +46,8 @@ class JWTVerify extends Operation {
         const [key] = args;
 
         try {
-            const verified = jwt.verify(input, key, { algorithms: [
-                "HS256",
-                "HS384",
-                "HS512",
-                "none"
-            ]});
+            const verified = jwt.verify(input, key, { algorithms: JWT_ALGORITHMS});
+
 
             if (Object.prototype.hasOwnProperty.call(verified, "name") && verified.name === "JsonWebTokenError") {
                 throw new OperationError(verified.message);


### PR DESCRIPTION
Fixes #1073 - issue with JWT verify not working

The issue stemmed from the fact the list of signing algorithms did not match the list of algorithms that could be verified. This meant that you could created a recipe that signed something and then verified it, and it would fail for some signing algorithms.

The fix creates a new file with the list of JWT algorithms that can be used, and the two operations use that instead.