### PR TITLE
Operation Sort: added value Length to option Order

### DIFF
--- a/src/core/lib/Sort.mjs
+++ b/src/core/lib/Sort.mjs
@@ -103,3 +103,15 @@ export function hexadecimalSort(a, b) {
 
     return a.localeCompare(b);
 }
+
+/**
+ * Comparison operation for sorting of lines by length
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function lengthSort(a, b) {
+    return a.length - b.length;
+}
+

--- a/src/core/operations/Sort.mjs
+++ b/src/core/operations/Sort.mjs
@@ -7,7 +7,7 @@
 import Operation from "../Operation.mjs";
 import Utils from "../Utils.mjs";
 import {INPUT_DELIM_OPTIONS} from "../lib/Delim.mjs";
-import {caseInsensitiveSort, ipSort, numericSort, hexadecimalSort} from "../lib/Sort.mjs";
+import {caseInsensitiveSort, ipSort, numericSort, hexadecimalSort, lengthSort} from "../lib/Sort.mjs";
 
 /**
  * Sort operation
@@ -39,7 +39,7 @@ class Sort extends Operation {
             {
                 "name": "Order",
                 "type": "option",
-                "value": ["Alphabetical (case sensitive)", "Alphabetical (case insensitive)", "IP address", "Numeric", "Numeric (hexadecimal)"]
+                "value": ["Alphabetical (case sensitive)", "Alphabetical (case insensitive)", "IP address", "Numeric", "Numeric (hexadecimal)", "Length"]
             }
         ];
     }
@@ -65,6 +65,8 @@ class Sort extends Operation {
             sorted = sorted.sort(numericSort);
         } else if (order === "Numeric (hexadecimal)") {
             sorted = sorted.sort(hexadecimalSort);
+        } else if (order === "Length") {
+            sorted = sorted.sort(lengthSort);
         }
 
         if (sortReverse) sorted.reverse();


### PR DESCRIPTION
I added value Length to the Order option of the Sort operation.
This sorts lines/fields by their length.

Example of use: use the strings operation to extract strings from a malware sample, and then sort those strings by length.
