### PR TITLE
Remove version 10 message from banner

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Production Build
       if: success()
-      run: npx grunt prod --msg="Version 10 is here! Read about the new features <a href='https://github.com/gchq/CyberChef/wiki/Character-encoding,-EOL-separators,-and-editor-features'>here</a>"
+      run: npx grunt prod --msg=""
 
     - name: Generate sitemap
       run: npx grunt exec:sitemap

--- a/src/web/App.mjs
+++ b/src/web/App.mjs
@@ -650,7 +650,7 @@ class App {
 
         // const compareURL = `https://github.com/gchq/CyberChef/compare/v${prev.join(".")}...v${PKG_VERSION}`;
 
-        let compileInfo = `<a href='https://github.com/gchq/CyberChef/blob/master/CHANGELOG.md'>Last build: ${timeSinceCompile.substr(0, 1).toUpperCase() + timeSinceCompile.substr(1)} ago</a>`;
+        let compileInfo = `<a href='https://github.com/gchq/CyberChef/blob/master/CHANGELOG.md'>Last build: ${timeSinceCompile.substring(0, 1).toUpperCase() + timeSinceCompile.substring(1)} ago</a>`;
 
         if (window.compileMessage !== "") {
             compileInfo += " - " + window.compileMessage;


### PR DESCRIPTION
Closes #2168

Also replaced usage of `substr` with `substring` as `substr` is deprecated (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr )