### PR TITLE
fix: incorrect hover on baking info

### DIFF
--- a/src/web/utils/statusBar.mjs
+++ b/src/web/utils/statusBar.mjs
@@ -275,7 +275,6 @@ class StatusBarPanel {
             bakingTime.textContent = this.timing.duration(this.tabNumGetter());
 
             const info = this.timing.printStages(this.tabNumGetter()).replace(/\n/g, "<br>");
-            bakingTimeInfo.setAttribute("title", info);
             bakingTimeInfo.setAttribute("data-original-title", info);
         } else {
             bakingTimeInfo.style.display = "none";


### PR DESCRIPTION
Thanks for creating this app. I really like it.

I noticed after upgrading to v10, the newly added hover for the baking time is a bit off. I think it should be removed.

Before:
![screen-2023-03-28-21-40-49](https://user-images.githubusercontent.com/7546654/228187729-c52df25d-e2d0-4d04-9e7f-77f8aefd832d.jpg)

After:
![image](https://user-images.githubusercontent.com/7546654/228188124-ce6767a9-0af2-4204-a224-6ada4cfe6568.png)

