### PR TITLE
fix: return empty output for zero-length To Modhex input

### DIFF
--- a/src/core/lib/Modhex.mjs
+++ b/src/core/lib/Modhex.mjs
@@ -50,6 +50,7 @@ const HEX_ALPHABET_MAP = HEX_ALPHABET.split("");
 export function toModhex(data, delim=" ", padding=2, extraDelim="", lineSize=0) {
     if (!data) return "";
     if (data instanceof ArrayBuffer) data = new Uint8Array(data);
+    if (data.length === 0) return "";
 
     const regularHexString = toHex(data, "", padding, "", 0);
 
@@ -100,6 +101,7 @@ export function toModhex(data, delim=" ", padding=2, extraDelim="", lineSize=0) 
 export function toModhexFast(data) {
     if (!data) return "";
     if (data instanceof ArrayBuffer) data = new Uint8Array(data);
+    if (data.length === 0) return "";
 
     const output = [];
 

--- a/tests/operations/tests/Modhex.mjs
+++ b/tests/operations/tests/Modhex.mjs
@@ -147,4 +147,24 @@ dc;ii;hv;ig;hr;hf;dc;he;hj;hv;hv;ie;hg;du",
             }
         ]
     },
+    {
+        name: "Empty input through From Hex and To Modhex returns empty output",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": [
+                    "Auto"
+                ]
+            },
+            {
+                "op": "To Modhex",
+                "args": [
+                    "Space",
+                    0
+                ]
+            }
+        ]
+    },
 ]);


### PR DESCRIPTION
## Bug
https://github.com/gchq/CyberChef/issues/2246 — `To Modhex` crashes for empty `ArrayBuffer` input because the function only guards falsy values and then forwards zero-length byte data into hex conversion.

## Fix
- Add an explicit zero-length guard after `ArrayBuffer` conversion in `toModhex`
- Apply the same guard in `toModhexFast` for consistency
- Add an operation test that reproduces the reported empty `From Hex -> To Modhex` flow and asserts empty output

## Testing
- Attempted `npm test -- tests/operations/tests/Modhex.mjs` in this environment
- Test harness currently fails early due Node 22 JSON import assertion parsing (`assert {type: "json"}`) incompatibility with this project’s test runner setup

Happy to address any feedback.

Greetings, saschabuehrle
