### PR TITLE
Use byteLength instead of length to check validity of ArrayBuffer in "View Bit Plane"

### DIFF
--- a/src/core/operations/ViewBitPlane.mjs
+++ b/src/core/operations/ViewBitPlane.mjs
@@ -90,7 +90,7 @@ class ViewBitPlane extends Operation {
      * @returns {html}
      */
     present(data) {
-        if (!data.length) return "";
+        if (!data.byteLength) return "";
         const type = isImage(data);
 
         return `<img src="data:${type};base64,${toBase64(data)}">`;


### PR DESCRIPTION
fix  #1229

[`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) doesn't have a property `length`, so this part will prevent it from showing resulting image.

https://github.com/gchq/CyberChef/blob/ed8bd34915a70e15def593df4105a7f112b2ff69/src/core/operations/ViewBitPlane.mjs#L93

I changed this line to use `byteLength`, which `ArrayBuffer` has, to enable displaying the result.
