### PR TITLE
Updated xmldom package to new namespace for vuln remediation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@babel/polyfill": "^7.12.1",
         "@blu3r4y/lzma": "^2.3.3",
         "@wavesenterprise/crypto-gost-js": "^2.1.0-RC1",
+        "@xmldom/xmldom": "^0.8.0",
         "argon2-browser": "^1.18.0",
         "arrive": "^2.4.1",
         "avsc": "^5.7.7",
@@ -92,7 +93,6 @@
         "unorm": "^1.6.0",
         "utf8": "^3.0.0",
         "vkbeautify": "^0.99.3",
-        "xmldom": "^0.6.0",
         "xpath": "0.0.34",
         "xregexp": "^5.1.1",
         "zlibjs": "^0.3.1"
@@ -3172,6 +3172,14 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -14834,13 +14842,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/xpath": {
       "version": "0.0.34",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "unorm": "^1.6.0",
     "utf8": "^3.0.0",
     "vkbeautify": "^0.99.3",
-    "xmldom": "^0.6.0",
+    "@xmldom/xmldom": "^0.8.0",
     "xpath": "0.0.34",
     "xregexp": "^5.1.1",
     "zlibjs": "^0.3.1"

--- a/src/core/operations/CSSSelector.mjs
+++ b/src/core/operations/CSSSelector.mjs
@@ -6,7 +6,7 @@
 
 import Operation from "../Operation.mjs";
 import OperationError from "../errors/OperationError.mjs";
-import xmldom from "xmldom";
+import xmldom from "@xmldom/xmldom";
 import nwmatcher from "nwmatcher";
 
 /**

--- a/src/core/operations/XPathExpression.mjs
+++ b/src/core/operations/XPathExpression.mjs
@@ -6,7 +6,7 @@
 
 import Operation from "../Operation.mjs";
 import OperationError from "../errors/OperationError.mjs";
-import xmldom from "xmldom";
+import xmldom from "@xmldom/xmldom";
 import xpath from "xpath";
 
 /**


### PR DESCRIPTION
Output from npm audit from current master shows critical severity for xmldom library:
```
xmldom  *
Severity: critical
xmldom allows multiple root nodes in a DOM - https://github.com/advisories/GHSA-crh6-fp67-6883
Misinterpretation of malicious XML input - https://github.com/advisories/GHSA-5fg8-2547-mr8q
No fix available
node_modules/xmldom
```

As per the package github page (https://github.com/xmldom/xmldom), they changed the namespace to `@xmldom/xmldom` so this PR updates that dependency in package.json and usage of the package in the source.