### PR TITLE
Make package build multi-platform by adding linux/arm64/v8

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -61,7 +61,7 @@ jobs:
         tags: ${{ steps.image-metadata.outputs.tags }}
         labels: ${{ steps.image-metadata.outputs.labels }}
         containerfiles: ./Dockerfile
-        platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
+        platforms: linux/amd64,linux/arm64/v8
         oci: true
         # Webpack seems to use a lot of open files, increase the max open file limit to accomodate.
         extra-args: |

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -61,7 +61,7 @@ jobs:
         tags: ${{ steps.image-metadata.outputs.tags }}
         labels: ${{ steps.image-metadata.outputs.labels }}
         containerfiles: ./Dockerfile
-        platforms: linux/amd64,linux/arm64/v8
+        platforms: linux/amd64,linux/arm64
         oci: true
         # Webpack seems to use a lot of open files, increase the max open file limit to accomodate.
         extra-args: |

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -61,7 +61,7 @@ jobs:
         tags: ${{ steps.image-metadata.outputs.tags }}
         labels: ${{ steps.image-metadata.outputs.labels }}
         containerfiles: ./Dockerfile
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
         oci: true
         # Webpack seems to use a lot of open files, increase the max open file limit to accomodate.
         extra-args: |

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Apt update
+      run: sudo apt-get update
+    - name: apt install buildah qemu-user-static
+      run: sudo apt-get install -y buildah qemu-user-static
+
     - name: Set node version
       uses: actions/setup-node@v3
       with:
@@ -61,7 +66,7 @@ jobs:
         tags: ${{ steps.image-metadata.outputs.tags }}
         labels: ${{ steps.image-metadata.outputs.labels }}
         containerfiles: ./Dockerfile
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64, linux/arm64
         oci: true
         # Webpack seems to use a lot of open files, increase the max open file limit to accomodate.
         extra-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:18-alpine AS build
+FROM --platform=${PLATFORM} node:18-alpine AS build
 
 COPY . .
 RUN npm ci
 RUN npm run build
 
-FROM nginx:1.25-alpine3.18 AS cyberchef
+FROM --platform=${PLATFORM} nginx:1.25-alpine3.18 AS cyberchef
 
 COPY --from=build ./build/prod /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG PLATFORM
+
 FROM --platform=${PLATFORM} node:18-alpine AS build
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-ARG PLATFORM
-
-FROM --platform=${PLATFORM} node:18-alpine AS build
+FROM node:18-alpine AS build
 
 COPY . .
 RUN npm ci
 RUN npm run build
 
-FROM --platform=${PLATFORM} nginx:1.25-alpine3.18 AS cyberchef
+FROM nginx:1.25-alpine3.18 AS cyberchef
 
 COPY --from=build ./build/prod /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:18-alpine AS build
+ARG PLATFORM
+
+FROM --platform=${PLATFORM} node:18-alpine AS build
 
 COPY . .
 RUN npm ci
 RUN npm run build
 
-FROM nginx:1.25-alpine3.18 AS cyberchef
+FROM --platform=${PLATFORM} nginx:1.25-alpine3.18 AS cyberchef
 
 COPY --from=build ./build/prod /usr/share/nginx/html/


### PR DESCRIPTION
Currently it only supports amd64 which doesn't work on raspberry pi. So i added linux/arm64/v8 platform. This can be later refined as required.
Ref: https://github.com/grocy/grocy-docker/blob/main/.github/workflows/publish.yml#L43