### PR TITLE
Fix JSON folder folding in Firefox

### DIFF
--- a/src/web/stylesheets/operations/json.css
+++ b/src/web/stylesheets/operations/json.css
@@ -44,7 +44,8 @@ ul.json-dict, ol.json-array {
     display: contents;
 }
 .json-summary {
-    display: contents;
+    display: inline;
+    list-style: none;
 }
 
 /* Display object and array brackets when closed */


### PR DESCRIPTION
Close #1707

Looks like that using `display: contents;` in summary may cause some weird effect.

https://github.com/whatwg/html/issues/1839#issuecomment-251574911

This PR:

1. remove `display: contents;`
2. add `list-style: none;` for hiding the default disclosure triangle
3. add `display: inline;` to ensure consistent layout