### PR TITLE
Fix possible browser freeze

### DIFF
--- a/src/web/workers/DishWorker.mjs
+++ b/src/web/workers/DishWorker.mjs
@@ -98,7 +98,7 @@ async function bufferToStr(data) {
         try {
             str = cptable.utils.decode(data.encoding, new Uint8Array(data.buffer));
         } catch (err) {
-            str = err;
+            str = err.message;
         }
     }
 


### PR DESCRIPTION
`cptable.utils.decode` will throw a Runtime Error instead of returning an error message string, so `err` should be changed to `err.message`.
Without the fix, whenever it fails to decode using given character encoding, the whole window freezes. For example, input a Chinese character 你 in UTF-8 and change output encoding to GB18030 will 100% freeze the browser.