### PR TITLE
Feat PadLines: added "Mode" argument

### DIFF
--- a/src/core/operations/PadLines.mjs
+++ b/src/core/operations/PadLines.mjs
@@ -19,6 +19,7 @@ class PadLines extends Operation {
 
         this.name = "Pad lines";
         this.module = "Default";
+        this.description = "Add the specified character to the beginning or end of each line. Operation modes for padding length are either fixed or target line length."
         this.description = "Add the specified number of the specified character to the beginning or end of each line";
         this.inputType = "string";
         this.outputType = "string";
@@ -37,6 +38,11 @@ class PadLines extends Operation {
                 "name": "Character",
                 "type": "binaryShortString",
                 "value": " "
+            },
+            {
+                "name": "Mode",
+                "type": "option",
+                "value": ["Fixed Count", "Target Length"]
             }
         ];
     }
@@ -47,22 +53,23 @@ class PadLines extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const [position, len, chr] = args,
+        const [position, len, chr, mode] = args,
             lines = input.split("\n");
         let output = "",
             i = 0;
 
-        if (position === "Start") {
-            for (i = 0; i < lines.length; i++) {
-                output += lines[i].padStart(lines[i].length+len, chr) + "\n";
-            }
-        } else if (position === "End") {
-            for (i = 0; i < lines.length; i++) {
-                output += lines[i].padEnd(lines[i].length+len, chr) + "\n";
+        for (let i = 0; i < lines.length; i++) {
+            let line = lines[i];
+            let targetLength = mode == "Fixed Count" ? line.length + len : len;
+
+            if (position === "Start") {
+                lines[i] = line.padStart(targetLength, chr);
+            } else if (position === "End") {
+                lines[i] = line.padEnd(targetLength, chr);
             }
         }
 
-        return output.slice(0, output.length-1);
+        return lines.join('\n');
     }
 
 }

--- a/src/core/operations/PadLines.mjs
+++ b/src/core/operations/PadLines.mjs
@@ -19,7 +19,7 @@ class PadLines extends Operation {
 
         this.name = "Pad lines";
         this.module = "Default";
-        this.description = "Add the specified character to the start or end of each line. Padding can use either a fixed character count or a target final line length."
+        this.description = "Add the specified character to the start or end of each line. Padding can use either a fixed character count or a target final line length.";
         this.inputType = "string";
         this.outputType = "string";
         this.args = [
@@ -54,12 +54,10 @@ class PadLines extends Operation {
     run(input, args) {
         const [position, len, chr, mode] = args,
             lines = input.split("\n");
-        let output = "",
-            i = 0;
 
         for (let i = 0; i < lines.length; i++) {
-            let line = lines[i];
-            let targetLength = mode == "Fixed Count" ? line.length + len : len;
+            const line = lines[i];
+            const targetLength = mode === "Fixed Count" ? line.length + len : len;
 
             if (position === "Start") {
                 lines[i] = line.padStart(targetLength, chr);
@@ -68,7 +66,7 @@ class PadLines extends Operation {
             }
         }
 
-        return lines.join('\n');
+        return lines.join("\n");
     }
 
 }

--- a/src/core/operations/PadLines.mjs
+++ b/src/core/operations/PadLines.mjs
@@ -19,8 +19,7 @@ class PadLines extends Operation {
 
         this.name = "Pad lines";
         this.module = "Default";
-        this.description = "Add the specified character to the beginning or end of each line. Operation modes for padding length are either fixed or target line length."
-        this.description = "Add the specified number of the specified character to the beginning or end of each line";
+        this.description = "Add the specified character to the start or end of each line. Padding can use either a fixed character count or a target final line length."
         this.inputType = "string";
         this.outputType = "string";
         this.args = [

--- a/tests/operations/tests/PadLines.mjs
+++ b/tests/operations/tests/PadLines.mjs
@@ -1,0 +1,67 @@
+/**
+ * Pad Lines tests.
+ *
+ * @author oliver-mitchell [oliver@polymerlabs.dev]
+ *
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Can pad Lines adds the specified number of characters to the start.",
+        input: "ABCD\nEF",
+        expectedOutput: `--ABCD\n--EF`,
+        recipeConfig: [
+            {
+                op: "Pad Lines",
+                args: ["Start", 2, "-", "Fixed Count"], // [Position, Length, Character, Mode]
+            },
+        ],
+    },
+    {
+        name: "Can pad lines adds the specified number of characters to the start.",
+        input: "ABCD\nEF",
+        expectedOutput: `--ABCD\n--EF`,
+        recipeConfig: [
+            {
+                op: "Pad Lines",
+                args: ["Start", 2, "-", "Fixed Count"], // [Position, Length, Character, Mode]
+            },
+        ],
+    },
+    {
+        name: "Can pad lines adds the specified number of characters to the end.",
+        input: "ABCD\nEF",
+        expectedOutput: `ABCD--\nEF--`,
+        recipeConfig: [
+            {
+                op: "Pad Lines",
+                args: ["End", 2, "-", "Fixed Count"], // [Position, Length, Character, Mode]
+            },
+        ],
+    },
+    {
+        name: "Can pad lines with enough characters to the start in target length mode.",
+        input: "ABCD\nEF",
+        expectedOutput: `------ABCD\n--------EF`,
+        recipeConfig: [
+            {
+                op: "Pad Lines",
+                args: ["Start", 10, "-", "Target Length"], // [Position, Length, Character, Mode]
+            },
+        ],
+    },
+    {
+        name: "Can pad lines with enough characters to the end in target length mode.",
+        input: "ABCD\nEF",
+        expectedOutput: `ABCD------\nEF--------`,
+        recipeConfig: [
+            {
+                op: "Pad Lines",
+                args: ["End", 10, "-", "Target Length"], // [Position, Length, Character, Mode]
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
Commit overview:
- Added "Mode" argument to the Pad Lines operation.
- Added "Fixed Count" mode. Mimics original behaviour, fixed number of characters added to the string.
- Added "Target Length" mode. Adds padding characters in order to reach a certain length.
- Modified Pad lines implementation to use join rather than slice for final result

**Description**
Adds a new "Mode" argument to the "Pad Lines" operation. Mode allows the user to configure how many padding characters are added. 

The default mode "Fixed Count" mimics the existing behaviour; a fixed number of padding characters is added to the start or end of the string.

The alternative mode "Target Length" differs from "Fixed Count" in that the number of padding characters added is variable; the count argument is instead interpreted as the target length of the overall line.

**Existing Issue**
N/A

**Screenshots**
<img width="1071" height="530" alt="Screenshot 2026-05-06 at 12 37 41 AM" src="https://github.com/user-attachments/assets/b2c25aeb-627d-4bb9-907f-5df6ef335edb" />

**AI disclosure**
No AI was used for this change.

**Test Coverage**
Tests have been added for the Pad line operation.
