### PR TITLE
Series Chart HTML Formatting fix

### DIFF
--- a/src/core/operations/SeriesChart.mjs
+++ b/src/core/operations/SeriesChart.mjs
@@ -16,6 +16,20 @@ const d3 = d3temp.default ? d3temp.default : d3temp;
 const nodom = nodomtemp.default ? nodomtemp.default: nodomtemp;
 
 /**
+ * Removes D3's internal bound data from a nodom tree before serialization.
+ * nodom serializes enumerable expando properties such as __data__ as attributes,
+ * so leaving them on attacker-controlled values can create executable markup.
+ *
+ * @param {Object} node
+ */
+function clearD3BoundData(node) {
+    delete node.__data__;
+
+    if (!node.childNodes) return;
+    node.childNodes.forEach(clearD3BoundData);
+}
+
+/**
  * Series chart operation
  */
 class SeriesChart extends Operation {
@@ -221,6 +235,8 @@ class SeriesChart extends Operation {
                 .attr("transform", "rotate(-90)")
                 .text(serie.name);
         });
+
+        clearD3BoundData(svg.node());
 
         return svg._groups[0][0].outerHTML;
     }

--- a/tests/operations/tests/Charts.mjs
+++ b/tests/operations/tests/Charts.mjs
@@ -42,6 +42,17 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "Series chart escapes x-axis values in serialized SVG",
+        input: `s,x"><script>globalThis.seriesChartInjected=1</script><g a=",1`,
+        unexpectedMatch: /<script>|__data__=/,
+        recipeConfig: [
+            {
+                "op": "Series chart",
+                "args": ["Line feed", "Comma", "", 1, "red"]
+            }
+        ],
+    },
+    {
         name: "Heatmap chart",
         input: "100 100\n200 200\n300 300\n400 400\n500 500",
         expectedMatch: /^<svg width/,


### PR DESCRIPTION
**Description**
Series Chart operation incorrectly failed to escape characters when returning HTML

The D3 library stores series names within internal `__data__` attributes, and the library we used to build the DOM (`nodom`) incorrectly allows `__data__` attributes containing quotes to break out of the attribute. This removes the data attributes as they're unused.

**Existing Issue**
No

**AI disclosure**
gpt-5.5

**Test Coverage**
Yes