### PR TITLE
Added code/operation for 'HTML To Text'

### DIFF
--- a/src/core/operations/HTMLToText.mjs
+++ b/src/core/operations/HTMLToText.mjs
@@ -36,14 +36,14 @@ class HTMLToText extends Operation {
         // TODO: Add blacklisted tags via args.
         // TODO: Extract from HTML comments.
         let output = "";
-        const blacklistedTags = [ "script", "style" ];
-        const tagRegex = /<\w+>[\s?!\-_().,\/#{}*"£$%^&;:a-z]*/gis;
+        const blacklistedTags = ["script", "style"];
+        const tagRegex = /<\w+>[\s?!\-_().,/#{}*"£$%^&;:a-z]*/gis;
         const tagMatches = input.match(tagRegex);
         tagMatches.forEach((iterativeMatch) => {
-            const closingTagOffset = iterativeMatch.indexOf('>');
+            const closingTagOffset = iterativeMatch.indexOf(">");
             const tag = iterativeMatch.substring(1, closingTagOffset);
             for (let i = 0; i < blacklistedTags.length; i++) {
-                if (tag == blacklistedTags[i]) {
+                if (tag === blacklistedTags[i]) {
                     return; // This is why a forEach(...) loop couldn't be used for this nested one.
                 }
             }

--- a/src/core/operations/HTMLToText.mjs
+++ b/src/core/operations/HTMLToText.mjs
@@ -33,7 +33,24 @@ class HTMLToText extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        return input;
+        // TODO: Add blacklisted tags via args.
+        // TODO: Extract from HTML comments.
+        let output = "";
+        const blacklistedTags = [ "script", "style" ];
+        const tagRegex = /<\w+>[\s?!\-_().,\/#{}*"£$%^&;:a-z]*/gis;
+        const tagMatches = input.match(tagRegex);
+        tagMatches.forEach((iterativeMatch) => {
+            const closingTagOffset = iterativeMatch.indexOf('>');
+            const tag = iterativeMatch.substring(1, closingTagOffset);
+            for (let i = 0; i < blacklistedTags.length; i++) {
+                if (tag == blacklistedTags[i]) {
+                    return; // This is why a forEach(...) loop couldn't be used for this nested one.
+                }
+            }
+            // The tag has been validated, extract all text.
+            output += iterativeMatch.substring(closingTagOffset + 1);
+        });
+        return output;
     }
 
 }

--- a/src/core/operations/HTMLToText.mjs
+++ b/src/core/operations/HTMLToText.mjs
@@ -1,6 +1,7 @@
 /**
  * @author tlwr [toby@toby.codes]
  * @author Matt C [me@mitt.dev]
+ * @author Michael Rowley [michaellrowley@protonmail.com]
  * @copyright Crown Copyright 2019
  * @license Apache-2.0
  */
@@ -33,8 +34,6 @@ class HTMLToText extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        // TODO: Add blacklisted tags via args.
-        // TODO: Extract from HTML comments.
         let output = "";
         const blacklistedTags = ["script", "style"];
         const tagRegex = /<\w+>[\s?!\-_().,/#{}*"£$%^&;:a-z]*/gis;
@@ -43,7 +42,8 @@ class HTMLToText extends Operation {
             const closingTagOffset = iterativeMatch.indexOf(">");
             const tag = iterativeMatch.substring(1, closingTagOffset);
             for (let i = 0; i < blacklistedTags.length; i++) {
-                if (tag === blacklistedTags[i]) {
+                if (tag === blacklistedTags[i] ||
+                    tag.split(' ')[0] == blacklistedTags[i]) {
                     return; // This is why a forEach(...) loop couldn't be used for this nested one.
                 }
             }


### PR DESCRIPTION
I don't know how it was approved/merged before but there was a 'HTML To Text' operation with no functional code (the ``run`` function simply returned the input) - this commit brings functional code to the operation but there are some flaws/things that need to be improved (HTML comment handling and inline CSS).