### PR TITLE
X86-64-Disassembler-JS: Fixed right shift 32 problem

### DIFF
--- a/src/core/vendor/DisassembleX86-64.mjs
+++ b/src/core/vendor/DisassembleX86-64.mjs
@@ -4054,7 +4054,7 @@ function DecodeImmediate( type, BySize, SizeSetting )
     
     //Sign bit adjust.
     
-    if( V32 >= ( n >> 1 ) ) { V32 -= n; }
+    if( V32 >= ( n / 2 ) ) { V32 -= n; }
     
     //Add position.
     


### PR DESCRIPTION
Update the disassembler to the most recent version: https://github.com/Recoskie/X86-64-Disassembler-JS/releases/tag/V2.3