### PR TITLE
Align Markdown table column separators

### DIFF
--- a/src/core/operations/ToTable.mjs
+++ b/src/core/operations/ToTable.mjs
@@ -214,7 +214,7 @@ class ToTable extends Operation {
             output += outputRow(row, longestCells);
             let rowOutput = verticalBorder;
             row.forEach(function(cell, index) {
-                rowOutput += " " +  headerDivider + " " + verticalBorder;
+                rowOutput += " " +  headerDivider.repeat(longestCells[index]) + " " + verticalBorder;
             });
             output += rowOutput += "\n";
 


### PR DESCRIPTION
#1439 aligned the table column-separators for all table rows except for the row separating the table header and table values. Please find the before and after output of the 'To Table' operation below.

**Before**
```md
| Fruit     | Price |
| - | - |
| Apple     | 1     |
| Banana    | 2     |
| Cantalope | 3     |
```

**After**
```md
| Fruit     | Price |
| --------- | ----- |
| Apple     | 1     |
| Banana    | 2     |
| Cantalope | 3     |

```
