### PR TITLE
Have "Parse X.509 certificate" emit user-friendly message on certificate load error

### DIFF
--- a/src/core/operations/ParseX509Certificate.mjs
+++ b/src/core/operations/ParseX509Certificate.mjs
@@ -57,23 +57,29 @@ class ParseX509Certificate extends Operation {
         const cert = new r.X509(),
             inputFormat = args[0];
 
-        switch (inputFormat) {
-            case "DER Hex":
-                input = input.replace(/\s/g, "");
-                cert.readCertHex(input);
-                break;
-            case "PEM":
-                cert.readCertPEM(input);
-                break;
-            case "Base64":
-                cert.readCertHex(toHex(fromBase64(input, null, "byteArray"), ""));
-                break;
-            case "Raw":
-                cert.readCertHex(toHex(Utils.strToByteArray(input), ""));
-                break;
-            default:
-                throw "Undefined input format";
+        let undefinedInputFormat = false;
+        try {
+            switch (inputFormat) {
+                case "DER Hex":
+                    input = input.replace(/\s/g, "");
+                    cert.readCertHex(input);
+                    break;
+                case "PEM":
+                    cert.readCertPEM(input);
+                    break;
+                case "Base64":
+                    cert.readCertHex(toHex(fromBase64(input, null, "byteArray"), ""));
+                    break;
+                case "Raw":
+                    cert.readCertHex(toHex(Utils.strToByteArray(input), ""));
+                    break;
+                default:
+                    undefinedInputFormat = true;
+            }
+        } catch (e) {
+            throw "Certificate load error (non-certificate input?)";
         }
+        if (undefinedInputFormat) throw "Undefined input format";
 
         const sn = cert.getSerialNumberHex(),
             issuer = cert.getIssuer(),


### PR DESCRIPTION
Sample input (generated exclusively for this demo):

```
-----BEGIN RSA PRIVATE KEY-----
MIGqAgEAAiEAqEyL5PMVCPjoKZyZfA1bEV7SaMvgcYByNbqb7kt/mGcCAwEAAQIh
AIdRdLHTWThrmY/LoAUEYBFbIi+fNq1b/1yBybRIgcNBAhEA2sdJBnhagHAnRu1j
MB1RNwIRAMTuq6v/HrYtwjryP1i5SlECEGq3iwd87ah5DK+sXBW8N0ECECmHGvR+
K//GznqXsvwGtsECEFrG+GuzNG2Un/o/hMDeyj4=
-----END RSA PRIVATE KEY-----
```

"Parse X.509 certificate" in current version yields this output for this input:

```
Parse X.509 certificate - TypeError in https://gchq.github.io/CyberChef/modules/PublicKey.js on line 2.<br><br>Message: t is null
```

This looked confusing for me, so I added a try-catch statement to have the operation yield this output instead:

```
Parse X.509 certificate - Certificate load error (non-certificate input?)
```
