### PR TITLE
Fix CryptoJS argument passing in DeriveEVPKey

### DIFF
--- a/src/core/operations/DeriveEVPKey.mjs
+++ b/src/core/operations/DeriveEVPKey.mjs
@@ -62,11 +62,13 @@ class DeriveEVPKey extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const passphrase = Utils.convertToByteString(args[0].string, args[0].option),
+        const passphrase = CryptoJS.enc.Latin1.parse(
+                Utils.convertToByteString(args[0].string, args[0].option)),
             keySize = args[1] / 32,
             iterations = args[2],
             hasher = args[3],
-            salt = Utils.convertToByteString(args[4].string, args[4].option),
+            salt = CryptoJS.enc.Latin1.parse(
+                Utils.convertToByteString(args[4].string, args[4].option)),
             key = CryptoJS.EvpKDF(passphrase, salt, { // lgtm [js/insufficient-password-hash]
                 keySize: keySize,
                 hasher: CryptoJS.algo[hasher],


### PR DESCRIPTION
As pointed out in https://github.com/gchq/CyberChef/issues/1593, CryptoJS treats strings as Utf8, so for binary strings, Latin1 needs to be used.
This PR should fix that issue, and there are no other instances of raw strings being passed to CryptoJS methods.