### PR TITLE
Fix splitter resizing (#1805)

### DIFF
--- a/src/web/App.mjs
+++ b/src/web/App.mjs
@@ -307,7 +307,7 @@ class App {
             sizes: [20, 30, 50],
             minSize: minimise ? [0, 0, 0] : [240, 310, 450],
             gutterSize: 4,
-            expandToMin: true,
+            expandToMin: false,
             onDrag: debounce(function() {
                 this.adjustComponentSizes();
             }, 50, "dragSplitter", this, [])

--- a/tests/browser/01_io.js
+++ b/tests/browser/01_io.js
@@ -693,7 +693,14 @@ module.exports = {
         /* Complex deep link populates the input correctly (encoding, eol, input) */
         browser
             .urlHash("recipe=To_Base64('A-Za-z0-9%2B/%3D')&input=VGhlIHNoaXBzIGh1bmcgaW4gdGhlIHNreSBpbiBtdWNoIHRoZSBzYW1lIHdheSB0aGF0IGJyaWNrcyBkb24ndC4M&ienc=21866&oenc=1201&ieol=FF&oeol=PS")
-            .waitForElementVisible("#rec-list li.operation");
+            .waitForElementVisible("#rec-list li.operation")
+            .waitForElementVisible("#input-text .cm-file-details")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-toggle-shown")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-thumbnail")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-name")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-size")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-type")
+            .waitForElementVisible("#input-text .cm-file-details .file-details-loaded");
 
         browser.expect.element(`#input-text .cm-content`).to.have.property("textContent").match(/^.{65}$/);
         browser.expect.element("#input-text .cm-status-bar .stats-length-value").text.to.equal("66");


### PR DESCRIPTION
This is one way to fix #1805

This reverts the change of `expandToMin` from   6f6786d79e98259b81722624cb959ccee74e7208

Original opening in small window  
![orig_3](https://github.com/gchq/CyberChef/assets/36287452/2a1055b6-c9f5-4e3e-a850-3b173ce3c2dc)

After this change, opening in same sized window
![fixed_3](https://github.com/gchq/CyberChef/assets/36287452/9feaa08b-1686-4553-9361-956e5e3b841a)

After maximizing with original
![orig_maximized_3](https://github.com/gchq/CyberChef/assets/36287452/87eb786b-0b73-4876-a596-0093ef8a2d2b)

After maximizing this version  
![fixed_maximized_3](https://github.com/gchq/CyberChef/assets/36287452/cb5207f7-70ec-4b7f-8c7e-55baaaf88c37)

