### PR TITLE
Added escape sequence "\a" (audible bell, 0x07) to Utils.parseEscaped…

### DIFF
--- a/src/core/Utils.mjs
+++ b/src/core/Utils.mjs
@@ -206,7 +206,7 @@ class Utils {
      * Utils.parseEscapedChars("\\n");
      */
     static parseEscapedChars(str) {
-        return str.replace(/\\([bfnrtv'"]|[0-3][0-7]{2}|[0-7]{1,2}|x[\da-fA-F]{2}|u[\da-fA-F]{4}|u\{[\da-fA-F]{1,6}\}|\\)/g, function(m, a) {
+        return str.replace(/\\([abfnrtv'"]|[0-3][0-7]{2}|[0-7]{1,2}|x[\da-fA-F]{2}|u[\da-fA-F]{4}|u\{[\da-fA-F]{1,6}\}|\\)/g, function(m, a) {
             switch (a[0]) {
                 case "\\":
                     return "\\";
@@ -219,6 +219,8 @@ class Utils {
                 case "6":
                 case "7":
                     return String.fromCharCode(parseInt(a, 8));
+                case "a":
+                    return String.fromCharCode(7);
                 case "b":
                     return "\b";
                 case "t":

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -119,6 +119,7 @@ import "./tests/SIGABA.mjs";
 import "./tests/ELFInfo.mjs";
 import "./tests/Subsection.mjs";
 import "./tests/CaesarBoxCipher.mjs";
+import "./tests/UnescapeString.mjs";
 import "./tests/LS47.mjs";
 import "./tests/LZString.mjs";
 

--- a/tests/operations/tests/UnescapeString.mjs
+++ b/tests/operations/tests/UnescapeString.mjs
@@ -1,0 +1,55 @@
+/**
+ * UnescapeString tests.
+ *
+ * @copyright Crown Copyright 2022
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "UnescapeString: escape sequences",
+        input: "\\a\\b\\f\\n\\r\\t\\v\\'\\\"",
+        expectedOutput: String.fromCharCode(0x07, 0x08, 0x0c, 0x0a, 0x0d, 0x09,
+            0x0b, 0x27, 0x22),
+        recipeConfig: [
+            {
+                op: "Unescape string",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "UnescapeString: octals",
+        input: "\\0\\01\\012\\1\\12",
+        expectedOutput: String.fromCharCode(0, 1, 10, 1, 10),
+        recipeConfig: [
+            {
+                op: "Unescape string",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "UnescapeString: hexadecimals",
+        input: "\\x00\\xAA\\xaa",
+        expectedOutput: String.fromCharCode(0, 170, 170),
+        recipeConfig: [
+            {
+                op: "Unescape string",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "UnescapeString: unicode",
+        input: "\\u0061\\u{0062}",
+        expectedOutput: "ab",
+        recipeConfig: [
+            {
+                op: "Unescape string",
+                args: [],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
…Chars().

The sequence is part of C and C++ standards, as well as protocol buffers encoding.

- https://en.wikipedia.org/wiki/Escape_sequences_in_C
- https://en.cppreference.com/w/cpp/language/escape
- https://developers.google.com/protocol-buffers/docs/text-format-spec#string