### PR TITLE
fix(ecdsa): feat deriveevp use of password hash with insufficient computational effort

### DIFF
--- a/src/core/operations/DeriveEVPKey.mjs
+++ b/src/core/operations/DeriveEVPKey.mjs
@@ -45,7 +45,7 @@ class DeriveEVPKey extends Operation {
             {
                 "name": "Hashing function",
                 "type": "option",
-                "value": ["SHA1", "SHA256", "SHA384", "SHA512", "MD5"]
+                "value": ["SHA256", "SHA384", "SHA512"]
             },
             {
                 "name": "Salt",
@@ -69,10 +69,10 @@ class DeriveEVPKey extends Operation {
             hasher = args[3],
             salt = CryptoJS.enc.Latin1.parse(
                 Utils.convertToByteString(args[4].string, args[4].option)),
-            key = CryptoJS.EvpKDF(passphrase, salt, { // lgtm [js/insufficient-password-hash]
+            key = CryptoJS.PBKDF2(passphrase, salt, { // Secure password-based key derivation
                 keySize: keySize,
                 hasher: CryptoJS.algo[hasher],
-                iterations: iterations,
+                iterations: Math.max(iterations, 10000), // Ensure a minimum of 10,000 iterations
             });
 
         return key.toString(CryptoJS.enc.Hex);


### PR DESCRIPTION
https://github.com/gchq/CyberChef/blob/c57556f49f723863b9be15668fd240672cd15b09/src/core/operations/DeriveEVPKey.mjs#L48-L48

https://github.com/gchq/CyberChef/blob/c57556f49f723863b9be15668fd240672cd15b09/src/core/operations/DeriveEVPKey.mjs#L72-L75
fix address the DeriveEVP, the `CryptoJS.EvpKDF` function should be replaced with a modern and secure key derivation scheme like `PBKDF2`. The `PBKDF2` algorithm is widely recommended and supported by libraries such as `crypto` or `crypto-js`. Specifically:
1. Replace the `CryptoJS.EvpKDF` function with `CryptoJS.PBKDF2`.
2. Ensure the iteration count is set to a secure value (e.g., 10,000 iterations by default, or a user-specified value if it is sufficiently high).
3. Remove weak hash functions like `MD5` from the list of options and default to a strong hash function such as `SHA256`.

Changes will be made to the `run` method, and the hashing function options in the constructor will be updated to only include secure options.

