### PR TITLE
feat: add +/- notation option to Diff operation

### DIFF
--- a/src/core/operations/Diff.mjs
+++ b/src/core/operations/Diff.mjs
@@ -57,6 +57,11 @@ class Diff extends Operation {
                 "type": "boolean",
                 "value": false,
                 "hint": "Relevant for word and line"
+            },
+            {
+                "name": "Show +/- notation",
+                "type": "boolean",
+                "value": false
             }
         ];
     }
@@ -73,7 +78,8 @@ class Diff extends Operation {
                 showAdded,
                 showRemoved,
                 showSubtraction,
-                ignoreWhitespace
+                ignoreWhitespace,
+                showNotation
             ] = args,
             samples = input.split(sampleDelim);
         let output = "",
@@ -118,12 +124,23 @@ class Diff extends Operation {
         }
 
         for (let i = 0; i < diff.length; i++) {
-            if (diff[i].added) {
-                if (showAdded) output += "<ins>" + Utils.escapeHtml(diff[i].value) + "</ins>";
-            } else if (diff[i].removed) {
-                if (showRemoved) output += "<del>" + Utils.escapeHtml(diff[i].value) + "</del>";
-            } else if (!showSubtraction) {
-                output += Utils.escapeHtml(diff[i].value);
+            if (showNotation) {
+                const escapedValue = Utils.escapeHtml(diff[i].value);
+                if (diff[i].added) {
+                    if (showAdded) output += "+ " + escapedValue;
+                } else if (diff[i].removed) {
+                    if (showRemoved) output += "- " + escapedValue;
+                } else if (!showSubtraction) {
+                    output += "  " + escapedValue;
+                }
+            } else {
+                if (diff[i].added) {
+                    if (showAdded) output += "<ins>" + Utils.escapeHtml(diff[i].value) + "</ins>";
+                } else if (diff[i].removed) {
+                    if (showRemoved) output += "<del>" + Utils.escapeHtml(diff[i].value) + "</del>";
+                } else if (!showSubtraction) {
+                    output += Utils.escapeHtml(diff[i].value);
+                }
             }
         }
 

--- a/src/core/operations/Diff.mjs
+++ b/src/core/operations/Diff.mjs
@@ -60,6 +60,7 @@ class Diff extends Operation {
             },
             {
                 "name": "Show +/- notation",
+                "hint": "Works only in Line diff mode.",
                 "type": "boolean",
                 "value": false
             }
@@ -90,6 +91,34 @@ class Diff extends Operation {
 
         if (!samples || samples.length !== 2) {
             throw new OperationError("Incorrect number of samples, perhaps you need to modify the sample delimiter or add more samples?");
+        }
+
+        // +/- notation only works properly with Line diff mode
+        // For other modes, it falls back to HTML format and this option is ignored (see hint).
+        const useNotation = showNotation && diffBy === "Line";
+
+        if (useNotation) {
+            const patch = jsdiff.createTwoFilesPatch("original", "modified", samples[0], samples[1], "", "", {
+                context: Infinity,
+                ignoreWhitespace: ignoreWhitespace,
+            });
+
+            const lines = patch.split("\n");
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
+                if (line.startsWith("@@")) {
+                    if (showSubtraction) output += line + "\n";
+                } else if (line.startsWith("+") && !line.startsWith("+++")) {
+                    if (showAdded) output += line + "\n";
+                } else if (line.startsWith("-") && !line.startsWith("---")) {
+                    if (showRemoved) output += line + "\n";
+                } else if (line.startsWith("===") || line.startsWith("---") || line.startsWith("+++") || line.startsWith("\\")) {
+                    continue;
+                } else if (line.length > 0 && !showSubtraction) {
+                    output += line.substring(1) + "\n";
+                }
+            }
+            return output.slice(0, -1);
         }
 
         switch (diffBy) {
@@ -124,23 +153,12 @@ class Diff extends Operation {
         }
 
         for (let i = 0; i < diff.length; i++) {
-            if (showNotation) {
-                const escapedValue = Utils.escapeHtml(diff[i].value);
-                if (diff[i].added) {
-                    if (showAdded) output += "+ " + escapedValue;
-                } else if (diff[i].removed) {
-                    if (showRemoved) output += "- " + escapedValue;
-                } else if (!showSubtraction) {
-                    output += "  " + escapedValue;
-                }
-            } else {
-                if (diff[i].added) {
-                    if (showAdded) output += "<ins>" + Utils.escapeHtml(diff[i].value) + "</ins>";
-                } else if (diff[i].removed) {
-                    if (showRemoved) output += "<del>" + Utils.escapeHtml(diff[i].value) + "</del>";
-                } else if (!showSubtraction) {
-                    output += Utils.escapeHtml(diff[i].value);
-                }
+            if (diff[i].added) {
+                if (showAdded) output += "<ins>" + Utils.escapeHtml(diff[i].value) + "</ins>";
+            } else if (diff[i].removed) {
+                if (showRemoved) output += "<del>" + Utils.escapeHtml(diff[i].value) + "</del>";
+            } else if (!showSubtraction) {
+                output += Utils.escapeHtml(diff[i].value);
             }
         }
 

--- a/src/core/operations/Diff.mjs
+++ b/src/core/operations/Diff.mjs
@@ -118,7 +118,7 @@ class Diff extends Operation {
                     output += line.substring(1) + "\n";
                 }
             }
-            return output.slice(0, -1);
+            return `<pre>${Utils.escapeHtml(output.slice(0, -1))}</pre>`;
         }
 
         switch (diffBy) {

--- a/tests/browser/02_ops.js
+++ b/tests/browser/02_ops.js
@@ -127,6 +127,7 @@ module.exports = {
         // testOp(browser, "Derive PBKDF2 key", "test input", "test_output");
         // testOp(browser, "Detect File Type", "test input", "test_output");
         testOpHtml(browser, "Diff", "The cat sat on the mat\n\nThe mat cat on the sat", "ins:first-child", "mat", ["\\n\\n", "Word", true, true, false, false]);
+        testOp(browser, "Diff", "line1\nline2\n\nline1\nline2 modified", "line1\n-line2\n+line2 modified", ["\\n\\n", "Line", true, true, false, false, true]);
         // testOp(browser, "Disassemble x86", "test input", "test_output");
         testOpImage(browser, "Dither Image", "files/Hitchhikers_Guide.jpeg");
     // testOp(browser, "Divide", "test input", "test_output");

--- a/tests/browser/02_ops.js
+++ b/tests/browser/02_ops.js
@@ -127,7 +127,7 @@ module.exports = {
         // testOp(browser, "Derive PBKDF2 key", "test input", "test_output");
         // testOp(browser, "Detect File Type", "test input", "test_output");
         testOpHtml(browser, "Diff", "The cat sat on the mat\n\nThe mat cat on the sat", "ins:first-child", "mat", ["\\n\\n", "Word", true, true, false, false]);
-        testOp(browser, "Diff", "line1\nline2\n\nline1\nline2 modified", "line1\n-line2\n+line2 modified", ["\\n\\n", "Line", true, true, false, false, true]);
+        testOpHtml(browser, "Diff", "line1\nline2\n\nline1\nline2 modified", "pre", "line1\n-line2\n+line2 modified", ["\\n\\n", "Line", true, true, false, false, true]);
         // testOp(browser, "Disassemble x86", "test input", "test_output");
         testOpImage(browser, "Dither Image", "files/Hitchhikers_Guide.jpeg");
     // testOp(browser, "Divide", "test input", "test_output");

--- a/tests/operations/tests/Diff.mjs
+++ b/tests/operations/tests/Diff.mjs
@@ -1,0 +1,313 @@
+/**
+ * @author mikecat
+ * @copyright Crown Copyright 2023
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        "name": "Diff: Show +/- notation - true (Line mode)",
+        "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
+        "expectedOutput": "line1\n-line2\n+line2modified\nline3",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n\\n",
+                    "Line",
+                    true,
+                    true,
+                    false,
+                    false,
+                    true
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Show +/- notation - false (Line mode)",
+        "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
+        "expectedOutput": "line1\n<del>line2\n</del><ins>line2modified\n</ins>line3",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n\\n",
+                    "Line",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Show +/- notation - with showAdded false (Line mode)",
+        "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
+        "expectedOutput": "line1\n-line2\nline3",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n\\n",
+                    "Line",
+                    false,
+                    true,
+                    false,
+                    false,
+                    true
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Show +/- notation - with showRemoved false (Line mode)",
+        "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
+        "expectedOutput": "line1\n+line2modified\nline3",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n\\n",
+                    "Line",
+                    true,
+                    false,
+                    false,
+                    false,
+                    true
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Show +/- notation - with showSubtraction true (Line mode)",
+        "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
+        "expectedOutput": "@@ -1,3 +1,3 @@\n-line2\n+line2modified",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n\\n",
+                    "Line",
+                    true,
+                    true,
+                    true,
+                    false,
+                    true
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Show +/- notation ignored for Character mode",
+        "input": "abc\ndef",
+        "expectedOutput": "<del>abc</del><ins>def</ins>",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Character",
+                    true,
+                    true,
+                    false,
+                    false,
+                    true
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Show +/- notation ignored for Word mode",
+        "input": "hello world\nhello cruel world",
+        "expectedOutput": "hello <ins>cruel </ins>world",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Word",
+                    true,
+                    true,
+                    false,
+                    false,
+                    true
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Show +/- notation ignored for Sentence mode",
+        "input": "Hello world.\nHello there.",
+        "expectedOutput": "<del>Hello world.</del><ins>Hello there.</ins>",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Sentence",
+                    true,
+                    true,
+                    false,
+                    false,
+                    true
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Character mode basic",
+        "input": "abc\nabc",
+        "expectedOutput": "abc",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Character",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Character mode with changes",
+        "input": "abc\nabcdef",
+        "expectedOutput": "abc<ins>def</ins>",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Character",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Word mode basic",
+        "input": "hello world\nhello world",
+        "expectedOutput": "hello world",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Word",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Word mode with changes",
+        "input": "hello world\nhello cruel world",
+        "expectedOutput": "hello <ins>cruel </ins>world",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Word",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Line mode basic",
+        "input": "line1\nline2\nline3\n\nline1\nline2\nline3",
+        "expectedOutput": "line1\nline2\nline3",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n\\n",
+                    "Line",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Line mode with changes",
+        "input": "line1\nline2\nline3\n\nline1\nline4\nline3",
+        "expectedOutput": "line1\n<del>line2\n</del><ins>line4\n</ins>line3",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n\\n",
+                    "Line",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Sentence mode basic",
+        "input": "Hello world.\nHello world.",
+        "expectedOutput": "Hello world.",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Sentence",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Sentence mode with changes",
+        "input": "Hello world.\nHello there.",
+        "expectedOutput": "<del>Hello world.</del><ins>Hello there.</ins>",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n",
+                    "Sentence",
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ],
+            },
+        ],
+    },
+]);

--- a/tests/operations/tests/Diff.mjs
+++ b/tests/operations/tests/Diff.mjs
@@ -9,7 +9,7 @@ TestRegister.addTests([
     {
         "name": "Diff: Show +/- notation - true (Line mode)",
         "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
-        "expectedOutput": "line1\n-line2\n+line2modified\nline3",
+        "expectedOutput": "<pre>line1\n-line2\n+line2modified\nline3</pre>",
         "recipeConfig": [
             {
                 "op": "Diff",
@@ -47,7 +47,7 @@ TestRegister.addTests([
     {
         "name": "Diff: Show +/- notation - with showAdded false (Line mode)",
         "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
-        "expectedOutput": "line1\n-line2\nline3",
+        "expectedOutput": "<pre>line1\n-line2\nline3</pre>",
         "recipeConfig": [
             {
                 "op": "Diff",
@@ -66,7 +66,7 @@ TestRegister.addTests([
     {
         "name": "Diff: Show +/- notation - with showRemoved false (Line mode)",
         "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
-        "expectedOutput": "line1\n+line2modified\nline3",
+        "expectedOutput": "<pre>line1\n+line2modified\nline3</pre>",
         "recipeConfig": [
             {
                 "op": "Diff",
@@ -85,7 +85,7 @@ TestRegister.addTests([
     {
         "name": "Diff: Show +/- notation - with showSubtraction true (Line mode)",
         "input": "line1\nline2\nline3\n\nline1\nline2modified\nline3",
-        "expectedOutput": "@@ -1,3 +1,3 @@\n-line2\n+line2modified",
+        "expectedOutput": "<pre>@@ -1,3 +1,3 @@\n-line2\n+line2modified</pre>",
         "recipeConfig": [
             {
                 "op": "Diff",
@@ -95,6 +95,25 @@ TestRegister.addTests([
                     true,
                     true,
                     true,
+                    false,
+                    true
+                ],
+            },
+        ],
+    },
+    {
+        "name": "Diff: Show +/- notation escapes HTML",
+        "input": "line<1\nold&\n\nline<1\nnew>",
+        "expectedOutput": "<pre>line&lt;1\n-old&amp;\n+new&gt;</pre>",
+        "recipeConfig": [
+            {
+                "op": "Diff",
+                "args": [
+                    "\\n\\n",
+                    "Line",
+                    true,
+                    true,
+                    false,
                     false,
                     true
                 ],


### PR DESCRIPTION
Closes #2312

Added a "Show +/- notation" boolean option to the Diff operation (default: false).

When enabled:
- Added lines are prefixed with "+ "
- Removed lines are prefixed with "- "
- Unchanged lines are prefixed with "  " (two spaces)

Output is compatible with standard unified diff format, allowing export to tools like Slack's diff snippet viewer. Existing highlighting behavior is unchanged when the option is off.