### PR TITLE
Fix, and link, Fernet tests

### DIFF
--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -72,6 +72,7 @@ import "./tests/ExtractAudioMetadata.mjs";
 import "./tests/ExtractEmailAddresses.mjs";
 import "./tests/ExtractHashes.mjs";
 import "./tests/ExtractIPAddresses.mjs";
+import "./tests/Fernet.mjs";
 import "./tests/Float.mjs";
 import "./tests/FileTree.mjs";
 import "./tests/FletcherChecksum.mjs";

--- a/tests/operations/tests/Fernet.mjs
+++ b/tests/operations/tests/Fernet.mjs
@@ -5,7 +5,7 @@
  * @copyright Karsten Silkenbäumer 2019
  * @license Apache-2.0
  */
-import TestRegister from "../TestRegister";
+import TestRegister from "../../lib/TestRegister.mjs";
 
 TestRegister.addTests([
     {
@@ -47,7 +47,7 @@ TestRegister.addTests([
     {
         name: "Fernet Encrypt: no input",
         input: "",
-        expectedMatch: /^gAAAAABce-[\w-]+={0,2}$/,
+        expectedMatch: /^gAAA[\w-]+={0,2}$/,
         recipeConfig: [
             {
                 op: "Fernet Encrypt",
@@ -69,12 +69,27 @@ TestRegister.addTests([
     {
         name: "Fernet Encrypt: valid arguments",
         input: "This is a secret message.\n",
-        expectedMatch: /^gAAAAABce-[\w-]+={0,2}$/,
+        expectedMatch: /^gAAA[\w-]+={0,2}$/,
         recipeConfig: [
             {
                 op: "Fernet Encrypt",
                 args: ["MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="]
             }
+        ],
+    },
+    {
+        name: "Fernet Encrypt/Decrypt: round trip",
+        input: "This is a secret message.\n",
+        expectedOutput: "This is a secret message.\n",
+        recipeConfig: [
+            {
+                op: "Fernet Encrypt",
+                args: ["MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="]
+            },
+            {
+                op: "Fernet Decrypt",
+                args: ["MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="]
+            },
         ],
     }
 ]);


### PR DESCRIPTION
**Description**
* Fix some errors in the structure of the Fernet tests, and also some time-based drift in the values being tested.
* Actually link the tests into the main testing functionality.

**Existing Issue**
Discovered whilst looking into PR #1431 which automatically links all test files found.

**AI disclosure**
No use of AI

**Test Coverage**
Improved by actually running some existing tests, and fixing them.