### PR TITLE
add offset field to 'Add Line Numbers' operation

### DIFF
--- a/src/core/operations/AddLineNumbers.mjs
+++ b/src/core/operations/AddLineNumbers.mjs
@@ -22,7 +22,13 @@ class AddLineNumbers extends Operation {
         this.description = "Adds line numbers to the output.";
         this.inputType = "string";
         this.outputType = "string";
-        this.args = [];
+        this.args = [
+            {
+                "name": "Offset",
+                "type": "number",
+                "value": 0
+            }
+        ];
     }
 
     /**
@@ -33,10 +39,11 @@ class AddLineNumbers extends Operation {
     run(input, args) {
         const lines = input.split("\n"),
             width = lines.length.toString().length;
+        const offset = parseInt(args[0], 10);
         let output = "";
 
         for (let n = 0; n < lines.length; n++) {
-            output += (n+1).toString().padStart(width, " ") + " " + lines[n] + "\n";
+            output += (n+1+offset).toString().padStart(width, " ") + " " + lines[n] + "\n";
         }
         return output.slice(0, output.length-1);
     }

--- a/src/core/operations/AddLineNumbers.mjs
+++ b/src/core/operations/AddLineNumbers.mjs
@@ -39,7 +39,7 @@ class AddLineNumbers extends Operation {
     run(input, args) {
         const lines = input.split("\n"),
             width = lines.length.toString().length;
-        const offset = parseInt(args[0], 10);
+        const offset = args[0] ? parseInt(args[0], 10) : 0;
         let output = "";
 
         for (let n = 0; n < lines.length; n++) {


### PR DESCRIPTION
For issue: https://github.com/gchq/CyberChef/issues/1865

Very simple change. Default offset is 0, so this should only add to existing functionality

I think this is particularly useful for including line numbers for code snippets when the original source is important.

eg: 
![image](https://github.com/user-attachments/assets/8fffa097-12df-424e-9c93-5cf7abdcf261)
