### PR TITLE
Added the ability to paste one or more Images from the Clipboard

### DIFF
--- a/src/web/waiters/InputWaiter.mjs
+++ b/src/web/waiters/InputWaiter.mjs
@@ -151,6 +151,18 @@ class InputWaiter {
                 // Event handlers
                 EditorView.domEventHandlers({
                     paste(event, view) {
+                        const clipboardData = event.clipboardData || window.clipboardData;
+                        const items = clipboardData.items;
+                        event.target.files = [];
+                        for (let i = 0; i < items.length; i++) {
+                            const item = items[i];
+                            if (item.type.indexOf("image") !== -1) {
+                                const file = item.getAsFile();
+                                event.target.files.push(file);
+
+                                event.preventDefault(); // Prevent the default paste behavior
+                            }
+                        }
                         setTimeout(() => {
                             self.afterPaste(event);
                         });
@@ -917,6 +929,9 @@ class InputWaiter {
      * @param {event} e
      */
     afterPaste(e) {
+        if (e.target.files) {
+            this.loadUIFiles(e.target.files);
+        }
         // If EOL has been fixed, skip this.
         if (this.eolState > 1) return;
 


### PR DESCRIPTION
We have added the ability to paste one or more images directly from the clipboard. This is especially useful if we need screenshots as input, e.g., for QR code analysis. 

To use this feature:
1. Copy image to clipboard (e.g. by taking a screenshot)
2. Paste it into the input field, just like you would paste text
3. Work with CyberChef as if the image was loaded as a file



