### PR TITLE
Markdown To HTML Converter Improvement

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -465,7 +465,8 @@
             "BSON deserialise",
             "To MessagePack",
             "From MessagePack",
-            "Render Markdown"
+            "Render Markdown",
+            "Convert Markdown to HTML"
         ]
     },
     {

--- a/src/core/operations/MarkdownToHTML.mjs
+++ b/src/core/operations/MarkdownToHTML.mjs
@@ -9,7 +9,7 @@ import MarkdownIt from "markdown-it";
 import hljs from "highlight.js";
 
 /**
- * Render Markdown operation
+ * Convert Markdown to HTML operation
  */
 class MarkdownToHTML extends Operation {
 

--- a/src/core/operations/MarkdownToHTML.mjs
+++ b/src/core/operations/MarkdownToHTML.mjs
@@ -1,0 +1,69 @@
+/**
+ * @author yilmaz08
+ * @copyright Crown Copyright 2019
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import MarkdownIt from "markdown-it";
+import hljs from "highlight.js";
+
+/**
+ * Render Markdown operation
+ */
+class MarkdownToHTML extends Operation {
+
+    /**
+     * MarkdownToHTML constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Convert Markdown to HTML";
+        this.module = "Code";
+        this.description = "Converts input Markdown as plain HTML.";
+        this.infoURL = "https://wikipedia.org/wiki/Markdown";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Autoconvert URLs to links",
+                type: "boolean",
+                value: false
+            },
+            {
+                name: "Enable syntax highlighting",
+                type: "boolean",
+                value: true
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {html}
+     */
+    run(input, args) {
+        const [convertLinks, enableHighlighting] = args,
+            md = new MarkdownIt({
+                linkify: convertLinks,
+                html: false,
+                highlight: function(str, lang) {
+                    if (lang && hljs.getLanguage(lang) && enableHighlighting) {
+                        try {
+                            return hljs.highlight(lang, str).value;
+                        } catch (__) {}
+                    }
+
+                    return "";
+                }
+            }),
+            rendered = md.render(input);
+
+        return rendered;
+    }
+
+}
+
+export default MarkdownToHTML;


### PR DESCRIPTION
Since I had needed a Markdown to HTML converter before I thought it can also be added here. I copied RenderMarkdown.mjs and played with the new MarkdownToHTML.mjs a bit and made it return string output instead of html. So, now it returns plain html instead of rendering it.