### PR TITLE
Accessibility - On focus CSS styling within options dialog to match mouse hover

### DIFF
--- a/src/web/stylesheets/layout/_modals.css
+++ b/src/web/stylesheets/layout/_modals.css
@@ -99,9 +99,11 @@
 .bmd-form-group.is-focused [class^='bmd-label'],
 .bmd-form-group.is-focused [class*=' bmd-label'],
 .bmd-form-group.is-focused label,
-.checkbox label:hover {
+.checkbox label:hover,
+.bmd-form-group.is-filled:focus-within .checkbox.option-item label {
     color: var(--input-highlight-colour);
 }
+
 
 .bmd-form-group.option-item label+.form-control{
     background-image:


### PR DESCRIPTION
**Issue**
[Issue #1718](https://github.com/gchq/CyberChef/issues/1718)

This PR aims to solve some of the the 'limited keyboard interaction' outlined in section 1 of **keyboard Navigation** in the issue linked above, focusing on the _Options_ dialog box. E.g. Unclear navigation through the checkbox items as there is no visual focus of the elements for keyboard users.

**Code changes:**
- Added CSS styling for form group checkbox elements to match styling of mouse hover

**User-facing changes:**
- checkbox element labels change colour on focus with keyboard navigation


**To replicate:**
- Open options dialog with mouse click (keyboard functionality is being implemented in separate PR)
- `Tab` through checkbox elements
- Expect labels to change on focus and match styling of mouse hover