### PR TITLE
fix: handle Auto delimiter in fromDecimal (#2217)

### DIFF
--- a/src/core/lib/Decimal.mjs
+++ b/src/core/lib/Decimal.mjs
@@ -24,9 +24,9 @@ import Utils from "../Utils.mjs";
  * fromDecimal("10:20:30", "Colon");
  */
 export function fromDecimal(data, delim="Auto") {
-    delim = Utils.charRep(delim);
+    const delimRegex = delim === "Auto" ? /[^\d-]+/ : Utils.charRep(delim);
     const output = [];
-    let byteStr = data.split(delim);
+    let byteStr = data.split(delimRegex);
     if (byteStr[byteStr.length-1] === "")
         byteStr = byteStr.slice(0, byteStr.length-1);
 

--- a/tests/node/tests/operations.mjs
+++ b/tests/node/tests/operations.mjs
@@ -532,6 +532,12 @@ Top Drawer`, {
         assert.strictEqual(chef.fromDecimal("72 101 108 108 111").toString(), "Hello");
     }),
 
+    it("From decimal with Auto delimiter", () => {
+        assert.strictEqual(chef.fromDecimal("72,101,108,108,111").toString(), "Hello");
+        assert.strictEqual(chef.fromDecimal("72:101:108:108:111").toString(), "Hello");
+        assert.strictEqual(chef.fromDecimal("72;101;108;108;111").toString(), "Hello");
+    }),
+
     it("From hex", () => {
         assert.strictEqual(chef.fromHex("52 69 6e 67 20 41 6e 79 20 42 65 6c 6c 73 3f").toString(), "Ring Any Bells?");
     }),


### PR DESCRIPTION
## Summary

Fixes the fromDecimal() function to correctly handle the Auto delimiter mode. Utils.charRep("Auto") returns undefined, causing data.split(undefined) to treat the entire input as a single element and only parse the first decimal value.

## Changes

- Use regex `/[^\d-]+/` to split on any non-digit, non-minus character when delimiter is "Auto", consistent with how fromHex() handles its Auto mode
- Added test cases for Auto delimiter with comma, colon, and semicolon separators

## Related Issue

Closes #2217

## Testing

- Verified fix with space, comma, colon, and semicolon separators
- Verified signed value support still works
- Verified explicit delimiter mode is unaffected
- ESLint passes clean