### PR TITLE
Update Sitemap URLs to Use Valid Paths in sitemap.mjs

### DIFF
--- a/src/web/static/sitemap.mjs
+++ b/src/web/static/sitemap.mjs
@@ -15,14 +15,14 @@ const smStream = new sm.SitemapStream({
 });
 
 smStream.write({
-    url: "/",
+    url: "CyberChef/",
     changefreq: "weekly",
     priority: 1.0
 });
 
 for (const op in OperationConfig) {
     smStream.write({
-        url: `/?op=${encodeURIComponent(op)}`,
+        url: `CyberChef/?op=${encodeURIComponent(op)}`,
         changeFreq: "yearly",
         priority: 0.5
     });


### PR DESCRIPTION
There are errors in the sitemap.xml file generated by default. It can visit https://gchq.github.io/CyberChef/sitemap.xml to see the paths of all URLs that are missing from the CyberChef directory.

This PR updates the URLs in the sitemap to ensure they use valid paths, specifically updating the base path to include "CyberChef" where necessary.

Changes include:
- Line 18: Updating the root URL path from "/" to "/CyberChef/".
- Line 25: Modifying operation URLs from `/?op=...` to `/CyberChef/?op=...`.

These changes will help search engines properly index the CyberChef operations and improve the overall SEO of the site. This ensures that all generated sitemap URLs are accessible and correctly formatted.

Please review the changes. Thank you!