### PR TITLE
Fixed XSS in JPath expression operation

### DIFF
--- a/src/core/operations/JPathExpression.mjs
+++ b/src/core/operations/JPathExpression.mjs
@@ -49,6 +49,14 @@ class JPathExpression extends Operation {
         let results,
             obj;
 
+        // Split the string by literal quotes
+        const quoteSplit = query.split(/(?<=[^\\])"/);
+        for (let i = 0; i < quoteSplit.length; i++) {
+            // Only check the text that isn't surrounded by quotes.
+            if (i % 2 === 0 && quoteSplit[i].match(/\[\??\(/))
+                throw new OperationError("Query contains unsafe expression.");
+        }
+
         try {
             obj = JSON.parse(input);
         } catch (err) {

--- a/tests/operations/tests/Code.mjs
+++ b/tests/operations/tests/Code.mjs
@@ -311,6 +311,17 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "JPath Expression: Script-based expression",
+        input: "[{}]",
+        recipeConfig: [
+            {
+                "op": "JPath expression",
+                "args": ["$..[?(({__proto__:[].constructor}).constructor(\"self.postMessage({action:'bakeComplete',data:{bakeId:1,dish:{type:1,value:''},duration:1,error:false,id:undefined,inputNum:2,progress:1,result:'<iframe/onload=debugger>',type: 'html'}});\")();)]", "\n"]
+            }
+        ],
+        expectedOutput: "Query contains unsafe expression."
+    },
+    {
         name: "CSS selector",
         input: '<div id="test">\n<p class="a">hello</p>\n<p>world</p>\n<p class="a">again</p>\n</div>',
         expectedOutput: '<p class="a">hello</p>\n<p class="a">again</p>',

--- a/tests/operations/tests/Code.mjs
+++ b/tests/operations/tests/Code.mjs
@@ -268,49 +268,6 @@ TestRegister.addTests([
         ],
     },
     {
-        name: "JPath Expression: All elements in array with property",
-        input: JSON.stringify(JSON_TEST_DATA),
-        expectedOutput: [
-            "{\"category\":\"fiction\",\"author\":\"Herman Melville\",\"title\":\"Moby Dick\",\"isbn\":\"0-553-21311-3\",\"price\":8.99}",
-            "{\"category\":\"fiction\",\"author\":\"J. R. R. Tolkien\",\"title\":\"The Lord of the Rings\",\"isbn\":\"0-395-19395-8\",\"price\":22.99}"
-        ].join("\n"),
-        recipeConfig: [
-            {
-                "op": "JPath expression",
-                "args": ["$..book[?(@.isbn)]", "\n"]
-            }
-        ],
-    },
-    {
-        name: "JPath Expression: All elements in array which meet condition",
-        input: JSON.stringify(JSON_TEST_DATA),
-        expectedOutput: [
-            "{\"category\":\"fiction\",\"author\":\"Evelyn Waugh\",\"title\":\"Sword of Honour\",\"price\":12.99}",
-            "{\"category\":\"fiction\",\"author\":\"Herman Melville\",\"title\":\"Moby Dick\",\"isbn\":\"0-553-21311-3\",\"price\":8.99}",
-            "{\"category\":\"fiction\",\"author\":\"J. R. R. Tolkien\",\"title\":\"The Lord of the Rings\",\"isbn\":\"0-395-19395-8\",\"price\":22.99}"
-        ].join("\n"),
-        recipeConfig: [
-            {
-                "op": "JPath expression",
-                "args": ["$..book[?(@.price<30 && @.category==\"fiction\")]", "\n"]
-            }
-        ],
-    },
-    {
-        name: "JPath Expression: All elements in object",
-        input: JSON.stringify(JSON_TEST_DATA),
-        expectedOutput: [
-            "{\"category\":\"reference\",\"author\":\"Nigel Rees\",\"title\":\"Sayings of the Century\",\"price\":8.95}",
-            "{\"category\":\"fiction\",\"author\":\"Herman Melville\",\"title\":\"Moby Dick\",\"isbn\":\"0-553-21311-3\",\"price\":8.99}"
-        ].join("\n"),
-        recipeConfig: [
-            {
-                "op": "JPath expression",
-                "args": ["$..book[?(@.price<10)]", "\n"]
-            }
-        ],
-    },
-    {
         name: "JPath Expression: Script-based expression",
         input: "[{}]",
         recipeConfig: [


### PR DESCRIPTION
This pull should fix issue #1318 - I can confirm that it mitigates the exploit that po6ix provided but I don't have enough experience in JPath to confirm that it protects from all future variations of this.
A more in-depth explanation of this mitigation is available [here](https://github.com/gchq/CyberChef/issues/1318#issuecomment-1214335645).