### PR TITLE
Bump webpack-dev-server to 5.2.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,8 +43,6 @@ updates:
         versions: [ '>=2.0.0' ]
       - dependency-name: 'jimp'
         versions: [ '1.6.1' ]
-      - dependency-name: 'webpack-dev-server'
-        versions: [ '>=5.1.0' ]
     groups:
       #
       # Grouping so we don't get a seperate PR for every patch version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,7 +159,7 @@
         "terser": "^5.46.2",
         "webpack": "^5.106.2",
         "webpack-bundle-analyzer": "^5.3.0",
-        "webpack-dev-server": "^5.0.4",
+        "webpack-dev-server": "^5.2.4",
         "webpack-node-externals": "^3.0.0",
         "worker-loader": "^3.0.8"
       },
@@ -18362,9 +18362,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "terser": "^5.46.2",
     "webpack": "^5.106.2",
     "webpack-bundle-analyzer": "^5.3.0",
-    "webpack-dev-server": "^5.0.4",
+    "webpack-dev-server": "^5.2.4",
     "webpack-node-externals": "^3.0.0",
     "worker-loader": "^3.0.8"
   },


### PR DESCRIPTION
**Description**
Update to latest webpack-dev-server - updates from vulnerable version

**Existing Issue**
[dependabot alert 258](https://github.com/gchq/CyberChef/security/dependabot/258)

**AI disclosure**
None used

**Test Coverage**
Manually checked 'npm run start' compiles/runs OK