### PR TITLE
Put required margin for QR Code by default

### DIFF
--- a/src/core/operations/GenerateQRCode.mjs
+++ b/src/core/operations/GenerateQRCode.mjs
@@ -44,7 +44,7 @@ class GenerateQRCode extends Operation {
             {
                 "name": "Margin (num modules)",
                 "type": "number",
-                "value": 2,
+                "value": 4,
                 "min": 0
             },
             {


### PR DESCRIPTION
It is specified that a margin of 4 or more modules is required for QR Code.

[Point for determining the code area | QRcode.com | DENSO WAVE](https://www.qrcode.com/en/howto/code.html)

The default setting of "Generate QR Code" operation was adding only a margin of 2 modules, so I changed this to 4 modules to meet the specification.

---

QR Code is registered trademark of [DENSO WAVE INCORPORATED](http://www.denso-wave.com/en/).