### PR TITLE
Tiny typo fix

### DIFF
--- a/src/core/operations/ToBase85.mjs
+++ b/src/core/operations/ToBase85.mjs
@@ -33,7 +33,7 @@ class ToBase85 extends Operation {
                 value: ALPHABET_OPTIONS
             },
             {
-                name: "Include delimeter",
+                name: "Include delimiter",
                 type: "boolean",
                 value: false
             }


### PR DESCRIPTION
This adjusts spelling in the "To Base85" operation from "delimeter" to "delimiter".