### PR TITLE
Disable 'Extract ID3' Nightwatch tests

### DIFF
--- a/tests/browser/02_ops.js
+++ b/tests/browser/02_ops.js
@@ -126,8 +126,8 @@ module.exports = {
         // testOp(browser, "Extract email addresses", "test input", "test_output");
         // testOp(browser, "Extract file paths", "test input", "test_output");
         testOpFile(browser, "Extract Files", "files/Hitchhikers_Guide.jpeg", ".card:last-child .collapsed", "extracted_at_0x3d38.zlib");
-        testOpFile(browser, "Extract ID3", "files/mp3example.mp3", "tr:last-child td:last-child", "Kevin MacLeod");
-        // testOp(browser, "Extract IP addresses", "test input", "test_output");
+        // This test seems unreliable on GitHub Actions, not reproducible locally.
+        // testOpFile(browser, "Extract ID3", "files/mp3example.mp3", "tr:last-child td:last-child", "Kevin MacLeod");        // testOp(browser, "Extract IP addresses", "test input", "test_output");
         // testOp(browser, "Extract LSB", "test input", "test_output");
         // testOp(browser, "Extract MAC addresses", "test input", "test_output");
         // testOp(browser, "Extract RGBA", "test input", "test_output");


### PR DESCRIPTION
I hate to just disable tests, but this issue is not reproducible locally and has sat unfixed for over a year now.