### PR TITLE
chore (deps) bump chromedriver from 130.0.4 to 146.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
         "autoprefixer": "^10.4.27",
         "babel-loader": "^10.1.1",
         "base64-loader": "^1.0.0",
-        "chromedriver": "^130.0.4",
+        "chromedriver": "^146.0.6",
         "cli-progress": "^3.12.0",
         "colors": "^1.4.0",
         "compression-webpack-plugin": "^11.1.0",
@@ -6246,26 +6246,36 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "130.0.4",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-130.0.4.tgz",
-      "integrity": "sha512-lpR+PWXszij1k4Ig3t338Zvll9HtCTiwoLM7n4pCCswALHxzmgwaaIFBh3rt9+5wRk9D07oFblrazrBxwaYYAQ==",
+      "version": "146.0.6",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-146.0.6.tgz",
+      "integrity": "sha512-FIRi3hy0nRiyirK03etVXEpYTIodevFcvTBAM5ZCq+pX3w31jLm6JE8BVW1ypAVLvSp6HJDvboCcdgUroS3miw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.7.4",
+        "axios": "^1.13.5",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
-        "proxy-agent": "^6.4.0",
-        "proxy-from-env": "^1.1.0",
+        "proxy-agent": "^6.5.0",
+        "proxy-from-env": "^2.0.0",
         "tcp-port-used": "^1.0.2"
       },
       "bin": {
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/chromedriver/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ci-info": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "autoprefixer": "^10.4.27",
     "babel-loader": "^10.1.1",
     "base64-loader": "^1.0.0",
-    "chromedriver": "^130.0.4",
+    "chromedriver": "^146.0.6",
     "cli-progress": "^3.12.0",
     "colors": "^1.4.0",
     "compression-webpack-plugin": "^11.1.0",


### PR DESCRIPTION
Bumps chromedriver from 130.0.4 to 146.0.6

Partly raised to explore problems seen with browser testing in #2278.
