### PR TITLE
Convert hex string to lowercase before parsing as ASN.1

### DIFF
--- a/src/core/operations/ParseASN1HexString.mjs
+++ b/src/core/operations/ParseASN1HexString.mjs
@@ -45,7 +45,7 @@ class ParseASN1HexString extends Operation {
      */
     run(input, args) {
         const [index, truncateLen] = args;
-        return r.ASN1HEX.dump(input.replace(/\s/g, ""), {
+        return r.ASN1HEX.dump(input.replace(/\s/g, "").toLowerCase(), {
             "ommitLongOctet": truncateLen
         }, index);
     }

--- a/src/core/operations/ParseX509Certificate.mjs
+++ b/src/core/operations/ParseX509Certificate.mjs
@@ -59,7 +59,7 @@ class ParseX509Certificate extends Operation {
 
         switch (inputFormat) {
             case "DER Hex":
-                input = input.replace(/\s/g, "");
+                input = input.replace(/\s/g, "").toLowerCase();
                 cert.readCertHex(input);
                 break;
             case "PEM":


### PR DESCRIPTION
fix #1355
fix #1203

The underlying ASN.1 and X509 parser library `jsrsasign` doesn't look supporting uppercase hex string.

[jsrsasign/asn1hex-1.1.js at master · kjur/jsrsasign](https://github.com/kjur/jsrsasign/blob/c665ebcebc62cc7e55ffadbf2efec7ef89279b00/src/asn1hex-1.1.js#L840)

Therefore, adding conversion to lowercase before passing to the parser library to avoid trouble.
