### PR TITLE
Add dockerfile and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:dubnium-buster-slim
+RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
+COPY . /
+ENV NODE_OPTIONS="--max_old_space_size=2048"
+RUN npm install node-sass
+RUN npm install -g grunt-cli
+RUN npm i
+CMD grunt dev   

--- a/README.md
+++ b/README.md
@@ -22,17 +22,6 @@ Cryptographic operations in CyberChef should not be relied upon to provide secur
 
 [A live demo can be found here][1] - have fun!
 
-## Running in Docker
-
-If you would like to run the app locally in docker please follow the steps below:
-
-```
-git clone https://github.com/gchq/CyberChef.git
-cd CyberChef
-docker build --tag cyberchef .
-docker run --rm --name cyberchef -it -p 8080:8080 cyberchef
-```
-
 ## How it works
 
 There are four main areas in CyberChef:
@@ -113,6 +102,17 @@ An installation walkthrough, how-to guides for adding new operations and themes,
  - Push your changes to your fork.
  - Submit a pull request. If you are doing this for the first time, you will be prompted to sign the [GCHQ Contributor Licence Agreement](https://cla-assistant.io/gchq/CyberChef) via the CLA assistant on the pull request. This will also ask whether you are happy for GCHQ to contact you about a token of thanks for your contribution, or about job opportunities at GCHQ.
 
+
+## Running in Docker
+
+If you would like to run the app locally in docker please follow the steps below:
+
+```
+git clone https://github.com/gchq/CyberChef.git
+cd CyberChef
+docker build --tag cyberchef .
+docker run --rm --name cyberchef -it -p 8080:8080 cyberchef
+```
 
 ## Licencing
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Cryptographic operations in CyberChef should not be relied upon to provide secur
 
 [A live demo can be found here][1] - have fun!
 
+## Running in Docker
+
+If you would like to run the app locally in docker please follow the steps below:
+
+```
+git clone https://github.com/gchq/CyberChef.git
+cd CyberChef
+docker build --tag cyberchef .
+docker run --rm --name cyberchef -it -p 8080:8080 cyberchef
+```
 
 ## How it works
 


### PR DESCRIPTION
This adds a working dockerfile to the project and instructions on how to use it in the readme. 

(This could also be used to generate a docker image that can be pushed to Dockerhub for people to use if the project team so desires)