### PR TITLE
fix: fromDecimal Auto delimiter now correctly handles multiple numbers

### DIFF
--- a/src/core/lib/Decimal.mjs
+++ b/src/core/lib/Decimal.mjs
@@ -24,12 +24,19 @@ import Utils from "../Utils.mjs";
  * fromDecimal("10:20:30", "Colon");
  */
 export function fromDecimal(data, delim="Auto") {
-    delim = Utils.charRep(delim);
-    const output = [];
-    let byteStr = data.split(delim);
-    if (byteStr[byteStr.length-1] === "")
-        byteStr = byteStr.slice(0, byteStr.length-1);
+    let byteStr;
+    if (delim === "Auto") {
+        // Auto mode: split on any non-digit, non-minus character (similar to fromHex)
+        byteStr = data.split(/[^\d-]+/);
+    } else {
+        delim = Utils.charRep(delim);
+        byteStr = data.split(delim);
+    }
+    
+    // Remove empty strings from the array
+    byteStr = byteStr.filter(str => str !== "");
 
+    const output = [];
     for (let i = 0; i < byteStr.length; i++) {
         output[i] = parseInt(byteStr[i], 10);
     }

--- a/tests/operations/tests/FromDecimal.mjs
+++ b/tests/operations/tests/FromDecimal.mjs
@@ -30,4 +30,37 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "From Decimal with Auto delimiter (space)",
+        input: "72 101 108 108 111",
+        expectedOutput: "Hello",
+        recipeConfig: [
+            {
+                op: "From Decimal",
+                args: ["Auto", false]
+            },
+        ],
+    },
+    {
+        name: "From Decimal with Auto delimiter (comma)",
+        input: "72,101,108,108,111",
+        expectedOutput: "Hello",
+        recipeConfig: [
+            {
+                op: "From Decimal",
+                args: ["Auto", false]
+            },
+        ],
+    },
+    {
+        name: "From Decimal with Auto delimiter (mixed)",
+        input: "72, 101 : 108; 108\t111",
+        expectedOutput: "Hello",
+        recipeConfig: [
+            {
+                op: "From Decimal",
+                args: ["Auto", false]
+            },
+        ],
+    },
 ]);


### PR DESCRIPTION
Fixes #2217

## Summary
The fromDecimal function now correctly handles the 'Auto' delimiter mode, similar to fromHex.

## Changes
- src/core/lib/Decimal.mjs: Use regex /[^\d-]+/ for Auto delimiter
- tests/operations/tests/FromDecimal.mjs: Added Auto delimiter test cases

## Before/After
- Before: "72 101 108 108 111" → Only "H" parsed
- After: "72 101 108 108 111" → "Hello" parsed correctly