### PR TITLE
Added algorithm-selection to JWT Verification (#624)

### DIFF
--- a/src/core/operations/JWTVerify.mjs
+++ b/src/core/operations/JWTVerify.mjs
@@ -26,7 +26,7 @@ class JWTVerify extends Operation {
         this.infoURL = "https://wikipedia.org/wiki/JSON_Web_Token";
         this.inputType = "string";
         this.outputType = "JSON";
-        let algOptions = JWT_ALGORITHMS;
+        const algOptions = JWT_ALGORITHMS;
         algOptions.push("Any");
         this.args = [
             {

--- a/src/core/operations/JWTVerify.mjs
+++ b/src/core/operations/JWTVerify.mjs
@@ -49,18 +49,15 @@ class JWTVerify extends Operation {
      */
     run(input, args) {
         const [key, alg] = args;
+        let algos = [];
         switch (alg) {
             case "Any":
-                const algos = JWT_ALGORITHMS;
+                algos = JWT_ALGORITHMS;
                 break;
             case "None":
-                const algos = [ "none" ];
+                algos.push("none");
             default:
-                const algIndex = JWT_ALGORITHMS.indexOf(alg);
-                if (algIndex === -1) {
-                    throw new OperationError("The JWT verification algorithm provided is not supported.");
-                }
-                const algos = JWT_ALGORITHMS[];
+                algos.push(alg);
                 break;
         }
 

--- a/src/core/operations/JWTVerify.mjs
+++ b/src/core/operations/JWTVerify.mjs
@@ -26,8 +26,8 @@ class JWTVerify extends Operation {
         this.infoURL = "https://wikipedia.org/wiki/JSON_Web_Token";
         this.inputType = "string";
         this.outputType = "JSON";
-        let algOptions = JWT_ALGORITHMS.slice(0, JWT_ALGORITHMS.length - 1);
-        algOptions.push("Any");
+        this.algOptions = JWT_ALGORITHMS;
+        this.algOptions.push("Any");
         this.args = [
             {
                 name: "Public/Secret Key",
@@ -37,7 +37,7 @@ class JWTVerify extends Operation {
             {
                 name: "Algorithm",
                 type: "option",
-                value: algOptions
+                value: this.algOptions
             }
         ];
     }

--- a/src/core/operations/JWTVerify.mjs
+++ b/src/core/operations/JWTVerify.mjs
@@ -26,8 +26,8 @@ class JWTVerify extends Operation {
         this.infoURL = "https://wikipedia.org/wiki/JSON_Web_Token";
         this.inputType = "string";
         this.outputType = "JSON";
-        this.algOptions = JWT_ALGORITHMS;
-        this.algOptions.push("Any");
+        let algOptions = JWT_ALGORITHMS;
+        algOptions.push("Any");
         this.args = [
             {
                 name: "Public/Secret Key",
@@ -37,7 +37,7 @@ class JWTVerify extends Operation {
             {
                 name: "Algorithm",
                 type: "option",
-                value: this.algOptions
+                value: algOptions
             }
         ];
     }
@@ -56,6 +56,7 @@ class JWTVerify extends Operation {
                 break;
             case "None":
                 algos.push("none");
+                break;
             default:
                 algos.push(alg);
                 break;

--- a/src/core/operations/JWTVerify.mjs
+++ b/src/core/operations/JWTVerify.mjs
@@ -35,7 +35,7 @@ class JWTVerify extends Operation {
                 value: "secret"
             },
             {
-                name: "Algorithm",
+                name: "Signing algorithm",
                 type: "option",
                 value: algOptions
             }

--- a/src/core/operations/JWTVerify.mjs
+++ b/src/core/operations/JWTVerify.mjs
@@ -26,12 +26,19 @@ class JWTVerify extends Operation {
         this.infoURL = "https://wikipedia.org/wiki/JSON_Web_Token";
         this.inputType = "string";
         this.outputType = "JSON";
+        let algOptions = JWT_ALGORITHMS.slice(0, JWT_ALGORITHMS.length - 1);
+        algOptions.push("Any");
         this.args = [
             {
                 name: "Public/Secret Key",
                 type: "text",
                 value: "secret"
             },
+            {
+                name: "Algorithm",
+                type: "option",
+                value: algOptions
+            }
         ];
     }
 
@@ -41,9 +48,21 @@ class JWTVerify extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const [key] = args;
-        const algos = JWT_ALGORITHMS;
-        algos[algos.indexOf("None")] = "none";
+        const [key, alg] = args;
+        switch (alg) {
+            case "Any":
+                const algos = JWT_ALGORITHMS;
+                break;
+            case "None":
+                const algos = [ "none" ];
+            default:
+                const algIndex = JWT_ALGORITHMS.indexOf(alg);
+                if (algIndex === -1) {
+                    throw new OperationError("The JWT verification algorithm provided is not supported.");
+                }
+                const algos = JWT_ALGORITHMS[];
+                break;
+        }
 
         try {
             const verified = jwt.verify(input, key, { algorithms: algos });


### PR DESCRIPTION
This feature should resolve issue #624 which describes the need for a way to verify the JWT algorithm in addition to its signature/key, no other functionality is adjusted.
Once compiled, use [this](http://localhost:8080/#recipe=JWT_Sign('cc-secret','HS256')JWT_Verify('cc-secret','HS256')&input=eyJIZWxsbyI6IldvcmxkIn0) link to sign and subsequently verify a JWT with various options.