### PR TITLE
Added 'LZString Decompress' and 'LZString Compress' operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2295,9 +2295,9 @@
       "dev": true
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
@@ -8731,6 +8731,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9014,9 +9019,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.5.tgz",
+      "integrity": "sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -12667,9 +12672,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.10.tgz",
-      "integrity": "sha512-kvvfiVvjGMxeUNB6MyYv5z7vhfFRwbwCXJAeL0/lnbrttBVqcMOnpHUf0X42LrPMR8mMpgapkJMchFH4FSHzNA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "lodash": "^4.17.21",
     "loglevel": "^1.7.1",
     "loglevel-message-prefix": "^3.0.0",
+    "lz-string": "^1.4.4",
     "markdown-it": "^12.2.0",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",

--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -313,7 +313,9 @@
             "Bzip2 Decompress",
             "Bzip2 Compress",
             "Tar",
-            "Untar"
+            "Untar",
+            "LZString Compress",
+            "LZString Decompress"
         ]
     },
     {

--- a/src/core/lib/LZString.mjs
+++ b/src/core/lib/LZString.mjs
@@ -1,0 +1,21 @@
+/**
+ * lz-string exports.
+ *
+ * @author crespyl [peter@crespyl.net]
+ * @copyright Peter Jacobs 2021
+ * @license Apache-2.0
+ */
+
+import LZString from "lz-string";
+
+export const COMPRESSION_OUTPUT_FORMATS = ["default", "UTF16", "Base64"];
+export const COMPRESSION_FUNCTIONS = {
+    "default": LZString.compress,
+    "UTF16":   LZString.compressToUTF16,
+    "Base64":  LZString.compressToBase64,
+};
+export const DECOMPRESSION_FUNCTIONS = {
+    "default": LZString.decompress,
+    "UTF16":   LZString.decompressFromUTF16,
+    "Base64":  LZString.decompressFromBase64,
+};

--- a/src/core/operations/LZStringCompress.mjs
+++ b/src/core/operations/LZStringCompress.mjs
@@ -1,0 +1,55 @@
+/**
+ * @author crespyl [peter@crespyl.net]
+ * @copyright Peter Jacobs 2021
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+
+import {COMPRESSION_OUTPUT_FORMATS, COMPRESSION_FUNCTIONS} from "../lib/LZString.mjs";
+
+/**
+ * LZString Compress operation
+ */
+class LZStringCompress extends Operation {
+
+    /**
+     * LZStringCompress constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "LZString Compress";
+        this.module = "Compression";
+        this.description = "Compress the input with lz-string.";
+        this.infoURL = "https://pieroxy.net/blog/pages/lz-string/index.html";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Compression Format",
+                type: "option",
+                defaultIndex: 0,
+                value: COMPRESSION_OUTPUT_FORMATS
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const compress = COMPRESSION_FUNCTIONS[args[0]];
+        if (compress) {
+            return compress(input);
+        } else {
+            throw new OperationError("Unable to find compression function");
+        }
+    }
+
+}
+
+export default LZStringCompress;

--- a/src/core/operations/LZStringDecompress.mjs
+++ b/src/core/operations/LZStringDecompress.mjs
@@ -1,0 +1,56 @@
+/**
+ * @author crespyl [peter@crespyl.net]
+ * @copyright Peter Jacobs 2021
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+
+import {COMPRESSION_OUTPUT_FORMATS, DECOMPRESSION_FUNCTIONS} from "../lib/LZString.mjs";
+
+/**
+ * LZString Decompress operation
+ */
+class LZStringDecompress extends Operation {
+
+    /**
+     * LZStringDecompress constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "LZString Decompress";
+        this.module = "Compression";
+        this.description = "Decompresses data that was compressed with lz-string.";
+        this.infoURL = "https://pieroxy.net/blog/pages/lz-string/index.html";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Compression Format",
+                type: "option",
+                defaultIndex: 0,
+                value: COMPRESSION_OUTPUT_FORMATS
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const decompress = DECOMPRESSION_FUNCTIONS[args[0]];
+        if (decompress) {
+            return decompress(input);
+        } else {
+            throw new OperationError("Unable to find decompression function");
+        }
+    }
+
+
+}
+
+export default LZStringDecompress;

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -107,6 +107,7 @@ import "./tests/CBORDecode.mjs";
 import "./tests/JA3Fingerprint.mjs";
 import "./tests/JA3SFingerprint.mjs";
 import "./tests/HASSH.mjs";
+import "./tests/LZString.mjs";
 
 
 // Cannot test operations that use the File type yet

--- a/tests/operations/tests/LZString.mjs
+++ b/tests/operations/tests/LZString.mjs
@@ -1,0 +1,33 @@
+/**
+ * LZString tests.
+ *
+ * @author crespyl [peter@crespyl.net]
+ * @copyright Peter Jacobs 2021
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "LZString Compress To Base64",
+        input: "hello world",
+        expectedOutput: "BYUwNmD2AEDukCcwBMg=",
+        recipeConfig: [
+            {
+                "op": "LZString Compress",
+                "args": ["Base64"]
+            }
+        ],
+    },
+    {
+        name: "LZString Decompress From Base64",
+        input: "BYUwNmD2AEDukCcwBMg=",
+        expectedOutput: "hello world",
+        recipeConfig: [
+            {
+                "op": "LZString Decompress",
+                "args": ["Base64"]
+            }
+        ],
+    }
+]);


### PR DESCRIPTION
Fixes #688

I've also made some tweaks that were necessary to get the app and tests running on my machine (adding `--experimental-json-modules` to some node invocations, and `.mjs` extensions in some import statements).  I'm not entirely clear whether the issues I had are just due to my versions of npm/node (7.3.0 and v15.5.1 respectively), so if necessary I can update this PR to limit it to just the new operations and tests.