### PR TITLE
Minor comment/formatting improvements

### DIFF
--- a/src/core/lib/Binary.mjs
+++ b/src/core/lib/Binary.mjs
@@ -19,27 +19,29 @@ import OperationError from "../errors/OperationError.mjs";
  * @returns {string}
  *
  * @example
- * // returns "00010000 00100000 00110000"
+ * // returns "00001010 00010100 00011110"
  * toBinary([10,20,30]);
  *
- * // returns "00010000 00100000 00110000"
- * toBinary([10,20,30], ":");
+ * // returns "00001010:00010100:00011110"
+ * toBinary([10,20,30], "Colon");
+ * 
+ * // returns "1010:10100:11110"
+ * toBinary([10,20,30], "Colon", 0);
  */
 export function toBinary(data, delim="Space", padding=8) {
-    if (!data) return "";
+    if (!data) throw new OperationError("Empty input data enocuntered");
 
     delim = Utils.charRep(delim);
     let output = "";
-
     for (let i = 0; i < data.length; i++) {
-        output += data[i].toString(2).padStart(padding, "0") + delim;
+        output += data[i].toString(2).padStart(padding, "0");
+        if (i !== data.length - 1) output += delim;
     }
-
     if (delim.length) {
-        return output.slice(0, -delim.length);
-    } else {
-        return output;
+        // Remove the delimiter from the end of the string.
+        output = output.slice(0, -delim.length);
     }
+    return output;
 }
 
 
@@ -53,10 +55,10 @@ export function toBinary(data, delim="Space", padding=8) {
  *
  * @example
  * // returns [10,20,30]
- * fromBinary("00010000 00100000 00110000");
+ * fromBinary("00001010 00010100 00011110");
  *
  * // returns [10,20,30]
- * fromBinary("00010000:00100000:00110000", "Colon");
+ * fromBinary("00001010:00010100:00011110", "Colon");
  */
 export function fromBinary(data, delim="Space", byteLen=8) {
     if (byteLen < 1 || Math.round(byteLen) !== byteLen)

--- a/src/core/operations/ToUpperCase.mjs
+++ b/src/core/operations/ToUpperCase.mjs
@@ -37,6 +37,9 @@ class ToUpperCase extends Operation {
      * @returns {string}
      */
     run(input, args) {
+        if (!args || args.length === 0) {
+            throw new OperationException("No capitalization scope was provided.");
+        }
         const scope = args[0];
         if (scope === "All") {
             return input.toUpperCase();

--- a/src/core/operations/ToUpperCase.mjs
+++ b/src/core/operations/ToUpperCase.mjs
@@ -38,23 +38,23 @@ class ToUpperCase extends Operation {
      */
     run(input, args) {
         const scope = args[0];
-
-        switch (scope) {
-            case "Word":
-                return input.replace(/(\b\w)/gi, function(m) {
-                    return m.toUpperCase();
-                });
-            case "Sentence":
-                return input.replace(/(?:\.|^)\s*(\b\w)/gi, function(m) {
-                    return m.toUpperCase();
-                });
-            case "Paragraph":
-                return input.replace(/(?:\n|^)\s*(\b\w)/gi, function(m) {
-                    return m.toUpperCase();
-                });
-            case "All": /* falls through */
-            default:
-                return input.toUpperCase();
+        if (scope === "All") {
+            return input.toUpperCase();
+        }
+        const scopeRegex = {
+            "Word": /(\b\w)/gi,
+            "Sentence": /(?:\.|^)\s*(\b\w)/gi,
+            "Paragraph": /(?:\n|^)\s*(\b\w)/gi
+        }[ scope ];
+        if (scopeRegex !== undefined) {
+            // Use the regexes to capitalize the input.
+            return input.replace(scopeRegex, function(m) {
+                return m.toUpperCase();
+            });
+        }
+        else {
+            // The selected scope was invalid.
+            throw new OperationError("Unrecognized capitalization scope");
         }
     }
 


### PR DESCRIPTION
In ``Binary.mjs`` the examples for ``toBinary`` and ``fromBinary`` seem to have incorrect return values.

In the ``toBinary`` function, I've added replaced the ``return ""`` with an exception to make debugging clearer.

The ``ToUpperCase`` operation has been restructured so that each scope (e.g "Word", "Sentence", "Paragraph") has its regex contained within a dictionary, this should make extending the functionality/modifying individual regular expressions easier (and exception-throwing has been added in the instance of an invalid scope being provided).