### PR TITLE
Added toggle treating "+" as space (default false)

### DIFF
--- a/src/core/operations/URLDecode.mjs
+++ b/src/core/operations/URLDecode.mjs
@@ -23,7 +23,13 @@ class URLDecode extends Operation {
         this.infoURL = "https://wikipedia.org/wiki/Percent-encoding";
         this.inputType = "string";
         this.outputType = "string";
-        this.args = [];
+        this.args = [
+            {
+                "name": "Treat \"+\" as space",
+                "type": "boolean",
+                "value": false
+            },
+        ];
         this.checks = [
             {
                 pattern: ".*(?:%[\\da-f]{2}.*){4}",
@@ -39,7 +45,8 @@ class URLDecode extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const data = input.replace(/\+/g, "%20");
+        const plusIsSpace = args[0];
+        const data = plusIsSpace ? input.replace(/\+/g, "%20") : input;
         try {
             return decodeURIComponent(data);
         } catch (err) {


### PR DESCRIPTION
To fix issue #1477 , I made treating `+` as the space character a togglable option, defaulting to false.