### PR TITLE
Add toggle "+" character to URLDecode operation

### DIFF
--- a/src/core/operations/URLDecode.mjs
+++ b/src/core/operations/URLDecode.mjs
@@ -23,7 +23,13 @@ class URLDecode extends Operation {
         this.infoURL = "https://wikipedia.org/wiki/Percent-encoding";
         this.inputType = "string";
         this.outputType = "string";
-        this.args = [];
+        this.args = [
+            {
+                "name": "Treat \"+\" as space",
+                "type": "boolean",
+                "value": true
+            },
+        ];
         this.checks = [
             {
                 pattern: ".*(?:%[\\da-f]{2}.*){4}",
@@ -39,7 +45,8 @@ class URLDecode extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const data = input.replace(/\+/g, "%20");
+        const plusIsSpace = args[0];
+        const data = plusIsSpace ? input.replace(/\+/g, "%20") : input;
         try {
             return decodeURIComponent(data);
         } catch (err) {

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -163,6 +163,7 @@ import "./tests/TranslateDateTimeFormat.mjs";
 import "./tests/Typex.mjs";
 import "./tests/UnescapeString.mjs";
 import "./tests/Unicode.mjs";
+import "./tests/URLEncodeDecode.mjs";
 import "./tests/RSA.mjs";
 import "./tests/CBOREncode.mjs";
 import "./tests/CBORDecode.mjs";

--- a/tests/operations/tests/URLEncodeDecode.mjs
+++ b/tests/operations/tests/URLEncodeDecode.mjs
@@ -1,0 +1,92 @@
+/**
+ * URLEncode and URLDecode tests.
+ *
+ * @author es45411 [135977478+es45411@users.noreply.github.com]
+ *
+ * @copyright Crown Copyright 2018
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    // URL Decode
+    {
+        name: "URLDecode: nothing",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                op: "URL Decode",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "URLDecode: spaces without special chars",
+        input: "Hello%20world%21",
+        expectedOutput: "Hello world!",
+        recipeConfig: [
+            {
+                op: "URL Decode",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "URLDecode: spaces with special chars",
+        input: "Hello%20world!",
+        expectedOutput: "Hello world!",
+        recipeConfig: [
+            {
+                op: "URL Decode",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "URLDecode: decode plus as space",
+        input: "Hello%20world!",
+        expectedOutput: "Hello world!",
+        recipeConfig: [
+            {
+                op: "URL Decode",
+                args: [],
+            },
+        ],
+    },
+    // URL Encode
+    {
+        name: "URLEncode: nothing",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                op: "URL Encode",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "URLEncode: spaces without special chars",
+        input: "Hello world!",
+        expectedOutput: "Hello%20world!",
+        recipeConfig: [
+            {
+                op: "URL Encode",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "URLEncode: spaces with special chars",
+        input: "Hello world!",
+        expectedOutput: "Hello%20world%21",
+        recipeConfig: [
+            {
+                op: "URL Encode",
+                args: [true],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
Adds option to disable treating "+" character as space in URLDecode operation. Fixes issue https://github.com/gchq/CyberChef/issues/1477

Changes originate from https://github.com/gchq/CyberChef/pull/1483