### PR TITLE
Require (a, 26) to be coprime in affine encode

### DIFF
--- a/src/core/lib/Ciphers.mjs
+++ b/src/core/lib/Ciphers.mjs
@@ -3,6 +3,7 @@
  *
  * @author Matt C [matt@artemisbot.uk]
  * @author n1474335 [n1474335@gmail.com]
+ * @author Evie H [evie@evie.sh]
  *
  * @copyright Crown Copyright 2018
  * @license Apache-2.0
@@ -10,6 +11,7 @@
  */
 
 import OperationError from "../errors/OperationError.mjs";
+import Utils from "../Utils.mjs";
 import CryptoJS from "crypto-js";
 
 /**
@@ -28,6 +30,10 @@ export function affineEncode(input, args) {
 
     if (!/^\+?(0|[1-9]\d*)$/.test(a) || !/^\+?(0|[1-9]\d*)$/.test(b)) {
         throw new OperationError("The values of a and b can only be integers.");
+    }
+
+    if (Utils.gcd(a, 26) !== 1) {
+        throw new OperationError("The value of `a` must be coprime to 26.");
     }
 
     for (let i = 0; i < input.length; i++) {

--- a/tests/browser/02_ops.js
+++ b/tests/browser/02_ops.js
@@ -37,7 +37,7 @@ module.exports = {
         testOp(browser, ["From Hex", "Add Text To Image", "To Base64"], Images.PNG_HEX, Images.PNG_CHEF_B64, [[], ["Chef", "Center", "Middle", 0, 0, 16], []]);
         testOp(browser, "Adler-32 Checksum", "test input", "16160411");
         testOp(browser, "Affine Cipher Decode", "test input", "rcqr glnsr", [1, 2]);
-        testOp(browser, "Affine Cipher Encode", "test input", "njln rbfpn", [2, 1]);
+        testOp(browser, "Affine Cipher Encode", "test input", "gndg zoujg", [3, 1]);
         testOp(browser, "AMF Decode", "\u000A\u0013\u0001\u0003a\u0006\u0009test", /"\$value": "test"/);
         testOp(browser, "AMF Encode", '{"a": "test"}', "\u000A\u0013\u0001\u0003a\u0006\u0009test");
         testOp(browser, "Analyse hash", "0123456789abcdef", /CRC-64/);


### PR DESCRIPTION
The affine multiplier is checked to be coprime to 26 in affine decode, but not encode, so this PR address that. It [doesn't make sense](https://en.wikipedia.org/wiki/Affine_cipher#Encryption) to allow non-coprime values in the cipher, as the resulting ciphertext is invalid and unable to be decoded.