### PR TITLE
Have "From Hex" treat the delimiter as delimiter, not what to erase

### DIFF
--- a/src/core/lib/Hex.mjs
+++ b/src/core/lib/Hex.mjs
@@ -105,13 +105,17 @@ export function fromHex(data, delim="Auto", byteLen=2) {
         throw new OperationError("Byte length must be a positive integer");
 
     if (delim !== "None") {
-        const delimRegex = delim === "Auto" ? /[^a-f\d]|(0x)/gi : Utils.regexRep(delim);
-        data = data.replace(delimRegex, "");
+        const delimRegex = delim === "Auto" ? /[^a-f\d]|0x/gi : Utils.regexRep(delim);
+        data = data.split(delimRegex);
+    } else {
+        data = [data];
     }
 
     const output = [];
-    for (let i = 0; i < data.length; i += byteLen) {
-        output.push(parseInt(data.substr(i, byteLen), 16));
+    for (let i = 0; i < data.length; i++) {
+        for (let j = 0; j < data[i].length; j += byteLen) {
+            output.push(parseInt(data[i].substr(j, byteLen), 16));
+        }
     }
     return output;
 }

--- a/tests/node/tests/operations.mjs
+++ b/tests/node/tests/operations.mjs
@@ -45,10 +45,10 @@ TestRegister.addApiTests([
         const result = chef.ADD("sample input", {
             key: {
                 string: "some key",
-                option: "Hex"
+                option: "utf8"
             }
         });
-        assert.equal(result.toString(), "aO[^ZS\u000eW\\^cb");
+        assert.equal(result.toString(), "\xe6\xd0\xda\xd5\x8c\xd0\x85\xe2\xe1\xdf\xe2\xd9");
     }),
 
 
@@ -121,10 +121,10 @@ Tiger-128`;
         const result = chef.AND("Scot-free", {
             key: {
                 string: "Raining Cats and Dogs",
-                option: "Hex",
+                option: "utf8",
             }
         });
-        assert.strictEqual(result.toString(), "\u0000\"M$(D  E");
+        assert.strictEqual(result.toString(), "Raid)fb A");
     }),
 
     it("atBash Cipher", () => {
@@ -371,10 +371,10 @@ color: white;
             },
             salt: {
                 string: "Market",
-                option: "Hex",
+                option: "utf8",
             },
         });
-        assert.strictEqual(result.toString(), "7c21a9f5063a4d62fb1050068245c181");
+        assert.strictEqual(result.toString(), "4930d5d200e80f18c96b5550d13c6af8");
     }),
 
     it("Derive PBKDF2 Key", () => {


### PR DESCRIPTION
fix #1211
fix #1285

Have "From Hex" treat the delimiter as delimiter, not what to erase.

This will change the output of "From Hex" for an input `0x12 0x34 0x5 0x6` with delimiter "Auto" from `12 34 56` to `12 34 05 06` (after applying "To Hex").
I think the latter output is more natural.

Note that this change breaks some test cases that uses non-hexadecimal strings like `"some key"` with `"Hex"` option.
Such input didn't make sense for me, so I changed thiese cases to use `"utf8"` option instead.
Please let me know if you don't agree.