### PR TITLE
Fix npm postinstall task failure when using Windows msys shells

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -390,13 +390,14 @@ module.exports = function (grunt) {
                 stdout: false,
             },
             fixCryptoApiImports: {
-                command: [
-                    `[[ "$OSTYPE" == "darwin"* ]]`,
-                    "&&",
-                    `find ./node_modules/crypto-api/src/ \\( -type d -name .git -prune \\) -o -type f -print0 | xargs -0 sed -i '' -e '/\\.mjs/!s/\\(from "\\.[^"]*\\)";/\\1.mjs";/g'`,
-                    "||",
-                    `find ./node_modules/crypto-api/src/ \\( -type d -name .git -prune \\) -o -type f -print0 | xargs -0 sed -i -e '/\\.mjs/!s/\\(from "\\.[^"]*\\)";/\\1.mjs";/g'`
-                ].join(" "),
+                command: function () {
+                    switch (process.platform) {
+                        case "darwin":
+                            return `find ./node_modules/crypto-api/src/ \\( -type d -name .git -prune \\) -o -type f -print0 | xargs -0 sed -i '' -e '/\\.mjs/!s/\\(from "\\.[^"]*\\)";/\\1.mjs";/g'`;
+                        default:
+                            return `find ./node_modules/crypto-api/src/ \\( -type d -name .git -prune \\) -o -type f -print0 | xargs -0 sed -i -e '/\\.mjs/!s/\\(from "\\.[^"]*\\)";/\\1.mjs";/g'`;
+                    }
+                },
                 stdout: false
             }
         },


### PR DESCRIPTION
Relates to #1306, #1488

This half-fixes `npm install` for Windows users so it'll work under MSYS environments like git bash. Otherwise the task fails due to some issue with `[[` being a shell keyword instead of an executable in the path. Example:

```sh
$ echo $OSTYPE
msys

$ npm install
> cyberchef@9.55.0 postinstall
> npx grunt exec:fixCryptoApiImports

Running "exec:fixCryptoApiImports" (exec) task
>> '[[' is not recognized as an internal or external command,
>> operable program or batch file.

$ command -V [[
[[ is a shell keyword
```

The `exec:fixCryptoApiImports` task can instead use node's `process.platform` to determine the current OS, avoiding the issue above. Now I'm able to run `npm install` on Windows 10 with git bash. Note that this will still fail with Windows' native cmd prompt.  
I don't have a mac handy so I haven't been able to test the OSX case.