### PR TITLE
fix: handle terminating chunk correctly in Dechunk HTTP response

### DIFF
--- a/src/core/operations/DechunkHTTPResponse.mjs
+++ b/src/core/operations/DechunkHTTPResponse.mjs
@@ -49,6 +49,13 @@ class DechunkHTTPResponse extends Operation {
             input = input.slice(chunkSizeEnd + chunkSize + lineEndingsLength);
             chunkSizeEnd = input.indexOf(lineEndings) + lineEndingsLength;
             chunkSize = parseInt(input.slice(0, chunkSizeEnd), 16);
+            if (chunkSize === 0) {
+                input = input.slice(chunkSizeEnd);
+                if (input.startsWith(lineEndings)) {
+                    input = input.slice(lineEndingsLength);
+                }
+                break;
+            }
         }
         return chunks.join("") + input;
     }


### PR DESCRIPTION
Fixes #2247

- Detects terminating zero-length chunk (chunkSize === 0)
- Prevents trailer data from leaking into output
- Handles chunk termination correctly as per RFC 7230