### PR TITLE
feat: Add option for native js implementation of jq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@alexaltea/capstone-js": "^3.0.5",
         "@astronautlabs/amf": "^0.0.6",
         "@blu3r4y/lzma": "^2.3.3",
+        "@michaelhomer/jqjs": "^1.5.0",
         "@wavesenterprise/crypto-gost-js": "^2.1.0-RC1",
         "@xmldom/xmldom": "^0.8.11",
         "argon2-browser": "^1.18.0",
@@ -3588,6 +3589,12 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@michaelhomer/jqjs": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@michaelhomer/jqjs/-/jqjs-1.5.0.tgz",
+      "integrity": "sha512-GzKHQkeoVGsGDl5tDbQvmrl6ai03Gu1/Tm+/qvaExAcYoslhVx+OMVMZAVdB3sSvOMlo3vUiQlgBjAFk0FdC7w==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/nice": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@alexaltea/capstone-js": "^3.0.5",
     "@astronautlabs/amf": "^0.0.6",
     "@blu3r4y/lzma": "^2.3.3",
+    "@michaelhomer/jqjs": "^1.5.0",
     "@wavesenterprise/crypto-gost-js": "^2.1.0-RC1",
     "@xmldom/xmldom": "^0.8.11",
     "argon2-browser": "^1.18.0",

--- a/src/core/operations/Jq.mjs
+++ b/src/core/operations/Jq.mjs
@@ -7,6 +7,7 @@
 import Operation from "../Operation.mjs";
 import OperationError from "../errors/OperationError.mjs";
 import * as jq from "jq-wasm";
+import * as jqjs from "@michaelhomer/jqjs";
 
 /**
  * jq operation
@@ -30,7 +31,12 @@ class Jq extends Operation {
                 name: "Query",
                 type: "string",
                 value: ""
-            }
+            },
+            {
+                name: "Implementation",
+                type: "option",
+                value: ["WASM", "Native JS"]
+            },
         ];
     }
 
@@ -41,12 +47,31 @@ class Jq extends Operation {
      */
     run(input, args) {
         return (async () => {
-            const [query] = args;
-            try {
-                const result = await jq.json(input, query);
-                return JSON.stringify(result);
-            } catch (err) {
-                throw new OperationError(`Invalid jq expression: ${err.message}`);
+            const query = args[0];
+            const implementation = args[1].toLowerCase();
+
+            switch (implementation) {
+                case "wasm":
+                    try {
+                        const result = await jq.json(input, query);
+                        return JSON.stringify(result);
+                    } catch (err) {
+                        throw new OperationError(`Invalid jq expression: ${err.message}`);
+                    }
+                case "native js":
+                    let result = '';
+                    let filter = jqjs.compile(query)
+                    for (let i of filter(input)) {
+                        if (typeof i == 'undefined') {
+                            result += 'undefined (runtime error)\n'
+                        } else {
+                            result += jqjs.prettyPrint(i) + '\n'
+                        }
+                    }
+                    return result;
+                default:
+                    throw new OperationError(`Invalid jq implementation: ${implementation}`);
+                    break;
             }
         })();
     }


### PR DESCRIPTION
Testing solutions to #2232

Performance with WASM jq can be slow for some reason (I should also investigate).

For example, running `length` on [512KB.json](https://microsoftedge.github.io/Demos/json-dummy-data/512KB.json) takes ~12000ms using WASM.

<img width="1680" height="816" alt="image" src="https://github.com/user-attachments/assets/261f9212-65b1-404d-9247-c2e82169bad7" />

Using native JS, the same operation takes 5ms

<img width="1680" height="818" alt="image" src="https://github.com/user-attachments/assets/c85a316a-4ad2-423f-9217-8b8241beb5c6" />

Note that using a smaller input takes less time. E.g [64KB.json](https://microsoftedge.github.io/Demos/json-dummy-data/64KB.json) takes ~250ms with WASM, but 2ms with native JS.

We should not replace the WASM version yet, as the JS version is not at full parity.