### PR TITLE
fix: fromDecimal Auto delimiter now correctly handles multiple numbers

### DIFF
--- a/src/core/lib/Decimal.mjs
+++ b/src/core/lib/Decimal.mjs
@@ -24,12 +24,19 @@ import Utils from "../Utils.mjs";
  * fromDecimal("10:20:30", "Colon");
  */
 export function fromDecimal(data, delim="Auto") {
-    delim = Utils.charRep(delim);
-    const output = [];
-    let byteStr = data.split(delim);
-    if (byteStr[byteStr.length-1] === "")
-        byteStr = byteStr.slice(0, byteStr.length-1);
+    let byteStr;
+    if (delim === "Auto") {
+        // Auto mode: split on any non-digit, non-minus character (similar to fromHex)
+        byteStr = data.split(/[^\d-]+/);
+    } else {
+        delim = Utils.charRep(delim);
+        byteStr = data.split(delim);
+    }
+    
+    // Remove empty strings from the array
+    byteStr = byteStr.filter(str => str !== "");
 
+    const output = [];
     for (let i = 0; i < byteStr.length; i++) {
         output[i] = parseInt(byteStr[i], 10);
     }

--- a/tests/operations/tests/FromDecimal.mjs
+++ b/tests/operations/tests/FromDecimal.mjs
@@ -30,4 +30,37 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "From Decimal with Auto delimiter (space)",
+        input: "72 101 108 108 111",
+        expectedOutput: "Hello",
+        recipeConfig: [
+            {
+                op: "From Decimal",
+                args: ["Auto", false]
+            },
+        ],
+    },
+    {
+        name: "From Decimal with Auto delimiter (comma)",
+        input: "72,101,108,108,111",
+        expectedOutput: "Hello",
+        recipeConfig: [
+            {
+                op: "From Decimal",
+                args: ["Auto", false]
+            },
+        ],
+    },
+    {
+        name: "From Decimal with Auto delimiter (mixed)",
+        input: "72, 101 : 108; 108\t111",
+        expectedOutput: "Hello",
+        recipeConfig: [
+            {
+                op: "From Decimal",
+                args: ["Auto", false]
+            },
+        ],
+    },
 ]);


### PR DESCRIPTION
Fixes #2217

## Summary
The `fromDecimal` function now correctly handles the `Auto` delimiter mode, similar to `fromHex`. Previously, when `delim='Auto'` (the default), it would only parse the first number, ignoring subsequent numbers regardless of the separator used.

## Problem
When `fromDecimal` was called without specifying a `delim` parameter (defaulting to `"Auto"`), it would:
1. Call `Utils.charRep("Auto")` → returns `"Auto"` string
2. Call `data.split("Auto")` → splits on the literal string `"Auto"` (not present in input)
3. Result: Only the first number would be parsed

## Solution
Implemented auto-detection logic similar to `fromHex`:
- When `delim='Auto'`, use regex `/[^\d-]+/` to split on any non-digit, non-minus character
- This automatically detects spaces, commas, semicolons, newlines, tabs, etc. as delimiters
- Filter out empty strings from the split result

## Changes

### src/core/lib/Decimal.mjs
```javascript
// Before
delim = Utils.charRep(delim);
let byteStr = data.split(delim);

// After
if (delim === "Auto") {
    byteStr = data.split(/[^\d-]+/);
} else {
    delim = Utils.charRep(delim);
    byteStr = data.split(delim);
}
byteStr = byteStr.filter(str => str !== "");
```

### tests/operations/tests/FromDecimal.mjs
Added test cases to verify Auto delimiter behavior:
- Auto with space: `"72 101 108 108 111"` → `"Hello"`
- Auto with comma: `"72,101,108,108,111"` → `"Hello"`
- Auto with mixed: `"72, 101 : 108; 108\t111"` → `"Hello"`

## Before/After

**Before:**
```
Input:  "72 101 108 108 111"
Delim:  Auto (default)
Output: Only "H" (first number 72)
```

**After:**
```
Input:  "72 101 108 108 111"
Delim:  Auto (default)
Output: "Hello" (all numbers parsed correctly)
```

## Testing
```bash
# Run the updated tests
npm test tests/operations/tests/FromDecimal.mjs
```

All new test cases pass, verifying that Auto mode now correctly handles various delimiters.