### PR TITLE
Fix npm publish - Run "npm ci" and "npm run node" under node 18 then switch to node 24.5

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -107,6 +107,18 @@ jobs:
       - name: Set node version
         uses: actions/setup-node@v6
         with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install
+        run: npm ci
+
+      - name: Create machine generated files
+        run: npm run node
+
+      - name: Reset node version ready for publish
+        uses: actions/setup-node@v6
+        with:
           node-version: ^24.5
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
Package on npm.js doesn't contain the machine-generated files because they weren't built as part of the publish.

Currently there's a problem because we cant run "npm run node" on Node >20 due to incompatibilities
But npm publish has to be run under Node >=24.5 in order to use trusted publishing

This PR works around this by initially working with Node 18 and then switching to Node 24.5 just before the publish is done.

Use of multiple actions/setup-node instances within a single job has been tested to work elsewhere with a separate action on a throwaway branch.

