### PR TITLE
Improve treatment of Hex (little endian) in Windows Filetime converters

### DIFF
--- a/src/core/operations/UNIXTimestampToWindowsFiletime.mjs
+++ b/src/core/operations/UNIXTimestampToWindowsFiletime.mjs
@@ -79,6 +79,9 @@ class UNIXTimestampToWindowsFiletime extends Operation {
                 flipped += result.charAt(i);
                 flipped += result.charAt(i + 1);
             }
+            if (result.length % 2 !== 0) {
+                flipped += "0" + result.charAt(0);
+            }
             result = flipped;
         }
 

--- a/src/core/operations/WindowsFiletimeToUNIXTimestamp.mjs
+++ b/src/core/operations/WindowsFiletimeToUNIXTimestamp.mjs
@@ -52,7 +52,10 @@ class WindowsFiletimeToUNIXTimestamp extends Operation {
         if (format === "Hex (little endian)") {
             // Swap endianness
             let result = "";
-            for (let i = input.length - 2; i >= 0; i -= 2) {
+            if (input.length % 2 !== 0) {
+                result += input.charAt(input.length - 1);
+            }
+            for (let i = input.length - input.length % 2 - 2; i >= 0; i -= 2) {
                 result += input.charAt(i);
                 result += input.charAt(i + 1);
             }


### PR DESCRIPTION
fix #1354

* Hex output: add 0 to proper position and always output even number of digits
* Hex input: treat odd number of digits like `123` like "From Hex" operation does: `12 03`