### PR TITLE
Add 'header' ingredient to JWT Sign operation

### DIFF
--- a/src/core/operations/JWTSign.mjs
+++ b/src/core/operations/JWTSign.mjs
@@ -36,6 +36,11 @@ class JWTSign extends Operation {
                 name: "Signing algorithm",
                 type: "option",
                 value: JWT_ALGORITHMS
+            },
+            {
+                name: "Header",
+                type: "text",
+                value: "{}"
             }
         ];
     }
@@ -46,11 +51,12 @@ class JWTSign extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const [key, algorithm] = args;
+        const [key, algorithm, header] = args;
 
         try {
             return jwt.sign(input, key, {
-                algorithm: algorithm === "None" ? "none" : algorithm
+                algorithm: algorithm === "None" ? "none" : algorithm,
+                header: JSON.parse(header || "{}")
             });
         } catch (err) {
             throw new OperationError(`Error: Have you entered the key correctly? The key should be either the secret for HMAC algorithms or the PEM-encoded private key for RSA and ECDSA.

--- a/tests/operations/tests/JWTSign.mjs
+++ b/tests/operations/tests/JWTSign.mjs
@@ -44,7 +44,18 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [hsKey, "HS256"],
+                args: [hsKey, "HS256", "{}"],
+            }
+        ],
+    },
+    {
+        name: "JWT Sign: HS256 with custom header",
+        input: inputObject,
+        expectedOutput: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImN1c3RvbS5rZXkifQ.eyJTdHJpbmciOiJTb21lU3RyaW5nIiwiTnVtYmVyIjo0MiwiaWF0IjoxfQ.kXln8btJburfRlND8IDZAQ8NZGFFZhvHyooHa6N9za8",
+        recipeConfig: [
+            {
+                op: "JWT Sign",
+                args: [hsKey, "HS256", `{"kid":"custom.key"}`],
             }
         ],
     },
@@ -55,7 +66,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [hsKey, "HS384"],
+                args: [hsKey, "HS384", "{}"],
             }
         ],
     },
@@ -66,7 +77,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [hsKey, "HS512"],
+                args: [hsKey, "HS512", "{}"],
             }
         ],
     },
@@ -77,7 +88,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [esKey, "ES256"],
+                args: [esKey, "ES256", "{}"],
             },
             {
                 op: "JWT Decode",
@@ -92,7 +103,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [esKey, "ES384"],
+                args: [esKey, "ES384", "{}"],
             },
             {
                 op: "JWT Decode",
@@ -107,7 +118,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [esKey, "ES512"],
+                args: [esKey, "ES512", "{}"],
             },
             {
                 op: "JWT Decode",
@@ -122,7 +133,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [rsKey, "RS256"],
+                args: [rsKey, "RS256", "{}"],
             },
             {
                 op: "JWT Decode",
@@ -137,7 +148,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [rsKey, "RS384"],
+                args: [rsKey, "RS384", "{}"],
             },
             {
                 op: "JWT Decode",
@@ -152,7 +163,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 op: "JWT Sign",
-                args: [esKey, "RS512"],
+                args: [esKey, "RS512", "{}"],
             },
             {
                 op: "JWT Decode",


### PR DESCRIPTION
Expose the 'header' option of the [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken?tab=readme-ov-file#usage) module as an ingredient. This allows for [adding and overwriting](https://github.com/auth0/node-jsonwebtoken/blob/bc28861f1fa981ed9c009e29c044a19760a0b128/sign.js#L97) JWT header fields such as `type` or `kid`.

![header-ingredient](https://github.com/user-attachments/assets/0d08c198-bada-4eb0-9a94-bf7f43c573c5)

Not sure how you typically handle JSON input like this. Should it be sanitized before passing it into the jwt library?