### PR TITLE
Load the user's preferred color scheme if the URL contains an invalid theme

### DIFF
--- a/src/web/waiters/OptionsWaiter.mjs
+++ b/src/web/waiters/OptionsWaiter.mjs
@@ -160,16 +160,31 @@ class OptionsWaiter {
 
         // Update theme selection
         const themeSelect = document.getElementById("theme");
-        themeSelect.selectedIndex = themeSelect.querySelector(`option[value="${theme}"`).index;
+        let themeOption = themeSelect.querySelector(`option[value="${theme}"]`);
+
+        if (!themeOption) {
+            const preferredColorScheme = this.getPreferredColorScheme();
+            document.querySelector(":root").className = preferredColorScheme;
+            themeOption = themeSelect.querySelector(`option[value="${preferredColorScheme}"]`);
+        }
+
+        themeSelect.selectedIndex = themeOption.index;
     }
 
     /**
      * Applies the user's preferred color scheme using the `prefers-color-scheme` media query.
      */
     applyPreferredColorScheme() {
-        const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
-        const theme = prefersDarkScheme ? "dark" : "classic";
+        const theme = this.getPreferredColorScheme();
         this.changeTheme(theme);
+    }
+
+    /**
+     * Get the user's preferred color scheme using the `prefers-color-scheme` media query.
+     */
+    getPreferredColorScheme() {
+        const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        return prefersDarkScheme ? "dark" : "classic";
     }
 
     /**


### PR DESCRIPTION
### What: 

- Load the user's preferred color scheme if the URL contains an invalid theme.
- Fix: #1996 

### To Reproduce

visit: https://gchq.github.io/CyberChef?theme=foo where foo is not a valid theme name.
It does not occur when foo is a valid theme name or for https://gchq.github.io/CyberChef

Expected behaviour

Cyberchef should probably give an "invalid theme" message or load with the default theme.
