### PR TITLE
Added NTLM operation

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -376,7 +376,8 @@
             "CRC-8 Checksum",
             "CRC-16 Checksum",
             "CRC-32 Checksum",
-            "TCP/IP Checksum"
+            "TCP/IP Checksum",
+            "NTLM"
         ]
     },
     {

--- a/src/core/operations/NTLM.mjs
+++ b/src/core/operations/NTLM.mjs
@@ -1,0 +1,46 @@
+/**
+ * @author brun0ne [brunonblok@gmail.com]
+ * @copyright Crown Copyright 2022
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+
+import cptable from "codepage";
+import {runHash} from "../lib/Hash.mjs";
+
+/**
+ * NTLM operation
+ */
+class NTLM extends Operation {
+
+    /**
+     * NTLM constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "NTLM";
+        this.module = "Crypto";
+        this.description = "Performs NTLM hashing on the input. It works by running MD4 on UTF16LE-encoded input. NTLM hashes are considered weak because they can be brute-forced very easily with modern hardware.";
+        this.infoURL = "https://en.wikipedia.org/wiki/NT_LAN_Manager";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const format = 1200;
+        const encoded = cptable.utils.encode(format, input);
+        const hashed = runHash("md4", encoded);
+
+        return hashed.toUpperCase();
+    }
+}
+
+export default NTLM;

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -121,7 +121,7 @@ import "./tests/Subsection.mjs";
 import "./tests/CaesarBoxCipher.mjs";
 import "./tests/LS47.mjs";
 import "./tests/LZString.mjs";
-
+import "./tests/NTLM.mjs";
 
 // Cannot test operations that use the File type yet
 // import "./tests/SplitColourChannels.mjs";

--- a/tests/operations/tests/NTLM.mjs
+++ b/tests/operations/tests/NTLM.mjs
@@ -1,0 +1,22 @@
+/**
+ * NTLM test.
+ *
+ * @author brun0ne [brunonblok@gmail.com]
+ * @copyright Crown Copyright 2022
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "NTLM Hashing",
+        input: "QWERTYUIOPASDFGHJKLZXCVBNM1234567890!@#$%^&*()_+.,?/",
+        expectedOutput: "C5FA1C40E55734A8E528DBFE21766D23",
+        recipeConfig: [
+            {
+                op: "NTLM",
+                args: [],
+            },
+        ],
+    }
+]);


### PR DESCRIPTION
I often found myself using online tools for getting NTLM hashes while working with Windows networks or doing sandboxes like HackTheBox. It would be nice to have it as one operation in CyberChef, so I implemented it.

It performs MD4 on UTF16LE-encoded input and makes it uppercase because that's how it appears most often.
