### PR TITLE
Parse IPv4 Header HTML formatting fix

### DIFF
--- a/src/core/operations/ParseIPv4Header.mjs
+++ b/src/core/operations/ParseIPv4Header.mjs
@@ -138,7 +138,7 @@ class ParseIPv4Header extends Operation {
         } else if (outputFormat === "Data (hex)") {
             return toHex(data);
         } else if (outputFormat === "Data (raw)") {
-            return Utils.byteArrayToChars(data);
+            return Utils.escapeHtml(Utils.byteArrayToChars(data));
         }
     }
 

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -126,6 +126,7 @@ import "./tests/NormaliseUnicode.mjs";
 import "./tests/NTLM.mjs";
 import "./tests/OTP.mjs";
 import "./tests/ParseEthernetFrame.mjs";
+import "./tests/ParseIPv4Header.mjs";
 import "./tests/ParseIPRange.mjs";
 import "./tests/ParseObjectIDTimestamp.mjs";
 import "./tests/ParseQRCode.mjs";

--- a/tests/operations/tests/ParseIPv4Header.mjs
+++ b/tests/operations/tests/ParseIPv4Header.mjs
@@ -1,0 +1,23 @@
+/**
+ * Parse IPv4 header tests.
+ *
+ * @author C85297 [95289555+C85297@users.noreply.github.com]
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Parse IPv4 header: Correctly formatted HTML output",
+        input: "45 00 00 3c 1c 46 40 00 40 06 b1 e6 c0 a8 00 01 c0 a8 00 02 3c 73 63 72 69 70 74 3e 61 6c 65 72 74 28 31 33 33 37 29 3c 2f 73 63 72 69 70 74 3e",
+        expectedOutput: "&lt;script&gt;alert(1337)&lt;/script&gt;",
+        recipeConfig: [
+            {
+                op: "Parse IPv4 header",
+                args: ["Hex", "Data (raw)"]
+            }
+        ]
+    }
+]);


### PR DESCRIPTION
**Description**
Parse IPv4 Header operation incorrectly failed to escape characters when returning HTML.

**Existing Issue**
#2394 

**AI disclosure**
gpt-5.5

**Test Coverage**
Yes