### PR TITLE
Octal ip addresses

### DIFF
--- a/src/core/operations/ExtractIPAddresses.mjs
+++ b/src/core/operations/ExtractIPAddresses.mjs
@@ -21,7 +21,7 @@ class ExtractIPAddresses extends Operation {
 
         this.name = "Extract IP addresses";
         this.module = "Regex";
-        this.description = "Extracts all IPv4 and IPv6 addresses.<br><br>Warning: Given a string <code>710.65.0.456</code>, this will match <code>10.65.0.45</code> so always check the original input!";
+        this.description = "Extracts all IPv4 and IPv6 addresses.<br><br>Warning: Given a string <code>1.2.3.4.5.6.7.8</code>, this will match <code>1.2.3.4 and 5.6.7.8</code> so always check the original input!";
         this.inputType = "string";
         this.outputType = "string";
         this.args = [

--- a/src/core/operations/ExtractIPAddresses.mjs
+++ b/src/core/operations/ExtractIPAddresses.mjs
@@ -67,12 +67,16 @@ class ExtractIPAddresses extends Operation {
         const [includeIpv4, includeIpv6, removeLocal, displayTotal, sort, unique] = args,
 
             // IPv4 decimal groups can have values 0 to 255. To construct a regex the following sub-regex is reused:
-            ipv4DecimalByte = "(?:25[0-5]|2[0-4]\\d|1?[1-9]\\d|\\d)",
+            ipv4DecimalByte = "(?:25[0-5]|2[0-4]\\d|1?[0-9]\\d|\\d)",
             ipv4OctalByte = "(?:0[1-3]?[0-7]{1,2})",
 
-            // Each variant requires exactly 4 groups with literal . between
-            ipv4Decimal = "(?:" + ipv4DecimalByte + "\\.){3}" + "(?:" + ipv4DecimalByte + ")",
-            ipv4Octal = "(?:" + ipv4OctalByte + "\\.){3}" + "(?:" + ipv4OctalByte + ")",
+            // Look behind and ahead will be used to exclude matches with additional decimal digits left and right of IP address
+            lookBehind = "(?<!\\d)",
+            lookAhead = "(?!\\d)",
+
+            // Each variant requires exactly 4 groups with literal . between.
+            ipv4Decimal = "(?:" + lookBehind + ipv4DecimalByte + "\\.){3}" + "(?:" + ipv4DecimalByte + lookAhead + ")",
+            ipv4Octal = "(?:" + lookBehind + ipv4OctalByte + "\\.){3}" + "(?:" + ipv4OctalByte + lookAhead + ")",
 
             // Then we allow IPv4 addresses to be expressed either entirely in decimal or entirely in Octal
             ipv4 = "(?:" + ipv4Decimal + "|" + ipv4Octal + ")",

--- a/src/core/operations/ExtractIPAddresses.mjs
+++ b/src/core/operations/ExtractIPAddresses.mjs
@@ -65,8 +65,17 @@ class ExtractIPAddresses extends Operation {
      */
     run(input, args) {
         const [includeIpv4, includeIpv6, removeLocal, displayTotal, sort, unique] = args,
-            // This regex has two major options; decimal values 0-255 or octal values prefixed with 0 up to 377
-            ipv4 = "(?:(?:(?:25[0-5]|2[0-4]\\d|1?[1-9]\\d|\\d)\\.){3}(?:(?:25[0-5]|2[0-4]\\d|1?[1-9]\\d|\\d)))|(?:(?:(?:0[1-3]?[0-7]{0,2})\\.){3}(?:0[1-3]?[0-7]{0,2}))",
+
+            // IPv4 decimal groups can have values 0 to 255. To construct a regex the following sub-regex is reused:
+            ipv4DecimalByte = "(?:25[0-5]|2[0-4]\\d|1?[1-9]\\d|\\d)",
+            ipv4OctalByte = "(?:0[1-3]?[0-7]{1,2})",
+
+            // Each variant requires exactly 4 groups with literal . between
+            ipv4Decimal = "(?:" + ipv4DecimalByte + "\\.){3}" + "(?:" + ipv4DecimalByte + ")",
+            ipv4Octal = "(?:" + ipv4OctalByte + "\\.){3}" + "(?:" + ipv4OctalByte + ")",
+
+            // Then we allow IPv4 addresses to be expressed either entirely in decimal or entirely in Octal
+            ipv4 = "(?:" + ipv4Decimal + "|" + ipv4Octal + ")",
             ipv6 = "((?=.*::)(?!.*::.+::)(::)?([\\dA-F]{1,4}:(:|\\b)|){5}|([\\dA-F]{1,4}:){6})(([\\dA-F]{1,4}((?!\\3)::|:\\b|(?![\\dA-F])))|(?!\\2\\3)){2}";
         let ips  = "";
 

--- a/src/core/operations/ExtractIPAddresses.mjs
+++ b/src/core/operations/ExtractIPAddresses.mjs
@@ -65,7 +65,8 @@ class ExtractIPAddresses extends Operation {
      */
     run(input, args) {
         const [includeIpv4, includeIpv6, removeLocal, displayTotal, sort, unique] = args,
-            ipv4 = "(?:(?:\\d|[01]?\\d\\d|2[0-4]\\d|25[0-5])\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d|\\d)(?:\\/\\d{1,2})?",
+            // This regex has two major options; decimal values 0-255 or octal values prefixed with 0 up to 377
+            ipv4 = "(?:(?:(?:25[0-5]|2[0-4]\\d|1?[1-9]\\d|\\d)\\.){3}(?:(?:25[0-5]|2[0-4]\\d|1?[1-9]\\d|\\d)))|(?:(?:(?:0[1-3]?[0-7]{0,2})\\.){3}(?:0[1-3]?[0-7]{0,2}))",
             ipv6 = "((?=.*::)(?!.*::.+::)(::)?([\\dA-F]{1,4}:(:|\\b)|){5}|([\\dA-F]{1,4}:){6})(([\\dA-F]{1,4}((?!\\3)::|:\\b|(?![\\dA-F])))|(?!\\2\\3)){2}";
         let ips  = "";
 

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -65,6 +65,7 @@ import "./tests/ELFInfo.mjs";
 import "./tests/Enigma.mjs";
 import "./tests/ExtractEmailAddresses.mjs";
 import "./tests/ExtractHashes.mjs";
+import "./tests/ExtractIPAddresses.mjs";
 import "./tests/Float.mjs";
 import "./tests/FileTree.mjs";
 import "./tests/FletcherChecksum.mjs";

--- a/tests/operations/tests/ExtractIPAddresses.mjs
+++ b/tests/operations/tests/ExtractIPAddresses.mjs
@@ -20,6 +20,28 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "ExtractIPAddress All 10s",
+        input: "10.10.10.10",
+        expectedOutput: "10.10.10.10",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
+        name: "ExtractIPAddress All 10s",
+        input: "100.100.100.100",
+        expectedOutput: "100.100.100.100",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
         name: "ExtractIPAddress 255s",
         input: "255.255.255.255",
         expectedOutput: "255.255.255.255",
@@ -44,6 +66,17 @@ TestRegister.addTests([
     {
         name: "ExtractIPAddress 256 in middle",
         input: "255.256.255.255 255.255.256.255",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
+        name: "ExtractIPAddress 256 at each end",
+        input: "256.255.255.255 255.255.255.256",
         expectedOutput: "",
         recipeConfig: [
             {

--- a/tests/operations/tests/ExtractIPAddresses.mjs
+++ b/tests/operations/tests/ExtractIPAddresses.mjs
@@ -1,0 +1,78 @@
+/**
+ * ExtractIPAddresses tests.
+ *
+ * @author gchqdev365 [gchqdev365@outlook.com]
+ * @copyright Crown Copyright 2025
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "ExtractIPAddress All Zeros",
+        input: "0.0.0.0",
+        expectedOutput: "0.0.0.0",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
+        name: "ExtractIPAddress 255s",
+        input: "255.255.255.255",
+        expectedOutput: "255.255.255.255",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
+        name: "ExtractIPAddress double digits",
+        input: "10.10.10.10 25.25.25.25 99.99.99.99",
+        expectedOutput: "10.10.10.10\n25.25.25.25\n99.99.99.99",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
+        name: "ExtractIPAddress 256 in middle",
+        input: "255.256.255.255 255.255.256.255",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
+        name: "ExtractIPAddress octal valid",
+        input: "01.01.01.01 0123.0123.0123.0123 0377.0377.0377.0377",
+        expectedOutput: "01.01.01.01\n0123.0123.0123.0123\n0377.0377.0377.0377",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
+        name: "ExtractIPAddress octal invalid",
+        input: "0378.01.01.01 03.0377.2.3",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+]);
+

--- a/tests/operations/tests/ExtractIPAddresses.mjs
+++ b/tests/operations/tests/ExtractIPAddresses.mjs
@@ -86,6 +86,28 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "ExtractIPAddress silly example",
+        input: "710.65.0.456",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
+        name: "ExtractIPAddress longer dotted decimal",
+        input: "1.2.3.4.5.6.7.8",
+        expectedOutput: "1.2.3.4\n5.6.7.8",
+        recipeConfig: [
+            {
+                "op": "Extract IP addresses",
+                "args": [true, true, false, false, false, false]
+            },
+        ],
+    },
+    {
         name: "ExtractIPAddress octal valid",
         input: "01.01.01.01 0123.0123.0123.0123 0377.0377.0377.0377",
         expectedOutput: "01.01.01.01\n0123.0123.0123.0123\n0377.0377.0377.0377",


### PR DESCRIPTION
Addresses bug report #2008 
Added explicit support for octal IP addresses.
Changed approach to IPv4 regex to be string manipulation generated.
Added some unit tests for IP address parsing - probably not full coverage.
Added lookahead and lookbehind tricks to resolve warned issue that 1.2.3.256 would still be extracted as 1.2.3.25. Now only accepts valid IP addresses. Warning replaced with clause about infinite length dotted decimal forms.