### PR TITLE
Separate npm publish out into separate job and run with Node 25

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,7 +18,6 @@ env:
 jobs:
   main:
     permissions:
-      id-token: write
       packages: write
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
(Hopefully) enables trusted publishing, which only works with Node >=22.14 and npm >=11.5.1 (which is included in node >=24.5))