### PR TITLE
Re-enable Npm Release in github workflows

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -92,6 +92,5 @@ jobs:
 
     - name: Publish to NPM
       uses: JS-DevTools/npm-publish@v1
-      if: false
       with:
         token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Workflow task `Publish to NPM` was disabled for testing on a fork, however we should re-enable on main before the next release.