### PR TITLE
Parse Ethernet Frame HTML formatting fix

### DIFF
--- a/src/core/operations/ParseEthernetFrame.mjs
+++ b/src/core/operations/ParseEthernetFrame.mjs
@@ -92,7 +92,7 @@ class ParseEthernetFrame extends Operation {
         const packetData = input.slice(offset);
 
         if (outputFormat === "Packet data") {
-            return Utils.byteArrayToChars(packetData);
+            return Utils.escapeHtml(Utils.byteArrayToChars(packetData));
         } else if (outputFormat === "Packet data (hex)") {
             return toHex(packetData);
         } else if (outputFormat === "Text output") {

--- a/tests/operations/tests/ParseEthernetFrame.mjs
+++ b/tests/operations/tests/ParseEthernetFrame.mjs
@@ -41,5 +41,16 @@ TestRegister.addTests([
                 "args": ["Hex", "Text output"]
             }
         ]
+    },
+    {
+        name: "Parse Ethernet frame escapes packet data HTML",
+        input: "000000000000ffffffffffff08003c696d67207372633d78206f6e6572726f723d616c6572742831293e3c7363726970743e616c6572742832293c2f7363726970743e",
+        expectedOutput: "&lt;img src=x onerror=alert(1)&gt;&lt;script&gt;alert(2)&lt;/script&gt;",
+        recipeConfig: [
+            {
+                "op": "Parse Ethernet frame",
+                "args": ["Hex", "Packet data"]
+            }
+        ]
     }
 ]);


### PR DESCRIPTION
**Description**
Parse Ethernet Frame operation incorrectly failed to escape characters when returning HTML

**Existing Issue**
#2394


**AI disclosure**
gpt-5.5

**Test Coverage**
Yes