### PR TITLE
Revert sitemap to v8.0.X as exports have changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -154,7 +154,7 @@
         "postcss-import": "^16.1.1",
         "postcss-loader": "^8.2.1",
         "prompt": "^1.3.0",
-        "sitemap": "^9.0.1",
+        "sitemap": "^8.0.3",
         "terser": "^5.46.2",
         "webpack": "^5.106.2",
         "webpack-bundle-analyzer": "^5.0.0",
@@ -16523,39 +16523,29 @@
       }
     },
     "node_modules/sitemap": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
-      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.3.tgz",
+      "integrity": "sha512-9Ew1tR2WYw8RGE2XLy7GjkusvYXy8Rg6y8TYuBuQMfIEdGcWoJpY2Wr5DzsEiL/TKCw56+YKTCCUHglorEYK+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^24.9.2",
+        "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
         "arg": "^5.0.0",
         "sax": "^1.4.1"
       },
       "bin": {
-        "sitemap": "dist/esm/cli.js"
+        "sitemap": "dist/cli.js"
       },
       "engines": {
-        "node": ">=20.19.5",
-        "npm": ">=10.8.2"
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/sitemap/node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/sitemap/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "postcss-import": "^16.1.1",
     "postcss-loader": "^8.2.1",
     "prompt": "^1.3.0",
-    "sitemap": "^9.0.1",
+    "sitemap": "^8.0.3",
     "terser": "^5.46.2",
     "webpack": "^5.106.2",
     "webpack-bundle-analyzer": "^5.0.0",


### PR DESCRIPTION
**Description**
Reverts sitemap to 8.0.3 as v9.x no longer provides a default export which breaks the build/deploy of master

**AI disclosure**
None used

**Test Coverage**
Manually tested that 'npx grunt exec:sitemap' no longer fails.
