### PR TITLE
Fix the name of the option used in "Parse ASN.1 hex string"

### DIFF
--- a/src/core/operations/ParseASN1HexString.mjs
+++ b/src/core/operations/ParseASN1HexString.mjs
@@ -46,7 +46,7 @@ class ParseASN1HexString extends Operation {
     run(input, args) {
         const [index, truncateLen] = args;
         return r.ASN1HEX.dump(input.replace(/\s/g, ""), {
-            "ommitLongOctet": truncateLen
+            "ommit_long_octet": truncateLen
         }, index);
     }
 


### PR DESCRIPTION
Example input:

```
-----BEGIN PUBLIC KEY-----
MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDH0ZadSjjtAOHcy5aweF8U4iJr
Pn/h2c/0a2ZEEretWbmzpQ0QuUE+jeLVZnPnFbC6KnqeZ3lIK8+iuVAyjGk9po3e
uP/pSsBin0sc9MMez2OYfOlMaShsqY9ciyKRt+Z56nmP17ssBEHJkoEV86R7hrwu
YbYbLRC2a3/CgG6PNQIDAQAB
-----END PUBLIC KEY-----
```

Recipe:

[PEM to Hex, Parse ASN.1 hex string - CyberChef](https://gchq.github.io/CyberChef/#recipe=PEM_to_Hex%28%29Parse_ASN.1_hex_string%280,32%29&input=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FESDBaYWRTamp0QU9IY3k1YXdlRjhVNGlKcgpQbi9oMmMvMGEyWkVFcmV0V2JtenBRMFF1VUUramVMVlpuUG5GYkM2S25xZVozbElLOCtpdVZBeWpHazlwbzNlCnVQL3BTc0JpbjBzYzlNTWV6Mk9ZZk9sTWFTaHNxWTljaXlLUnQrWjU2bm1QMTdzc0JFSEprb0VWODZSN2hyd3UKWWJZYkxSQzJhMy9DZ0c2UE5RSURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ)

Output of current version:

```
SEQUENCE
  SEQUENCE
    ObjectIdentifier rsaEncryption (1 2 840 113549 1 1 1)
    NULL
  BITSTRING, encapsulates
    SEQUENCE
      INTEGER 00c7d1969d4a38ed00e1dccb96b0785f14e2226b3e7fe1d9cff46b664412b7ad59b9b3a50d10b9413e8de2d56673e715b0ba2a7a9e6779482bcfa2b950328c693da68ddeb8ffe94ac0629f4b1cf4c31ecf63987ce94c69286ca98f5c8b2291b7e679ea798fd7bb2c0441c9928115f3a47b86bc2e61b61b2d10b66b7fc2806e8f35..(total 129bytes)..00c7d1969d4a38ed00e1dccb96b0785f14e2226b3e7fe1d9cff46b664412b7ad59b9b3a50d10b9413e8de2d56673e715b0ba2a7a9e6779482bcfa2b950328c693da68ddeb8ffe94ac0629f4b1cf4c31ecf63987ce94c69286ca98f5c8b2291b7e679ea798fd7bb2c0441c9928115f3a47b86bc2e61b61b2d10b66b7fc2806e8f35
      INTEGER 010001..(total 3bytes)..010001
```

This output looks weird because

* The same data is appearing twice for each INTEGER element, before and after "..(total ?bytes).."
* The 129-byte data is not truncated while "Truncate octet strings longer than" is set to 32

I found that the option "Truncate octet strings longer than" is not working because wrong name of an option is used in the implementation of "Parse ASN.1 hex string".

Checking [the source code of `jsrsasign`](https://github.com/kjur/jsrsasign/blob/c665ebcebc62cc7e55ffadbf2efec7ef89279b00/src/asn1hex-1.1.js#L861), I found that the correct option name should be `ommit_long_octet`, not `ommitLongOctet`, which is currently used.

I changed the name of option to use and got this output:

```
SEQUENCE
  SEQUENCE
    ObjectIdentifier rsaEncryption (1 2 840 113549 1 1 1)
    NULL
  BITSTRING, encapsulates
    SEQUENCE
      INTEGER 00c7d1969d4a38ed00e1dccb96b0785f..(total 129bytes)..86bc2e61b61b2d10b66b7fc2806e8f35
      INTEGER 010001
```

This output looks improved because:

* The 129-byte element is truncated according to the option Truncate octet strings longer than"
* The 3-byte element is not truncated and no "(total ?bytes)" is inserted
* There are no duplicate data displaying for the INTEGER elements
