### PR TITLE
- add regex group names

### DIFF
--- a/src/core/operations/RegularExpression.mjs
+++ b/src/core/operations/RegularExpression.mjs
@@ -203,7 +203,7 @@ function regexList(input, regex, displayTotal, matches, captureGroups) {
         if (captureGroups) {
             for (let i = 1; i < match.length; i++) {
                 if (matches) {
-                    output += "  Group " + i + ": ";
+                    output += "  Group " + i + " (" + regex.xregexp.captureNames[i - 1] + "): ";
                 }
                 output += match[i] + "\n";
             }


### PR DESCRIPTION
Addresses https://github.com/gchq/CyberChef/issues/1650

I've recently been using the regex operation with named capture groups. However the name of the group isn't surfaced in the output, and would be handy when I have a lot of groups.

Saw that this is an existing feature request, so added this in.

- When using regex operation, if including named capture groups then output the name of the group in the 'List matches with capture groups' output format.

<img width="261" alt="regex-named-groups" src="https://github.com/gchq/CyberChef/assets/1085154/0a2fdb12-29cf-44bb-99b9-2005d191aab9">

[Test link with data and operation](https://gchq.github.io/CyberChef/#recipe=Regular_expression('User%20defined','(?%3Cperson%3E%5C%5Cw%2B)@(?%3Cdomain%3E.%2B)',true,true,false,false,false,false,'List%20matches%20with%20capture%20groups')&input=bmFtZUB0ZXN0LmNvbQ)

Thanks