### PR TITLE
Add an Operation to Decode a URI to a JSON Object

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -238,6 +238,7 @@
             "Parse UDP",
             "Parse SSH Host Key",
             "Parse URI",
+            "Extract URI",
             "URL Encode",
             "URL Decode",
             "Protobuf Decode",

--- a/src/core/operations/ExtractURI.mjs
+++ b/src/core/operations/ExtractURI.mjs
@@ -1,0 +1,58 @@
+/**
+ * @author David Tomaschik [dwt@google.com]
+ * @copyright Google LLC 2024
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+
+/**
+ * Extract a URI to JSON Operation
+ */
+class ExtractURI extends Operation {
+    /**
+     * ExtractURI Constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Extract URI";
+        this.module = "URL";
+        this.description = "Extract components of URI to JSON for further processing.";
+        this.infoURL = "https://wikipedia.org/wiki/Uniform_Resource_Identifier";
+        this.inputType = "string";
+        this.outputType = "JSON";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {JSON}
+     */
+    run(input, args) {
+        const uri = new URL(input);
+        const pieces = {};
+        // Straight copy some attributes
+        ['protocol', 'hostname', 'port', 'username', 'password', 'pathname', 'hash'
+            ].forEach((name) => {
+                if (uri[name]) pieces[name] = uri[name];
+        });
+        // Now handle query params
+        const params = uri.searchParams;
+        if (params.size) {
+            pieces['query'] = {};
+            for (const name of params.keys()) {
+                const values = params.getAll(name);
+                if (values.length > 1) {
+                    pieces['query'][name] = values;
+                } else {
+                    pieces['query'][name] = values[0];
+                }
+            }
+        }
+        return pieces;
+    }
+};
+
+export default ExtractURI;

--- a/src/core/operations/ExtractURI.mjs
+++ b/src/core/operations/ExtractURI.mjs
@@ -34,20 +34,27 @@ class ExtractURI extends Operation {
         const uri = new URL(input);
         const pieces = {};
         // Straight copy some attributes
-        ['protocol', 'hostname', 'port', 'username', 'password', 'pathname', 'hash'
-            ].forEach((name) => {
-                if (uri[name]) pieces[name] = uri[name];
+        [
+            "hash",
+            "hostname",
+            "password",
+            "pathname",
+            "port",
+            "protocol",
+            "username"
+        ].forEach((name) => {
+            if (uri[name]) pieces[name] = uri[name];
         });
         // Now handle query params
         const params = uri.searchParams;
         if (params.size) {
-            pieces['query'] = {};
+            pieces.query = {};
             for (const name of params.keys()) {
                 const values = params.getAll(name);
                 if (values.length > 1) {
-                    pieces['query'][name] = values;
+                    pieces.query[name] = values;
                 } else {
-                    pieces['query'][name] = values[0];
+                    pieces.query[name] = values[0];
                 }
             }
         }

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -64,6 +64,7 @@ import "./tests/ELFInfo.mjs";
 import "./tests/Enigma.mjs";
 import "./tests/ExtractEmailAddresses.mjs";
 import "./tests/ExtractHashes.mjs";
+import "./tests/ExtractURI.mjs";
 import "./tests/Float.mjs";
 import "./tests/FileTree.mjs";
 import "./tests/FletcherChecksum.mjs";

--- a/tests/operations/tests/ExtractURI.mjs
+++ b/tests/operations/tests/ExtractURI.mjs
@@ -1,0 +1,36 @@
+/**
+ * Extract URI Tests
+ *
+ * @author David Tomaschik [dwt@google.com]
+ * @copyright Google LLC 2024
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Extract URI: Test",
+        input: "http://www.example.org:9999/path?foo=bar&baz=1&baz=2#frob",
+        expectedOutput: JSON.stringify({
+            "protocol": "http:",
+            "hostname": "www.example.org",
+            "port": "9999",
+            "pathname": "/path",
+            "hash": "#frob",
+            "query": {
+                "foo": "bar",
+                "baz": [
+                    "1",
+                    "2"
+                ]
+            }
+        }, null, 4),
+        recipeConfig: [
+            {
+                "op": "Extract URI",
+                "args": [],
+            }
+        ]
+    }
+]);

--- a/tests/operations/tests/ExtractURI.mjs
+++ b/tests/operations/tests/ExtractURI.mjs
@@ -13,11 +13,11 @@ TestRegister.addTests([
         name: "Extract URI: Test",
         input: "http://www.example.org:9999/path?foo=bar&baz=1&baz=2#frob",
         expectedOutput: JSON.stringify({
-            "protocol": "http:",
-            "hostname": "www.example.org",
-            "port": "9999",
-            "pathname": "/path",
             "hash": "#frob",
+            "hostname": "www.example.org",
+            "pathname": "/path",
+            "port": "9999",
+            "protocol": "http:",
             "query": {
                 "foo": "bar",
                 "baz": [


### PR DESCRIPTION
This essentially turns `http://www.example.org:9999/path?foo=bar&baz=1&baz=2#frob` into the following:

```
{
    "protocol": "http:",
    "hostname": "www.example.org",
    "port": "9999",
    "pathname": "/path",
    "hash": "#frob",
    "query": {
        "foo": "bar",
        "baz": [
            "1",
            "2"
        ]
    }
}
```

This is more or less just exposing the [WHATWG URL API](https://url.spec.whatwg.org/#api) to allow further processing of URL components (i.e., via JPATH selectors).