### PR TITLE
Add min size to Extract Files

### DIFF
--- a/src/core/operations/ExtractFiles.mjs
+++ b/src/core/operations/ExtractFiles.mjs
@@ -38,7 +38,7 @@ class ExtractFiles extends Operation {
                 <li>
                 ${supportedExts.join("</li><li>")}
                 </li>
-            </ul>`;
+            </ul>Minimum File Size can be used to prune small false positives.`;
         this.infoURL = "https://forensicswiki.xyz/wiki/index.php?title=File_Carving";
         this.inputType = "ArrayBuffer";
         this.outputType = "List<File>";
@@ -54,6 +54,11 @@ class ExtractFiles extends Operation {
                 name: "Ignore failed extractions",
                 type: "boolean",
                 value: true
+            },
+            {
+                name: "Minimum File Size",
+                type: "number",
+                value: 0
             }
         ]);
     }
@@ -66,6 +71,7 @@ class ExtractFiles extends Operation {
     run(input, args) {
         const bytes = new Uint8Array(input),
             categories = [],
+            minSize = args.pop(1),
             ignoreFailedExtractions = args.pop(1);
 
         args.forEach((cat, i) => {
@@ -80,7 +86,9 @@ class ExtractFiles extends Operation {
         const errors = [];
         detectedFiles.forEach(detectedFile => {
             try {
-                files.push(extractFile(bytes, detectedFile.fileDetails, detectedFile.offset));
+                let file;
+                if ((file = extractFile(bytes, detectedFile.fileDetails, detectedFile.offset)).size >= minSize)
+                    files.push(file);
             } catch (err) {
                 if (!ignoreFailedExtractions && err.message.indexOf("No extraction algorithm available") < 0) {
                     errors.push(


### PR DESCRIPTION
Added a minimum size argument to Extract Files to prune small false positives. 
It defaults to 0 to remain as the default behaviour. 