### PR TITLE
fix: use defaultIndex instead of 0 in transformArgs

### DIFF
--- a/src/node/api.mjs
+++ b/src/node/api.mjs
@@ -74,11 +74,11 @@ function transformArgs(opArgsList, newArgs) {
     return opArgs.map((arg) => {
         if (arg.type === "option") {
             // pick default option if not already chosen
-            return typeof arg.value === "string" ? arg.value : arg.value[0];
+            return typeof arg.value === "string" ? arg.value : arg.value[arg.defaultIndex ?? 0];
         }
 
         if (arg.type === "editableOption") {
-            return typeof arg.value === "string" ? arg.value : arg.value[0].value;
+            return typeof arg.value === "string" ? arg.value : arg.value[arg.defaultIndex ?? 0].value;
         }
 
         if (arg.type === "toggleString") {


### PR DESCRIPTION
This ensures that when recipes are calling ingredients without arguments using the API, the proper defaults are used.

When used in a browser, CyberChef fills in the proper defaults when the ingredient form is rendered (and subsequently alters the url), however, unit tests could still fail. E.g., calling `generate_UUID()` should use 'v4' as the default UUID version, but would pick 'v1' (the first option in the list). See also #2011.