### PR TITLE
Add to ECDSA Verify the message format

### DIFF
--- a/src/core/operations/ECDSAVerify.mjs
+++ b/src/core/operations/ECDSAVerify.mjs
@@ -9,6 +9,7 @@ import OperationError from "../errors/OperationError.mjs";
 import { fromBase64 } from "../lib/Base64.mjs";
 import { toHexFast } from "../lib/Hex.mjs";
 import r from "jsrsasign";
+import Utils from "../Utils.mjs";
 
 /**
  * ECDSA Verify operation
@@ -59,6 +60,11 @@ class ECDSAVerify extends Operation {
                 name: "Message",
                 type: "text",
                 value: ""
+            },
+            {
+                name: "Message format",
+                type: "option",
+                value: ["Raw", "Hex", "Base64"]
             }
         ];
     }
@@ -70,7 +76,7 @@ class ECDSAVerify extends Operation {
      */
     run(input, args) {
         let inputFormat = args[0];
-        const [, mdAlgo, keyPem, msg] = args;
+        const [, mdAlgo, keyPem, msg, msgFormat] = args;
 
         if (keyPem.replace("-----BEGIN PUBLIC KEY-----", "").length === 0) {
             throw new OperationError("Please enter a public key.");
@@ -145,7 +151,8 @@ class ECDSAVerify extends Operation {
             throw new OperationError("Provided key is not a public key.");
         }
         sig.init(key);
-        sig.updateString(msg);
+        const messageStr = Utils.convertToByteString(msg, msgFormat);
+        sig.updateString(messageStr);
         const result = sig.verify(signatureASN1Hex);
         return result ? "Verified OK" : "Verification Failure";
     }

--- a/tests/operations/tests/ECDSA.mjs
+++ b/tests/operations/tests/ECDSA.mjs
@@ -6,7 +6,10 @@
  * @license Apache-2.0
  */
 import TestRegister from "../../lib/TestRegister.mjs";
-import { ASCII_TEXT } from "../../samples/Ciphers.mjs";
+import {ALL_BYTES, ASCII_TEXT, UTF8_TEXT} from "../../samples/Ciphers.mjs";
+
+const SOME_HEX_BYTES = "cdb23f958e018418621d9e489b7bba0f0c481f604eba2eb1ea35e38f99490cc0";
+const SOME_BASE64_BYTES = "zbI/lY4BhBhiHZ5Im3u6DwxIH2BOui6x6jXjj5lJDMA=";
 
 const P256 = {
     // openssl ecparam -name prime256v1 -genkey -noout -out p256.priv.key
@@ -104,7 +107,7 @@ TestRegister.addTests([
             },
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "MD5", P256.publicKey, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "MD5", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -119,7 +122,7 @@ TestRegister.addTests([
             },
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-1", P256.publicKey, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-1", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -134,7 +137,7 @@ TestRegister.addTests([
             },
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-256", P256.publicKey, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-256", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -149,7 +152,7 @@ TestRegister.addTests([
             },
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-384", P256.publicKey, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-384", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -164,7 +167,7 @@ TestRegister.addTests([
             },
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-512", P256.publicKey, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-512", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -179,7 +182,7 @@ TestRegister.addTests([
             },
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-256", P256.publicKey, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-256", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -194,7 +197,7 @@ TestRegister.addTests([
             },
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-384", P384.publicKey, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-384", P384.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -209,7 +212,7 @@ TestRegister.addTests([
             },
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-512", P521.publicKey, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-512", P521.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -246,7 +249,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "ECDSA Verify",
-                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT]
+                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -257,7 +260,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "ECDSA Verify",
-                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT]
+                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -268,7 +271,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "ECDSA Verify",
-                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT]
+                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -279,7 +282,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "ECDSA Verify",
-                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT]
+                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -290,7 +293,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "ECDSA Verify",
-                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT]
+                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -301,7 +304,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "ECDSA Verify",
-                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT]
+                "args": ["Auto", "SHA-256", P256.publicKey, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -312,7 +315,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-256", P256.privateKeyPkcs1, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-256", P256.privateKeyPkcs1, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -323,7 +326,7 @@ TestRegister.addTests([
         recipeConfig: [
             {
                 "op": "ECDSA Verify",
-                "args": ["ASN.1 HEX", "SHA-256", PEM_PUB_RSA512, ASCII_TEXT]
+                "args": ["ASN.1 HEX", "SHA-256", PEM_PUB_RSA512, ASCII_TEXT, "Raw"]
             }
         ]
     },
@@ -458,6 +461,74 @@ TestRegister.addTests([
             {
                 "op": "ECDSA Signature Conversion",
                 "args": ["Auto", "Raw JSON"]
+            }
+        ]
+    },
+    {
+        name: "ECDSA Sign/Verify: P-256 with SHA256 UTF8",
+        input: UTF8_TEXT,
+        expectedOutput: "Verified OK",
+        recipeConfig: [
+            {
+                "op": "ECDSA Sign",
+                "args": [P256.privateKeyPkcs1, "SHA-256", "ASN.1 HEX"]
+            },
+            {
+                "op": "ECDSA Verify",
+                "args": ["ASN.1 HEX", "SHA-256", P256.publicKey, UTF8_TEXT, "Raw"]
+            }
+        ]
+    },
+    {
+        name: "ECDSA Sign/Verify: P-256 with SHA256 bytes raw",
+        input: ALL_BYTES,
+        expectedOutput: "Verified OK",
+        recipeConfig: [
+            {
+                "op": "ECDSA Sign",
+                "args": [P256.privateKeyPkcs1, "SHA-256", "ASN.1 HEX"]
+            },
+            {
+                "op": "ECDSA Verify",
+                "args": ["ASN.1 HEX", "SHA-256", P256.publicKey, ALL_BYTES, "Raw"]
+            }
+        ]
+    },
+    {
+        name: "ECDSA Sign/Verify: P-256 with SHA256 bytes hex",
+        input: SOME_HEX_BYTES,
+        expectedOutput: "Verified OK",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["Auto"]
+            },
+            {
+                "op": "ECDSA Sign",
+                "args": [P256.privateKeyPkcs1, "SHA-256", "ASN.1 HEX"]
+            },
+            {
+                "op": "ECDSA Verify",
+                "args": ["ASN.1 HEX", "SHA-256", P256.publicKey, SOME_HEX_BYTES, "Hex"]
+            }
+        ]
+    },
+    {
+        name: "ECDSA Sign/Verify: P-256 with SHA256 bytes Base64",
+        input: SOME_BASE64_BYTES,
+        expectedOutput: "Verified OK",
+        recipeConfig: [
+            {
+                "op": "From Base64",
+                "args": ["A-Za-z0-9+/=", true]
+            },
+            {
+                "op": "ECDSA Sign",
+                "args": [P256.privateKeyPkcs1, "SHA-256", "ASN.1 HEX"]
+            },
+            {
+                "op": "ECDSA Verify",
+                "args": ["ASN.1 HEX", "SHA-256", P256.publicKey, SOME_BASE64_BYTES, "Base64"]
             }
         ]
     }


### PR DESCRIPTION
Hi,

ECDSA signature verification had no option for the incoming message format (like RSA Sign Verify). I have added it and created some test.

Thank you for this wonderful tool,

Best regards