### PR TITLE
Updated jsonwebtoken dependency to 9+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "jsesc": "^3.0.2",
         "json5": "^2.2.3",
         "jsonpath-plus": "^8.0.0",
-        "jsonwebtoken": "8.5.1",
+        "jsonwebtoken": "^9.0.0",
         "jsqr": "^1.4.0",
         "jsrsasign": "^11.1.0",
         "kbpgp": "2.1.15",
@@ -9612,9 +9612,9 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -9625,20 +9625,42 @@
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
+    },
+    "node_modules/jsonwebtoken/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/jsqr": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "jsesc": "^3.0.2",
     "json5": "^2.2.3",
     "jsonpath-plus": "^8.0.0",
-    "jsonwebtoken": "8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "jsqr": "^1.4.0",
     "jsrsasign": "^11.1.0",
     "kbpgp": "2.1.15",

--- a/src/core/operations/JWTSign.mjs
+++ b/src/core/operations/JWTSign.mjs
@@ -50,7 +50,12 @@ class JWTSign extends Operation {
 
         try {
             return jwt.sign(input, key, {
-                algorithm: algorithm === "None" ? "none" : algorithm
+                algorithm: algorithm === "None" ? "none" : algorithm,
+
+                // To utilize jsonwebtoken 9+ library and maintain backwards compatibility for regression tests
+                // This could be turned into operation args in a future PR
+                allowInsecureKeySizes: true,
+                allowInvalidAsymmetricKeyTypes: true
             });
         } catch (err) {
             throw new OperationError(`Error: Have you entered the key correctly? The key should be either the secret for HMAC algorithms or the PEM-encoded private key for RSA and ECDSA.


### PR DESCRIPTION
As per npm audit, jwonwebtoken has a moderate level vuln:

```
jsonwebtoken  <=8.5.1
Severity: moderate
jsonwebtoken unrestricted key type could lead to legacy keys usage  - https://github.com/advisories/GHSA-8cf7-32gw-wr33
jsonwebtoken's insecure implementation of key retrieval function could lead to Forgeable Public/Private Tokens from RSA to HMAC - https://github.com/advisories/GHSA-hjrf-2m68-5959
jsonwebtoken vulnerable to signature validation bypass due to insecure default algorithm in jwt.verify() - https://github.com/advisories/GHSA-qwph-4952-7xr6
fix available via `npm audit fix --force`
Will install jsonwebtoken@9.0.2, which is a breaking change
node_modules/jsonwebtoken
```

This PR:
* Updates jsonwebtoken to latest 9+ version
* Updates JWTSign operation for backwards compatibility with insecure keys and invalid asym key types

As a future feature suggestion, add the insecure / invalid key flags as options to the module