### PR TITLE
feat: add Fang IP Addresses operation

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -286,7 +286,8 @@
             "Decode NetBIOS Name",
             "Defang URL",
             "Fang URL",
-            "Defang IP Addresses"
+            "Defang IP Addresses",
+            "Fang IP Addresses"
         ]
     },
     {

--- a/src/core/operations/FangIPAddresses.mjs
+++ b/src/core/operations/FangIPAddresses.mjs
@@ -1,0 +1,56 @@
+/**
+ * @author HarelKatz [github.com/HarelKatz]
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+
+/**
+ * Fang IP Addresses operation
+ */
+class FangIPAddresses extends Operation {
+
+    /**
+     * FangIPAddresses constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Fang IP Addresses";
+        this.module = "Default";
+        this.description = "Takes a defanged IPv4 or IPv6 address and 'Fangs' it, restoring it to a valid address. The inverse of <code>Defang IP Addresses</code>.<br><br>e.g. <code>192[.]168[.]1[.]1</code> becomes <code>192.168.1.1</code>.";
+        this.infoURL = "https://isc.sans.edu/forums/diary/Defang+all+the+things/22744/";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Restore [.]",
+                type: "boolean",
+                value: true
+            },
+            {
+                name: "Restore [:]",
+                type: "boolean",
+                value: true
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const [dots, colons] = args;
+
+        if (dots) input = input.replace(/\[\.\]/g, ".");
+        if (colons) input = input.replace(/\[:\]/g, ":");
+
+        return input;
+    }
+
+}
+
+export default FangIPAddresses;

--- a/tests/operations/tests/FangIPAddresses.mjs
+++ b/tests/operations/tests/FangIPAddresses.mjs
@@ -1,0 +1,88 @@
+/**
+ * Fang IP Addresses tests
+ *
+ * @author HarelKatz [github.com/HarelKatz]
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Fang IP: Valid IPV4",
+        input: "192[.]168[.]1[.]1",
+        expectedOutput: "192.168.1.1",
+        recipeConfig: [
+            {
+                op: "Fang IP Addresses",
+                args: [true, true],
+            },
+        ],
+    },
+    {
+        name: "Fang IP: Valid IPV6",
+        input: "2001[:]0db8[:]85a3[:]0000[:]0000[:]8a2e[:]0370[:]7343",
+        expectedOutput: "2001:0db8:85a3:0000:0000:8a2e:0370:7343",
+        recipeConfig: [
+            {
+                op: "Fang IP Addresses",
+                args: [true, true],
+            },
+        ],
+    },
+    {
+        name: "Fang IP: Valid IPV6 Shorthand",
+        input: "2001[:]db8[:]3c4d[:]15[:][:]1a2f[:]1a2b",
+        expectedOutput: "2001:db8:3c4d:15::1a2f:1a2b",
+        recipeConfig: [
+            {
+                op: "Fang IP Addresses",
+                args: [true, true],
+            },
+        ],
+    },
+    {
+        name: "Fang IP: Multiple defanged IPs in surrounding text",
+        input: "Connect to 10[.]0[.]0[.]1 or 192[.]168[.]1[.]254",
+        expectedOutput: "Connect to 10.0.0.1 or 192.168.1.254",
+        recipeConfig: [
+            {
+                op: "Fang IP Addresses",
+                args: [true, true],
+            },
+        ],
+    },
+    {
+        name: "Fang IP: Plain IP input is unchanged",
+        input: "192.168.1.1",
+        expectedOutput: "192.168.1.1",
+        recipeConfig: [
+            {
+                op: "Fang IP Addresses",
+                args: [true, true],
+            },
+        ],
+    },
+    {
+        name: "Fang IP: Restore dots only",
+        input: "192[.]168[.]1[.]1 ::[:]1",
+        expectedOutput: "192.168.1.1 ::[:]1",
+        recipeConfig: [
+            {
+                op: "Fang IP Addresses",
+                args: [true, false],
+            },
+        ],
+    },
+    {
+        name: "Fang IP: Restore colons only",
+        input: "192[.]168[.]1[.]1 2001[:]db8[:][:]1",
+        expectedOutput: "192[.]168[.]1[.]1 2001:db8::1",
+        recipeConfig: [
+            {
+                op: "Fang IP Addresses",
+                args: [false, true],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
**Description**
Adds a new `Fang IP Addresses` operation that restores defanged IPv4 and IPv6 addresses to their valid form. This is the missing inverse of the existing `Defang IP Addresses` operation.

Examples:
- `192[.]168[.]1[.]1` → `192.168.1.1`
- `2001[:]db8[:][:]1` → `2001:db8::1`

Two boolean args (`Restore [.]`, `Restore [:]`, both default `true`) match the toggle pattern of the existing `Fang URL` op. Lives in the **Default** module (pure JS, no new dependencies) and sits in the **Networking** category next to `Defang IP Addresses`.

**Existing Issue**
Related to #1513 and #1249 — both previously closed.

#1513 was closed as "supported by the new Fang operation". That's true for IPv4 incidentally — `Fang URL`'s blanket `[.]` → `.` replacement happens to restore defanged IPv4 — but **it does not restore `[:]` → `:` for IPv6**. Round-tripping IPv6 through `Defang IP Addresses` → `Fang URL` silently produces broken output (the `[:]` markers stay). This PR closes that gap.

Three reasons this op is worth adding even though `Fang URL` partially overlaps:

1. **IPv6 actually works.** `2001[:]db8[:][:]1` becomes `2001:db8::1` instead of staying mangled.
2. **Op-pair symmetry.** The repo already has `Defang URL` ↔ `Fang URL` and `Defang IP Addresses`. Adding `Fang IP Addresses` completes the matrix and matches user expectations.
3. **Discoverability.** A user searching "fang IP" in the operation list does not find `Fang URL`; the IP-specific name makes the IOC-handling workflow obvious without users having to learn that `Fang URL` happens to handle IPs too.

**Screenshots**
N/A — no visual changes; pure data-transformation operation.

**AI disclosure**
I used Claude Code to assist with implementation: scaffolding the operation, writing the test cases, searching prior issues, and verifying the lint/test/build workflow. I have reviewed all code being submitted and can answer questions about it.

**Test Coverage**
7 new tests in `tests/operations/tests/FangIPAddresses.mjs` covering: IPv4, full IPv6, IPv6 shorthand (with `[:][:]` from the existing Defang IP output), multiple defanged IPs in surrounding text, no-op on already-fanged input, and both arg toggles independently. `npm run lint`, `npm test`, and `npm run testnodeconsumer` all pass locally.