### PR TITLE
Accessibility - Favourites dialog box keyboard navigation

### DIFF
--- a/src/web/HTMLOperation.mjs
+++ b/src/web/HTMLOperation.mjs
@@ -52,14 +52,14 @@ class HTMLOperation {
             const infoLink = this.infoURL ? `<hr>${titleFromWikiLink(this.infoURL)}` : "";
 
             html += ` data-container='body' data-toggle='popover' data-placement='right'
-                data-content="${this.description}${infoLink}" data-html='true' data-trigger='hover'
+                data-content="${this.description}${infoLink}" data-html='true' data-trigger='hover focus'
                 data-boundary='viewport'`;
         }
 
         html += ">" + this.name;
 
         if (removeIcon) {
-            html += "<i class='material-icons remove-icon op-icon'>delete</i>";
+            html += "<i class='material-icons remove-icon op-icon' tabindex='0'>delete</i>";
         }
 
         html += "</li>";

--- a/src/web/html/index.html
+++ b/src/web/html/index.html
@@ -536,7 +536,7 @@
                     <div class="modal-body" id="favourites-body">
                         <ul>
                             <li><span style="font-weight: bold">To add:</span> drag the operation over the favourites category and drop it</li>
-                            <li><span style="font-weight: bold">To reorder:</span> drag up and down in the list below</li>
+                            <li><span style="font-weight: bold">To reorder:</span> drag up and down in the list below or press Ctrl + Up/Down Arrow</li>
                             <li><span style="font-weight: bold">To remove:</span> hit the delete button or drag out of the list below</li>
                         </ul>
                         <br>

--- a/src/web/html/index.html
+++ b/src/web/html/index.html
@@ -536,7 +536,7 @@
                     <div class="modal-body" id="favourites-body">
                         <ul>
                             <li><span style="font-weight: bold">To add:</span> drag the operation over the favourites category and drop it</li>
-                            <li><span style="font-weight: bold">To reorder:</span> drag up and down in the list below or press Ctrl + Up/Down Arrow</li>
+                            <li><span style="font-weight: bold">To reorder:</span> drag up and down in the list below or focus on operation and press Ctrl + Up/Down Arrow to reorder using keyboard</li>
                             <li><span style="font-weight: bold">To remove:</span> hit the delete button or drag out of the list below</li>
                         </ul>
                         <br>

--- a/src/web/waiters/OperationsWaiter.mjs
+++ b/src/web/waiters/OperationsWaiter.mjs
@@ -280,7 +280,7 @@ class OperationsWaiter {
     /**
      * Handler for navigation key press events.
      * Navigates through the favourites list and corresponding delete buttons.
-     * Move favourites elements up and down with Ctrl + Arrow keys to imite drag and drop mouse functionality.
+     * Move favourites elements up and down with Ctrl + Arrow keys to imitate drag and drop mouse functionality.
      */
     ArrowNavFavourites(event) {
         const currentElement = event.target;

--- a/src/web/waiters/OperationsWaiter.mjs
+++ b/src/web/waiters/OperationsWaiter.mjs
@@ -237,8 +237,15 @@ class OperationsWaiter {
         }
 
         const editFavouritesList = document.getElementById("edit-favourites-list");
+        const editFavouritesListElements = editFavouritesList.getElementsByTagName('li');
         editFavouritesList.innerHTML = html;
         this.removeIntent = false;
+
+        for (let i = 0; i < editFavouritesListElements.length; i++) {
+            editFavouritesListElements[i].setAttribute("tabindex", "0");
+            editFavouritesListElements[i].addEventListener("keydown", this.ArrowNavFavourites.bind(this), false)
+            editFavouritesListElements[i].firstElementChild.addEventListener("keydown", this.deleteFavourite.bind(this), false)
+        }
 
         const editableList = Sortable.create(editFavouritesList, {
             filter: ".remove-icon",
@@ -268,6 +275,69 @@ class OperationsWaiter {
         $("#edit-favourites-list [data-toggle=popover]").popover();
         $("#favourites-modal").modal();
     }
+
+
+    /**
+     * Handler for navigation key press events.
+     * Navigates through the favourites list and corresponding delete buttons.
+     * Move favourites elements up and down with Ctrl + Arrow keys to imite drag and drop mouse functionality. 
+     */
+    ArrowNavFavourites(event) {
+            const currentElement = event.target;
+            const nextElement = currentElement.nextElementSibling;
+            const prevElement = currentElement.previousElementSibling;
+            const favouritesList = currentElement.parentNode;
+
+            event.preventDefault();
+            event.stopPropagation();
+            if (event.key === "ArrowDown" && !event.ctrlKey) {
+                if (nextElement === null) {
+                    currentElement.parentElement.firstElementChild.focus();
+                } else {
+                    nextElement.focus();
+                }
+            } else if (event.key === "ArrowUp" && !event.ctrlKey) {
+                if (prevElement === null) {
+                    currentElement.parentElement.lastElementChild.focus();
+                } else {
+                    prevElement.focus();
+                }
+            } else if (event.key === "Tab") {
+                currentElement.parentElement.closest(".modal-body").nextElementSibling.getElementsByTagName("Button")[0].focus();
+            } else if (event.key === "ArrowRight" ) {
+                if (currentElement.firstElementChild !== null) {
+                    currentElement.firstElementChild.focus();
+                } else {
+                    return
+                }
+            } else if (event.key === "ArrowLeft" && (currentElement.classList.contains("remove-icon"))) {
+                currentElement.parentElement.focus();
+            } else if (event.ctrlKey && event.key === "ArrowDown") {
+                
+                if (nextElement === null) {
+                    favouritesList.insertBefore(currentElement, currentElement.parentElement.firstElementChild)
+                } else {
+                    favouritesList.insertBefore(currentElement, nextElement.nextElementSibling)
+            }
+                currentElement.focus();
+            } else if (event.ctrlKey && event.key === "ArrowUp") {
+                favouritesList.insertBefore(currentElement, prevElement)
+                currentElement.focus();
+}
+}
+
+    /**
+     * Handler for save favourites click events.
+     * Saves the selected favourites and reloads them.
+     */
+    deleteFavourite(event) {
+        if (event.key === "Enter") {
+        const el = event.target
+        if (el && el.parentNode) {
+        el.parentNode.remove();
+    }
+    }
+}
 
 
     /**

--- a/src/web/waiters/OperationsWaiter.mjs
+++ b/src/web/waiters/OperationsWaiter.mjs
@@ -237,14 +237,14 @@ class OperationsWaiter {
         }
 
         const editFavouritesList = document.getElementById("edit-favourites-list");
-        const editFavouritesListElements = editFavouritesList.getElementsByTagName('li');
+        const editFavouritesListElements = editFavouritesList.getElementsByTagName("li");
         editFavouritesList.innerHTML = html;
         this.removeIntent = false;
 
         for (let i = 0; i < editFavouritesListElements.length; i++) {
             editFavouritesListElements[i].setAttribute("tabindex", "0");
-            editFavouritesListElements[i].addEventListener("keydown", this.ArrowNavFavourites.bind(this), false)
-            editFavouritesListElements[i].firstElementChild.addEventListener("keydown", this.deleteFavourite.bind(this), false)
+            editFavouritesListElements[i].addEventListener("keydown", this.ArrowNavFavourites.bind(this), false);
+            editFavouritesListElements[i].firstElementChild.addEventListener("keydown", this.deleteFavourite.bind(this), false);
         }
 
         const editableList = Sortable.create(editFavouritesList, {
@@ -280,51 +280,48 @@ class OperationsWaiter {
     /**
      * Handler for navigation key press events.
      * Navigates through the favourites list and corresponding delete buttons.
-     * Move favourites elements up and down with Ctrl + Arrow keys to imite drag and drop mouse functionality. 
+     * Move favourites elements up and down with Ctrl + Arrow keys to imite drag and drop mouse functionality.
      */
     ArrowNavFavourites(event) {
-            const currentElement = event.target;
-            const nextElement = currentElement.nextElementSibling;
-            const prevElement = currentElement.previousElementSibling;
-            const favouritesList = currentElement.parentNode;
+        const currentElement = event.target;
+        const nextElement = currentElement.nextElementSibling;
+        const prevElement = currentElement.previousElementSibling;
+        const favouritesList = currentElement.parentNode;
 
-            event.preventDefault();
-            event.stopPropagation();
-            if (event.key === "ArrowDown" && !event.ctrlKey) {
-                if (nextElement === null) {
-                    currentElement.parentElement.firstElementChild.focus();
-                } else {
-                    nextElement.focus();
-                }
-            } else if (event.key === "ArrowUp" && !event.ctrlKey) {
-                if (prevElement === null) {
-                    currentElement.parentElement.lastElementChild.focus();
-                } else {
-                    prevElement.focus();
-                }
-            } else if (event.key === "Tab") {
-                currentElement.parentElement.closest(".modal-body").nextElementSibling.getElementsByTagName("Button")[0].focus();
-            } else if (event.key === "ArrowRight" ) {
-                if (currentElement.firstElementChild !== null) {
-                    currentElement.firstElementChild.focus();
-                } else {
-                    return
-                }
-            } else if (event.key === "ArrowLeft" && (currentElement.classList.contains("remove-icon"))) {
-                currentElement.parentElement.focus();
-            } else if (event.ctrlKey && event.key === "ArrowDown") {
-                
-                if (nextElement === null) {
-                    favouritesList.insertBefore(currentElement, currentElement.parentElement.firstElementChild)
-                } else {
-                    favouritesList.insertBefore(currentElement, nextElement.nextElementSibling)
+        event.preventDefault();
+        event.stopPropagation();
+        if (event.key === "ArrowDown" && !event.ctrlKey) {
+            if (nextElement === null) {
+                currentElement.parentElement.firstElementChild.focus();
+            } else {
+                nextElement.focus();
             }
-                currentElement.focus();
-            } else if (event.ctrlKey && event.key === "ArrowUp") {
-                favouritesList.insertBefore(currentElement, prevElement)
-                currentElement.focus();
-}
-}
+        } else if (event.key === "ArrowUp" && !event.ctrlKey) {
+            if (prevElement === null) {
+                currentElement.parentElement.lastElementChild.focus();
+            } else {
+                prevElement.focus();
+            }
+        } else if (event.key === "Tab") {
+            currentElement.parentElement.closest(".modal-body").nextElementSibling.getElementsByTagName("Button")[0].focus();
+        } else if (event.key === "ArrowRight") {
+            if (currentElement.firstElementChild !== null) {
+                currentElement.firstElementChild.focus();
+            }
+        } else if (event.key === "ArrowLeft" && (currentElement.classList.contains("remove-icon"))) {
+            currentElement.parentElement.focus();
+        } else if (event.ctrlKey && event.key === "ArrowDown") {
+            if (nextElement === null) {
+                favouritesList.insertBefore(currentElement, currentElement.parentElement.firstElementChild);
+            } else {
+                favouritesList.insertBefore(currentElement, nextElement.nextElementSibling);
+            }
+            currentElement.focus();
+        } else if (event.ctrlKey && event.key === "ArrowUp") {
+            favouritesList.insertBefore(currentElement, prevElement);
+            currentElement.focus();
+        }
+    }
 
     /**
      * Handler for save favourites click events.
@@ -332,12 +329,12 @@ class OperationsWaiter {
      */
     deleteFavourite(event) {
         if (event.key === "Enter") {
-        const el = event.target
-        if (el && el.parentNode) {
-        el.parentNode.remove();
+            const el = event.target;
+            if (el && el.parentNode) {
+                el.parentNode.remove();
+            }
+        }
     }
-    }
-}
 
 
     /**

--- a/src/web/waiters/OperationsWaiter.mjs
+++ b/src/web/waiters/OperationsWaiter.mjs
@@ -324,11 +324,11 @@ class OperationsWaiter {
     }
 
     /**
-     * Handler for save favourites click events.
-     * Saves the selected favourites and reloads them.
+     * Handler for delete favourites keydown events.
+     * delete the selected favourite from the list.
      */
     deleteFavourite(event) {
-        if (event.key === "Enter") {
+        if (event.key === "Enter" || event.key === " ") {
             const el = event.target;
             if (el && el.parentNode) {
                 el.parentNode.remove();


### PR DESCRIPTION
**Issue**
[Issue #1718](https://github.com/gchq/CyberChef/issues/1718)

This PR aims to solve some of the 'limited keyboard interaction' outlined in section 4/5 of **keyboard Navigation** in the issue linked above, focusing on the _Edit favourites_ dialog box. E.g. Inability to focus on menu items and view tooltips through tabbing, use of arrow keys for navigation and Lack of keyboard alternative for drag-and-drop operations

**Code changes:**
- TabIndex=0 added to elements within the Edit Favourites dialog
-  On focus styling of elements with tooltips to match mouse hover
-  Keydown event listeners added to favourite operations
- Function added to enable reordering of favorite operation using CTRL + arrow keys to mimic mouse drag function
- Arrow navigation of favourite items implemented

**User-facing changes:**
- tooltips show on focus 
- reorder instructions within dialog updated to include keyboard navigation


**To replicate:**
- Open favourites dialog with mouse click (keyboard functionality is being implemented in separate PR)
- `Tab` to first operation
- Press up/down arrow to navigate through the list (should loop back to top/bottom)
- press `Arrow Right` on any operation and either `Arrow Left` to focus back on the operation or `Enter`/ `Space` to delete from list
- pressing `Ctrl`+ `Up Arrow` / `Down Arrow` should move the focused operation up or down the list (should loop back to top/bottom)
- Press `Tab` to exit the list of operations and either reset/save/or cancel