### PR TITLE
Fix CBOR Encode for cbor v9: use streaming Encoder with pre-sorted Maps

### DIFF
--- a/src/core/operations/CBOREncode.mjs
+++ b/src/core/operations/CBOREncode.mjs
@@ -7,6 +7,73 @@
 import Operation from "../Operation.mjs";
 import Cbor from "cbor";
 
+// cbor v9: Encoder.encode/encodeCanonical return only the first byte.
+// Pre-sort map keys ourselves and use a custom Map semantic type so the
+// encoder writes keys in insertion order without re-sorting internally.
+
+/**
+ * Returns the byte-length of a CBOR-encoded text string key (header + payload).
+ * Used to implement RFC 7049 canonical map key ordering.
+ *
+ * @param {string} s
+ * @returns {number}
+ */
+function cborKeyEncodedLen(s) {
+    const n = Buffer.byteLength(s, "utf8");
+    if (n < 24)      return 1 + n;
+    if (n < 0x100)   return 2 + n;
+    if (n < 0x10000) return 3 + n;
+    return 5 + n;
+}
+
+/**
+ * Recursively converts plain objects to pre-sorted Maps so that the CBOR
+ * encoder emits keys in canonical (length-first, then lexicographic) order
+ * without relying on the cbor library's own canonical sort, which is broken
+ * in cbor v9 for streamed output.
+ *
+ * @param {*} val
+ * @returns {*}
+ */
+function prepareCBOR(val) {
+    if (Array.isArray(val)) return val.map(prepareCBOR);
+    if (val !== null && typeof val === "object" && !(val instanceof Map)) {
+        const sorted = Object.keys(val).sort((a, b) => {
+            const la = cborKeyEncodedLen(a), lb = cborKeyEncodedLen(b);
+            if (la !== lb) return la - lb;
+            return Buffer.from(a, "utf8").compare(Buffer.from(b, "utf8"));
+        });
+        return new Map(sorted.map(k => [k, prepareCBOR(val[k])]));
+    }
+    return val;
+}
+
+/**
+ * Encodes a value as canonical CBOR using a streaming Encoder.
+ * Returns a Promise that resolves to a Buffer containing the full encoding.
+ *
+ * @param {*} input
+ * @returns {Promise<Buffer>}
+ */
+function cborEncodeCanonical(input) {
+    return new Promise((resolve, reject) => {
+        const enc = new Cbor.Encoder({canonical: true});
+        enc.addSemanticType(Map, (e, m) => {
+            if (!e._pushInt(m.size, 5)) return false;
+            for (const [k, v] of m) {
+                if (!e.pushAny(k) || !e.pushAny(v)) return false;
+            }
+            return true;
+        });
+        const bufs = [];
+        enc.on("data", b => bufs.push(b));
+        enc.on("error", reject);
+        enc.on("finish", () => resolve(Buffer.concat(bufs)));
+        enc.pushAny(prepareCBOR(input));
+        enc.end();
+    });
+}
+
 /**
  * CBOR Encode operation
  */
@@ -32,8 +99,9 @@ class CBOREncode extends Operation {
      * @param {Object[]} args
      * @returns {ArrayBuffer}
      */
-    run(input, args) {
-        return new Uint8Array(Cbor.encodeCanonical(input)).buffer;
+    async run(input, args) {
+        const buf = await cborEncodeCanonical(input);
+        return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
     }
 
 }


### PR DESCRIPTION
## Problem

`cbor` v9 changed `Encoder.encode()` and `encodeCanonical()` from synchronous to async stream-based, but the static sync wrappers were kept and silently return only the **first chunk (~1 byte)** of output. The existing `CBOREncode` operation called `Cbor.encodeCanonical(input)` synchronously, so all multi-byte values were truncated.

Affected test cases (currently failing):
- `CBOR Encode: Can encode text` — expected `64 54 65 78 74`, received `64`
- `CBOR Encode: Can encode map` — expected `a3 61 61 01 ...`, received `a3`
- `CBOR Encode: Can encode list` — expected `83 00 01 02`, received `83`
- `CBOR Decode: Can encode decimal` — input truncated before decode

Single-byte values (`0f` for integer 15, `f4`/`f5` for booleans) still passed by coincidence.

## Fix

Drive a streaming `Encoder` directly:

1. **Pre-sort** plain object keys into `Map`s using RFC 7049 canonical order (shortest encoded key first, then lexicographic byte comparison) before encoding — so insertion order produces the canonical result.
2. **Register a custom `Map` semantic type** that bypasses the encoder's own canonical sort (which has the same first-byte-only bug in v9 due to an internal `NoFilter` stream).
3. **Collect all output chunks** via the `data` event, then return a correctly sliced `ArrayBuffer` (avoiding Node.js Buffer pool aliasing via `byteOffset`/`byteLength`).

`run()` becomes `async`; the CyberChef framework already `await`s `run()`.

## Test plan

- [ ] `CBOR Encode: Can encode integer` — `0f` ✓
- [ ] `CBOR Decode: Can encode decimal` — `f9 3e 00` ✓
- [ ] `CBOR Encode: Can encode text` — `64 54 65 78 74` ✓
- [ ] `CBOR Encode: Can encode boolean true` — `f5` ✓
- [ ] `CBOR Encode: Can encode boolean false` — `f4` ✓
- [ ] `CBOR Encode: Can encode map` — `a3 61 61 01 61 62 02 61 63 03` ✓
- [ ] `CBOR Encode: Can encode list` — `83 00 01 02` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)