### PR TITLE
feat: add Raw option for Jq operation

### DIFF
--- a/src/core/operations/Jq.mjs
+++ b/src/core/operations/Jq.mjs
@@ -53,7 +53,7 @@ class Jq extends Operation {
         } catch (err) {
             throw new OperationError(`Invalid jq expression: ${err.message}`);
         }
-        if (raw && typeof result === 'string') {
+        if (raw && typeof result === "string") {
             return result;
         } else {
             return JSON.stringify(result);

--- a/tests/operations/tests/Jq.mjs
+++ b/tests/operations/tests/Jq.mjs
@@ -1,0 +1,32 @@
+/**
+ * Jq tests.
+ *
+ * @author  rtpt-romankarwacik [roman.karwacik@redteam-pentesting.de]
+ *
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Get raw JSON Property",
+        input: '{"data": "testString\\u0000"}',
+        expectedOutput: "testString\u0000",
+        recipeConfig: [
+            {
+                op: "Jq",
+                args: [".data", true],
+            },
+        ],
+    },
+    {
+        name: "Get JSON Property",
+        input: '{"data": "testString\\u0000"}',
+        expectedOutput: "\"testString\\u0000\"",
+        recipeConfig: [
+            {
+                op: "Jq",
+                args: [".data", false],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
This is useful when data needs to be processed afterwards, for example strings, without needing to strip or unescape afterwards.