### PR TITLE
Add Parse Ethernet frame Operation

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -213,6 +213,7 @@
             "DNS over HTTPS",
             "Strip HTTP headers",
             "Dechunk HTTP response",
+            "Parse Ethernet frame",
             "Parse User Agent",
             "Parse IP range",
             "Parse IPv6 address",

--- a/src/core/operations/ParseEthernetFrame.mjs
+++ b/src/core/operations/ParseEthernetFrame.mjs
@@ -1,0 +1,115 @@
+/**
+ * @author tedk [tedk@ted.do]
+ * @copyright Crown Copyright 2024
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import Utils from "../Utils.mjs";
+import {fromHex, toHex} from "../lib/Hex.mjs";
+
+/**
+ * Parse Ethernet frame operation
+ */
+class ParseEthernetFrame extends Operation {
+
+    /**
+     * ParseEthernetFrame constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Parse Ethernet frame";
+        this.module = "Default";
+        this.description = "Parses an Ethernet frame and either shows the deduced values (Source and destination MAC, VLANs) or returns the packet data.\\n\\nGood for use in conjunction with the Parse IPv4, and Parse TCP/UDP recipes.";
+        this.infoURL = "https://en.wikipedia.org/wiki/Ethernet_frame#Frame_%E2%80%93_data_link_layer";
+        this.inputType = "string";
+        this.outputType = "html";
+        this.args = [
+            {
+                name: "Input type",
+                type: "option",
+                value: [
+                    "Raw", "Hex"
+                ],
+                defaultIndex: 0,
+            },
+            {
+                name: "Return type",
+                type: "option",
+                value: [
+                    "Text output", "Packet data", "Packet data (hex)",
+                ],
+                defaultIndex: 0,
+            }
+        ];
+    }
+
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {html}
+     */
+    run(input, args) {
+        const format = args[0];
+        const outputFormat = args[1];
+
+        if (format === "Hex") {
+            input = fromHex(input);
+        } else if (format === "Raw") {
+            input = new Uint8Array(Utils.strToArrayBuffer(input));
+        } else {
+            throw new OperationError("Invalid input format selected.");
+        }
+
+        const destinationMac = input.slice(0, 6);
+        const sourceMac = input.slice(6, 12);
+
+        let offset = 12;
+        const vlans = [];
+
+        while (offset < input.length) {
+            const ethType = Utils.byteArrayToChars(input.slice(offset, offset+2));
+            offset += 2;
+
+
+            if (ethType === "\x08\x00") {
+                break;
+            } else if (ethType === "\x81\x00" || ethType === "\x88\xA8") {
+                // Parse the VLAN tag:
+                // [0000] 0000 0000 0000
+                //  ^^^ PRIO  - Ignored
+                //     ^ DEI  - Ignored
+                //        ^^^^ ^^^^ ^^^^ VLAN ID
+                const vlanTag = input.slice(offset+2, offset+4);
+                vlans.push((vlanTag[0] & 0b00001111) << 4 | vlanTag[1]);
+
+                offset += 2;
+            } else {
+                break;
+            }
+        }
+
+        const packetData = input.slice(offset);
+
+        if (outputFormat === "Packet data") {
+            return Utils.byteArrayToChars(packetData);
+        } else if (outputFormat === "Packet data (hex)") {
+            return toHex(packetData);
+        } else if (outputFormat === "Text output") {
+            let retval = `Source MAC: ${toHex(sourceMac, ":")}\nDestination MAC: ${toHex(destinationMac, ":")}\n`;
+            if (vlans.length > 0) {
+                retval += `VLAN: ${vlans.join(", ")}\n`;
+            }
+            retval += `Data:\n${toHex(packetData)}`;
+            return retval;
+        }
+
+    }
+
+
+}
+
+export default ParseEthernetFrame;

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -105,6 +105,7 @@ import "./tests/NetBIOS.mjs";
 import "./tests/NormaliseUnicode.mjs";
 import "./tests/NTLM.mjs";
 import "./tests/OTP.mjs";
+import "./tests/ParseEthernetFrame.mjs";
 import "./tests/ParseIPRange.mjs";
 import "./tests/ParseObjectIDTimestamp.mjs";
 import "./tests/ParseQRCode.mjs";

--- a/tests/operations/tests/ParseEthernetFrame.mjs
+++ b/tests/operations/tests/ParseEthernetFrame.mjs
@@ -1,0 +1,45 @@
+/**
+ * Parse Ethernet frame tests.
+ *
+ * @author tedk [tedk@ted.do]
+ * @copyright Crown Copyright 2017
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Parse plain Ethernet frame",
+        input: "000000000000ffffffffffff08004500",
+        expectedOutput: "Source MAC: ff:ff:ff:ff:ff:ff\nDestination MAC: 00:00:00:00:00:00\nData:\n45 00",
+        recipeConfig: [
+            {
+                "op": "Parse Ethernet frame",
+                "args": ["Hex", "Text output"]
+            }
+        ]
+    },
+    // Example PCAP data from: https://packetlife.net/captures/protocol/vlan/
+    {
+        name: "Parse Ethernet frame with one VLAN tag (802.1q)",
+        input: "01000ccdcdd00013c3dfae188100a0760165aaaa",
+        expectedOutput: "Source MAC: 00:13:c3:df:ae:18\nDestination MAC: 01:00:0c:cd:cd:d0\nVLAN: 117\nData:\naa aa",
+        recipeConfig: [
+            {
+                "op": "Parse Ethernet frame",
+                "args": ["Hex", "Text output"]
+            }
+        ]
+    },
+    {
+        name: "Parse Ethernet frame with two VLAN tags (802.1ad)",
+        input: "0019aa7de688002155c8f13c810000d18100001408004500",
+        expectedOutput: "Source MAC: 00:21:55:c8:f1:3c\nDestination MAC: 00:19:aa:7d:e6:88\nVLAN: 16, 128\nData:\n45 00",
+        recipeConfig: [
+            {
+                "op": "Parse Ethernet frame",
+                "args": ["Hex", "Text output"]
+            }
+        ]
+    }
+]);


### PR DESCRIPTION
This adds a new operation+tests that parses Ethernet frames. 
Recently, I've been provided with Base64-encoded single packets which are annoying to decode manually, or even to strip the Ethernet header off.
This operation adds a basic information output and a 'packet data'-only which allows cascading to other Networking-related parsers (ie IPv4). I am still playing with the idea of updating those to allow the return of encapsulated data as well - allowing a quick/basic packet analysis through a recipe.
