### PR TITLE
Update kbpgp package (resolves #2135)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "jsonwebtoken": "8.5.1",
         "jsqr": "^1.4.0",
         "jsrsasign": "^11.1.0",
-        "kbpgp": "2.1.15",
+        "kbpgp": "^2.1.17",
         "libbzip2-wasm": "0.0.4",
         "libyara-wasm": "^1.2.1",
         "lodash": "^4.17.21",
@@ -12601,9 +12601,9 @@
       }
     },
     "node_modules/kbpgp": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/kbpgp/-/kbpgp-2.1.15.tgz",
-      "integrity": "sha512-iFdQT+m2Mi2DB14kEFydF2joNe9x3E2VZCGZUt7UXsiZnQx5TtSl4KofP7EPtjHvf7weCxNKlEPSYiiCNMZ2jA==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/kbpgp/-/kbpgp-2.1.17.tgz",
+      "integrity": "sha512-pnjH7amyg6dZLXyF42BKbCTST0l0r1ErunqtFRrJCkHkGJb83cZZmx1pnqNFr+d/ls+5gvcHrZLPfUG5q7oRYw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bn": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "jsonwebtoken": "8.5.1",
     "jsqr": "^1.4.0",
     "jsrsasign": "^11.1.0",
-    "kbpgp": "2.1.15",
+    "kbpgp": "^2.1.17",
     "libbzip2-wasm": "0.0.4",
     "libyara-wasm": "^1.2.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Update the kbpgp package to 2.1.17 as the older package doesn't support AEAD preferences, leading to failure when loading public keys (see #2135)