### PR TITLE
Add more helpful error for when numerical ingredient is left empty

### DIFF
--- a/src/core/Ingredient.mjs
+++ b/src/core/Ingredient.mjs
@@ -99,8 +99,6 @@ class Ingredient {
      * @param {string} type - The name of the data type.
     */
     static prepare(data, type) {
-        let number;
-
         switch (type) {
             case "binaryString":
             case "binaryShortString":
@@ -116,7 +114,9 @@ class Ingredient {
                 }
             case "number":
                 if (data === null) return data;
-                number = parseFloat(data);
+                if (isNaN(data)) throw "Ingredient can not be empty.";
+
+                let number = parseFloat(data);
                 if (isNaN(number)) {
                     const sample = Utils.truncate(data.toString(), 10);
                     throw "Invalid ingredient value. Not a number: " + sample;


### PR DESCRIPTION
Adding on to #1539, this PR gives a separate error for when the user leaves a numerical Ingredient input value empty. Behavior before this change would say `Invalid ingredient value. Not a number: NaN`, which might not make sense unless you know that an empty value parses into `NaN`.

This PR won't do much on its own, though, since without the update in #1539, it's gonna print `[object Object]` either way. I wanted to split these 2 fixes up just for consistency's sake; either both errors should show `[object Object]` or neither of them should, right?

(If that other one doesn't get accepted, I'd just close this one too, I guess)