### PR TITLE
Abort the previous bake when attempting the next autobake

### DIFF
--- a/src/web/App.mjs
+++ b/src/web/App.mjs
@@ -160,7 +160,12 @@ class App {
         // has completed.
         if (this.autoBakePause) return false;
 
-        if (this.autoBake_ && !this.baking) {
+        if (this.baking) {
+            this.manager.worker.cancelBakeForAutoBake();
+            this.baking = false;
+        }
+
+        if (this.autoBake_) {
             log.debug("Auto-baking");
             this.manager.worker.bakeInputs({
                 nums: [this.manager.tabs.getActiveTab("input")],

--- a/src/web/waiters/WorkerWaiter.mjs
+++ b/src/web/waiters/WorkerWaiter.mjs
@@ -323,6 +323,28 @@ class WorkerWaiter {
     }
 
     /**
+     * Cancels the current bake making it possible to autobake again
+     */
+    cancelBakeForAutoBake() {
+        if (this.totalOutputs > 1) {
+            this.cancelBake();
+        } else {
+            // In this case the UI changes can be skipped
+
+            for (let i = this.chefWorkers.length - 1; i >= 0; i--) {
+                if (this.chefWorkers[i].active) {
+                    this.removeChefWorker(this.chefWorkers[i]);
+                }
+            }
+
+            this.inputs = [];
+            this.inputNums = [];
+            this.totalOutputs = 0;
+            this.loadingOutputs = 0;
+        }
+    }
+
+    /**
      * Cancels the current bake by terminating and removing all ChefWorkers
      *
      * @param {boolean} [silent=false] - If true, don't set the output

--- a/tests/browser/01_io.js
+++ b/tests/browser/01_io.js
@@ -176,14 +176,12 @@ module.exports = {
         // Enable previously disabled autobake
         browser.click("#auto-bake-label");
 
-        browser
-            .sendKeys("#input-text .cm-content", "1");
+        browser.sendKeys("#input-text .cm-content", "1");
 
         browser.pause(500);
 
         // Make another change while the previous input is being baked
-        browser
-            .sendKeys("#input-text .cm-content", "2");
+        browser.sendKeys("#input-text .cm-content", "2");
 
         browser
             .waitForElementNotVisible("#stale-indicator")
@@ -670,6 +668,20 @@ module.exports = {
     },
 
     "Loading from URL": browser => {
+        utils.clear(browser);
+
+        /* Side panel displays correct info */
+        utils.uploadFile(browser, "files/TowelDay.jpeg");
+
+        browser
+            .waitForElementVisible("#input-text .cm-file-details")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-toggle-shown")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-thumbnail")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-name")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-size")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-type")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-loaded");
+
         /* Complex deep link populates the input correctly (encoding, eol, input) */
         browser
             .urlHash("recipe=To_Base64('A-Za-z0-9%2B/%3D')&input=VGhlIHNoaXBzIGh1bmcgaW4gdGhlIHNreSBpbiBtdWNoIHRoZSBzYW1lIHdheSB0aGF0IGJyaWNrcyBkb24ndC4M&ienc=21866&oenc=1201&ieol=FF&oeol=PS")

--- a/tests/browser/01_io.js
+++ b/tests/browser/01_io.js
@@ -191,6 +191,9 @@ module.exports = {
 
         // Ensure we got the latest input baked
         utils.expectOutput(browser, "input12");
+
+        // Turn autobake off again
+        browser.click("#auto-bake-label");
     },
 
     "Special content": browser => {

--- a/tests/browser/01_io.js
+++ b/tests/browser/01_io.js
@@ -167,6 +167,32 @@ module.exports = {
         browser.expect.element("#output-text .cm-status-bar .eol-value").text.to.equal("LF");
     },
 
+    "Autobaking the latest input": browser => {
+        // Use the sleep recipe to simulate a long running task
+        utils.loadRecipe(browser, "Sleep", "input", [2000]);
+
+        browser.waitForElementVisible("#stale-indicator");
+
+        // Enable previously disabled autobake
+        browser.click("#auto-bake-label");
+
+        browser
+            .sendKeys("#input-text .cm-content", "1");
+
+        browser.pause(500);
+
+        // Make another change while the previous input is being baked
+        browser
+            .sendKeys("#input-text .cm-content", "2");
+
+        browser
+            .waitForElementNotVisible("#stale-indicator")
+            .waitForElementNotVisible("#output-loader");
+
+        // Ensure we got the latest input baked
+        utils.expectOutput(browser, "input12");
+    },
+
     "Special content": browser => {
         /* Special characters are rendered correctly */
         utils.setInput(browser, SPECIAL_CHARS, false);


### PR DESCRIPTION
The current autobake design is that if the bake has already started, input updates do nothing.. This has proven to be counterintuitive, causing the issue https://github.com/gchq/CyberChef/issues/1467 to be reported (I think). Personally I'd also expect the autobake option to cause the previous bake to be aborted and restart with the new input..

Here's my attempt (at least there was an attempt...) at implementing this. The code is messy since I initially wanted to preserve the loader screen when changing input (canceling just the workers), but if the waiter has more than 1 output then I found that I need to call `cancelBake` anyway..

I was also able to test this behaviour thanks to the `Sleep` operation which makes reproducing the issue deterministic.