### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,18 +1,19 @@
 name: "Master Build, Test & Deploy"
 
-permissions:
-  contents: read
-
 on:
   workflow_dispatch:
   push:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   main:
     permissions:
       contents: write
+      pages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,7 +7,6 @@ on:
       - "v*"
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -18,6 +17,9 @@ env:
 
 jobs:
   main:
+    permissions:
+      id-token: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Added `packages: write` permission to releases workflow. Also updated master workflow to be consistent (and gave it `pages: write` which it seems like it should need, even though it doesn't seem to need it 🤔 )