### PR TITLE
ParseEthernetFrame - Fix vlan calculation

### DIFF
--- a/src/core/operations/ParseEthernetFrame.mjs
+++ b/src/core/operations/ParseEthernetFrame.mjs
@@ -74,17 +74,14 @@ class ParseEthernetFrame extends Operation {
             const ethType = Utils.byteArrayToChars(input.slice(offset, offset+2));
             offset += 2;
 
-
-            if (ethType === "\x08\x00") {
-                break;
-            } else if (ethType === "\x81\x00" || ethType === "\x88\xA8") {
+            if (ethType === "\x81\x00" || ethType === "\x88\xA8") {
                 // Parse the VLAN tag:
                 // [0000] 0000 0000 0000
                 //  ^^^ PRIO  - Ignored
                 //     ^ DEI  - Ignored
                 //        ^^^^ ^^^^ ^^^^ VLAN ID
-                const vlanTag = input.slice(offset+2, offset+4);
-                vlans.push((vlanTag[0] & 0b00001111) << 4 | vlanTag[1]);
+                const vlanTag = input.slice(offset, offset+2);
+                vlans.push(((vlanTag[0] & 0b00001111) << 8) | vlanTag[1]);
 
                 offset += 2;
             } else {

--- a/tests/operations/tests/ParseEthernetFrame.mjs
+++ b/tests/operations/tests/ParseEthernetFrame.mjs
@@ -23,7 +23,7 @@ TestRegister.addTests([
     {
         name: "Parse Ethernet frame with one VLAN tag (802.1q)",
         input: "01000ccdcdd00013c3dfae188100a0760165aaaa",
-        expectedOutput: "Source MAC: 00:13:c3:df:ae:18\nDestination MAC: 01:00:0c:cd:cd:d0\nVLAN: 117\nData:\naa aa",
+        expectedOutput: "Source MAC: 00:13:c3:df:ae:18\nDestination MAC: 01:00:0c:cd:cd:d0\nVLAN: 118\nData:\naa aa",
         recipeConfig: [
             {
                 "op": "Parse Ethernet frame",
@@ -34,7 +34,7 @@ TestRegister.addTests([
     {
         name: "Parse Ethernet frame with two VLAN tags (802.1ad)",
         input: "0019aa7de688002155c8f13c810000d18100001408004500",
-        expectedOutput: "Source MAC: 00:21:55:c8:f1:3c\nDestination MAC: 00:19:aa:7d:e6:88\nVLAN: 16, 128\nData:\n45 00",
+        expectedOutput: "Source MAC: 00:21:55:c8:f1:3c\nDestination MAC: 00:19:aa:7d:e6:88\nVLAN: 209, 20\nData:\n45 00",
         recipeConfig: [
             {
                 "op": "Parse Ethernet frame",


### PR DESCRIPTION
**Description**
Due to an oversight on my side, the calculation of VLANs in the Parse Ethernet Frame operation is wrong. This PR fixes these.
Because I wrote the tests using my own broken implementation, they were also wrong. They have now been fixed and verified against wireshark. Something I should have done previously. Live and learn.
Sorry for the extra work.

**Existing Issue**
N/A, Related to my PR #1722 

**Screenshots**
N/A

**AI disclosure**
No AI was used.

**Test Coverage**
Tests have been fixed, using Wireshark as a sanity check. 
