### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,10 +10,10 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set node version
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '18.x'
 
@@ -47,7 +47,7 @@ jobs:
 
     - name: Deploy to GitHub Pages
       if: success() && github.ref == 'refs/heads/master'
-      uses: crazy-max/ghaction-github-pages@v2
+      uses: crazy-max/ghaction-github-pages@v3
       with:
         target_branch: gh-pages
         build_dir: ./build/prod

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -9,10 +9,10 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set node version
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '18.x'
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -10,10 +10,10 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set node version
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '18.x'
 


### PR DESCRIPTION
This PR bumps GitHub Actions to their latest major versions, which now use Node 16 internally instead of Node 12 (EOL as of end of April 2022, no longer receives security updates):

-   Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
-   Changelog for `crazy-max/ghaction-github-pages` can be [found here](https://github.com/crazy-max/ghaction-github-pages/blob/dev/CHANGELOG.md)
-   Changelog for `github/codeql-action` actions can be [found here](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)
- Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)
