### PR TITLE
Removal of unnecessary error checking routine

### DIFF
--- a/src/core/operations/RawInflate.mjs
+++ b/src/core/operations/RawInflate.mjs
@@ -83,24 +83,6 @@ class RawInflate extends Operation {
             }),
             result = new Uint8Array(inflate.decompress());
 
-        // Raw Inflate sometimes messes up and returns nonsense like this:
-        // ]....]....]....]....]....]....]....]....]....]....]....]....]....]...
-        // e.g. Input data of [8b, 1d, dc, 44]
-        // Look for the first two square brackets:
-        if (result.length > 158 && result[0] === 93 && result[5] === 93) {
-            // If the first two square brackets are there, check that the others
-            // are also there. If they are, throw an error. If not, continue.
-            let valid = false;
-            for (let i = 0; i < 155; i += 5) {
-                if (result[i] !== 93) {
-                    valid = true;
-                }
-            }
-
-            if (!valid) {
-                throw new OperationError("Error: Unable to inflate data");
-            }
-        }
         // This seems to be the easiest way...
         return result.buffer;
     }


### PR DESCRIPTION
This situation occurs because the dependancy (zlibjs/bin/rawinflate.min.js) doesn't do a sanity check on distances going back farther than the current buffer.

For example:
DEFLATE data of '123' and then a length of 9 going back a distance of 6 ASCIIHEX: 333432869300

! infgen 3.0 output
!
last			! 1
fixed			! 01
literal '1		! 10000110
literal '2		! 01000110
literal '3		! 11000110
match 9 6		! 1 00100 1110000
infgen warning: distance too far back (6/3)
end			! 0000000
			! 0

We only have 3 characters, we shouldn't be able to seek 6 characters back. But rawinflate.min.js doesn't check for this like the infgen debug tool (and others) would. So CyberChef would happily provide this as the result: 123...123...
Where the dots are just nulls of likley empty memory preceding the actual buffer

So with the example in this source
// e.g. Input data of [8b, 1d, dc, 44]

last			! 1
fixed			! 01
literal ']		! 10110001
match 158 5		! 0 00100 11011 10000011
infgen warning: distance too far back (5/1)

This means we have a literal ']' and then we are asking for 158 more characters and to find them a distance of 5 back. This explains why the ']', why it repeats every 5, and why it is a length > 158.

This code should just be removed; it isn't justified. Being that this issue is a lack of sanity checking in a dependancy, and that this routine only catches the symptom of one of the nearly unlimited edge cases like this, AND it could filter out correct inputs, such as a recipe of this as input to RAWDEFLATE ]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX[]OMG[]HAX Then getting an error with the INFLATE even though the input is actually valid.