### PR TITLE
Overrides some bootstrap css values to make dropdowns look normal on …

### DIFF
--- a/src/web/stylesheets/utils/_overrides.css
+++ b/src/web/stylesheets/utils/_overrides.css
@@ -93,7 +93,8 @@ select.form-control:not([size]):not([multiple]), select.custom-file-control:not(
 [class^="bmd-label"],
 .form-control,
 .is-focused .form-control {
-    color: var(--primary-font-colour);
+    color: var(--primary-font-colour) !important;
+    background-color: var(--primary-background-colour) !important;
 }
 
 .form-control,


### PR DESCRIPTION
…firefox on windows

Bootstrap sets dropdown colours to default values, for some reason
only on gecko based browsers (firefox) these default values sometimes
override our theme. This commit adds `!important` to enforce our
theme colours.

see #1406 for more info