### PR TITLE
Add 'Generate SSHA Hash' operation

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -432,7 +432,8 @@
             "CRC-8 Checksum",
             "CRC-16 Checksum",
             "CRC-32 Checksum",
-            "TCP/IP Checksum"
+            "TCP/IP Checksum",
+            "Generate SSHA Hash"
         ]
     },
     {

--- a/src/core/operations/GenerateSSHAHash.mjs
+++ b/src/core/operations/GenerateSSHAHash.mjs
@@ -1,0 +1,46 @@
+/**
+ * @author git-commit-amen [daniel@danielwallace.com.au]
+ * @copyright Crown Copyright 2024
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import CryptoJS from "crypto-js";
+
+/**
+ * Generate SSHA Hash operation
+ */
+class GenerateSSHAHash extends Operation {
+
+    /**
+     * GenerateSSHAHash constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Generate SSHA Hash";
+        this.module = "Crypto";
+        this.description = "Generates an RFC 2307-compliant, cryptographically-secure SSHA (Salted SHA1) password hash - commonly used for storing passwords in systems such as OpenLDAP.";
+        this.infoURL = "https://www.openldap.org/faq/data/cache/347.html";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        if (!input) return "";
+
+        const salt = CryptoJS.lib.WordArray.random(128/8).toString().substr(0, 4);
+        const hash = CryptoJS.SHA1(input + salt);
+        const result = CryptoJS.enc.Latin1.parse(hash.toString(CryptoJS.enc.Latin1) + salt).toString(CryptoJS.enc.Base64);
+        return `{SSHA}${result}`;
+    }
+
+}
+
+export default GenerateSSHAHash;


### PR DESCRIPTION
This operation generates an RFC 2307-compliant, cryptographically-secure SSHA (Salted SHA1) password hash - commonly used for storing passwords in systems such as OpenLDAP.

More detail here on SSHA:
https://www.openldap.org/faq/data/cache/347.html

Some things to note:

- Contrary what the similar-sounding name may suggest, this is different to the existing SHA1 operation (although does _use_ SHA1 in part) and despite the code being very simple, it is actually a surprisingly difficult recipe to build in CyberChef using the existing set of operations
- No automated test is applicable for this. This is because the output (although derived from the input) is not deterministic, as it involves a random IV
- Given the intended use case of this involves entering a password into the input field, it would have been great to include a 'Mask Input' checkbox in the operation which causes the input field to mask, however I could not find any way to programmatically do this without attempting something extremely hacky... which just didn't seem right. Happy to consider any alternative options anyone may know of for that if it sounds like a good idea though.