### PR TITLE
feat: Remove operation by simple click button

### DIFF
--- a/src/web/HTMLOperation.mjs
+++ b/src/web/HTMLOperation.mjs
@@ -85,6 +85,7 @@ class HTMLOperation {
         <div class="recip-icons">
             <i class="material-icons breakpoint" title="Set breakpoint" break="false">pause</i>
             <i class="material-icons disable-icon" title="Disable operation" disabled="false">not_interested</i>
+            <i class="material-icons remove" title="Remove operation" disabled="false">close</i>
         </div>
         <div class="clearfix">&nbsp;</div>`;
 

--- a/src/web/Manager.mjs
+++ b/src/web/Manager.mjs
@@ -137,6 +137,7 @@ class Manager {
         this.addDynamicListener(".arg[type=checkbox], .arg[type=radio], select.arg", "change", this.recipe.ingChange, this.recipe);
         this.addDynamicListener(".disable-icon", "click", this.recipe.disableClick, this.recipe);
         this.addDynamicListener(".breakpoint", "click", this.recipe.breakpointClick, this.recipe);
+        this.addDynamicListener(".remove", "click", this.recipe.removeClick, this.recipe);
         this.addDynamicListener("#rec-list li.operation", "dblclick", this.recipe.operationDblclick, this.recipe);
         this.addDynamicListener("#rec-list li.operation > div", "dblclick", this.recipe.operationChildDblclick, this.recipe);
         this.addDynamicListener("#rec-list .dropdown-menu.toggle-dropdown a", "click", this.recipe.dropdownToggleClick, this.recipe);

--- a/src/web/waiters/RecipeWaiter.mjs
+++ b/src/web/waiters/RecipeWaiter.mjs
@@ -263,6 +263,19 @@ class RecipeWaiter {
 
 
     /**
+     * Handler for remove click events.
+     * Updates the icon status.
+     *
+     * @fires Manager#statechange
+     * @param {event} e
+     */
+    removeClick(e) {
+        e.target.parentNode.parentNode.remove(e)
+        this.opRemove(e);
+    }
+
+
+    /**
      * Handler for operation doubleclick events.
      * Removes the operation from the recipe and auto bakes.
      *


### PR DESCRIPTION
As a new user, It took me a while to figure that I have to **doubleClick** or **dragLeave** to remove an operation from the recipe. So i added a simple `x` button to each operation to make if more convenient at first glance to remove an operation. Hope this helps.