### PR TITLE
Make dependabot quieter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       day: 'friday'
       time: '03:00'
       timezone: Europe/London
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: 'chore (deps): '
     ignore:
@@ -41,7 +43,8 @@ updates:
         versions: [ '1.6.1' ]
     groups:
       #
-      # Grouping so we don't get a seperate PR for every patch version.
+      # Grouping so patch version updates are batched together in a single PR 
+      # and similarly with minor version updates
       #
       patch-updates:
         applies-to: version-updates
@@ -49,6 +52,12 @@ updates:
           - '*'
         update-types:
           - 'patch'
+      minor-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
 
   # Versioning on Github Actions
   - package-ecosystem: "github-actions"
@@ -60,8 +69,14 @@ updates:
       day: 'friday'
       time: '03:00'
       timezone: Europe/London
+    cooldown:
+      default-days: 4
     commit-message:
       prefix: 'chore (deps): '
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /
@@ -70,3 +85,11 @@ updates:
       day: 'friday'
       time: '03:00'
       timezone: Europe/London
+    cooldown:
+      default-days: 4
+    commit-message:
+      prefix: 'chore (deps): '
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
**Description**

Make dependabot quieter
* Batch up npm minor updates, github actions, and docker updates to reduce the number of PRs generated
* Add cooldown periods to reduce the degree of manual checking required for supply chain issues

**AI disclosure**
none used

**Test Coverage**
n/a