### PR TITLE
Add Extractor to find Bitcoin Addresses in Text

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -369,6 +369,7 @@
             "Extract EXIF",
             "Extract ID3",
             "Extract Files",
+            "Extract Bitcoin Addresses",
             "RAKE"
         ]
     },

--- a/src/core/operations/ExtractBitcoinAddresses.mjs
+++ b/src/core/operations/ExtractBitcoinAddresses.mjs
@@ -38,7 +38,7 @@ class ExtractBitcoinAddresses extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const [displayTotal] = args,
+        const displayTotal = args[0],
             bitcoin = "(?:[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,33}|bc1[a-z0-9]{39,59})";
 
         const bitcoins  = bitcoin;

--- a/src/core/operations/ExtractBitcoinAddresses.mjs
+++ b/src/core/operations/ExtractBitcoinAddresses.mjs
@@ -1,0 +1,56 @@
+/**
+ * @author homer.jonathan [homer.jonathan@gmail.com]
+ * @copyright Crown Copyright 2021
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import { search } from "../lib/Extract.mjs";
+
+/**
+ * Extract Bitcoin addresses operation
+ */
+class ExtractBitcoinAddresses extends Operation {
+
+    /**
+     * ExtractIPAddresses constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Extract Bitcoin Addresses";
+        this.module = "Regex";
+        this.description = "Extracts all Bitcoin addresses in input provided. ";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                "name": "Display total",
+                "type": "boolean",
+                "value": false
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const [displayTotal] = args,
+            bitcoin = "(?:[13]{1}[a-km-zA-HJ-NP-Z1-9]{26,33}|bc1[a-z0-9]{39,59})";
+
+        const bitcoins  = bitcoin;
+
+        if (bitcoins) {
+            const regex = new RegExp(bitcoins, "ig");
+            return search(input, regex, null, displayTotal);
+        } else {
+            return "";
+        }
+    }
+
+}
+
+export default ExtractBitcoinAddresses;

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -163,6 +163,7 @@ import "./tests/Unicode.mjs";
 import "./tests/YARA.mjs";
 import "./tests/ParseCSR.mjs";
 import "./tests/XXTEA.mjs";
+import "./tests/ExtractBitcoinAddresses.mjs";
 
 const testStatus = {
     allTestsPassing: true,

--- a/tests/operations/tests/ExtractBitcoinAddresses.mjs
+++ b/tests/operations/tests/ExtractBitcoinAddresses.mjs
@@ -1,0 +1,44 @@
+/**
+ * extract bitcoin address tests.
+ *
+ * @author homerjonathan [homer.jonathan@gmail.com]
+ * @copyright Crown Copyright 2021
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Extract Bitcoin Addresse",
+        input: "Ransomware I received once! My modest consulting fee is 1650 US Dollars transferred in Bitcoin. Exchange rate at the time of the transfer.\nYou need to send that amount to this wallet: 1HSb4fZHmyNro5LGyjQFpcDwqKjRUqJhh2",
+        expectedOutput: "1HSb4fZHmyNro5LGyjQFpcDwqKjRUqJhh2\n",
+        recipeConfig: [
+            {
+                "op": "Extract Bitcoin Addresses",
+                "args": [false]
+            },
+        ],
+    },
+    {
+        name: "Extract Bitcoin Addresse - Display total",
+        input: "Ransomware I received once! My modest consulting fee is 1650 US Dollars transferred in Bitcoin. Exchange rate at the time of the transfer.\nYou need to send that amount to this wallet: 1HSb4fZHmyNro5LGyjQFpcDwqKjRUqJhh2",
+        expectedOutput: "Total found: 1\n\n1HSb4fZHmyNro5LGyjQFpcDwqKjRUqJhh2\n",
+        recipeConfig: [
+            {
+                "op": "Extract Bitcoin Addresses",
+                "args": [true]
+            },
+        ],
+    },
+    {
+        name: "Extract Mulitple Bitcoin Addresses",
+        input: "1HSb4fZHmyNro5LGyjQFpcDwqKjRUqJhh2 and 17U1BaXwyuxeX2sZyMjC25G8skrZ8mtTdz plus this one 1NGCsGqSdNEKpptQ4DKbJEva59cTSk369o",
+        expectedOutput: "1HSb4fZHmyNro5LGyjQFpcDwqKjRUqJhh2\n17U1BaXwyuxeX2sZyMjC25G8skrZ8mtTdz\n1NGCsGqSdNEKpptQ4DKbJEva59cTSk369o\n",
+        recipeConfig: [
+            {
+                "op": "Extract Bitcoin Addresses",
+                "args": [false]
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
# Bitcoin Addresses

Added an Operation to Extractors to find Bitcoin Addresses in Text.  Since these are very comon in Ransomware it is useful to have the operation.  You can write the Regex expression but I feel that this is a valuable function to add.  The Regex is fairly smart and should discard many invalid Bitcoin Addresses.

Based on the information found here:

http://mokagio.github.io/tech-journal/2014/11/21/regex-bitcoin.html