### PR TITLE
Fix Ciphersaber2 key concatenation

### DIFF
--- a/src/core/lib/CipherSaber2.mjs
+++ b/src/core/lib/CipherSaber2.mjs
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  */
 export function encode(tempIVP, key, rounds, input) {
-    const ivp = new Uint8Array(key.concat(tempIVP));
+    const ivp = new Uint8Array([...key, ...tempIVP]);
     const state = new Array(256).fill(0);
     let j = 0, i = 0;
     const result = [];

--- a/tests/operations/tests/CipherSaber2.mjs
+++ b/tests/operations/tests/CipherSaber2.mjs
@@ -21,13 +21,16 @@ TestRegister.addTests([
         ],
     },
     {
+        // input taken from https://ciphersaber.gurus.org/
         name: "CipherSaber2 Decrypt",
-        input: "\x5d\xd9\x7f\xeb\x77\x3c\x42\x9d\xfe\x9c\x3b\x21\x63\xbd\x53\x38\x18\x7c\x36\x37",
-        expectedOutput: "helloworld",
+        input: "\x6f\x6d\x0b\xab\xf3\xaa\x67\x19\x03\x15\x30\xed\xb6\x77"  +
+            "\xca\x74\xe0\x08\x9d\xd0\xe7\xb8\x85\x43\x56\xbb\x14\x48\xe3" +
+            "\x7c\xdb\xef\xe7\xf3\xa8\x4f\x4f\x5f\xb3\xfd",
+        expectedOutput: "This is a test of CipherSaber.",
         recipeConfig: [
             {
                 op: "CipherSaber2 Decrypt",
-                args: [{ "option": "Latin1", "string": "test" }, 20],
+                args: [{ "option": "Latin1", "string": "asdfg" }, 1],
             },
         ],
     },


### PR DESCRIPTION
Previously the generated key was invalid because an Uint8Array was concatenated into a normal array but that wasn't supported by the concat function.

Effectively the IV was discarded so the cipher did not work :)
This should fix https://github.com/gchq/CyberChef/issues/1723