### PR TITLE
Validate random and QR input bounds

### DIFF
--- a/src/core/operations/GenerateQRCode.mjs
+++ b/src/core/operations/GenerateQRCode.mjs
@@ -64,6 +64,13 @@ class GenerateQRCode extends Operation {
     run(input, args) {
         const [format, size, margin, errorCorrection] = args;
 
+        if (!Number.isFinite(size) || size < 1) {
+            throw new OperationError("Module size must be greater than 0.");
+        }
+        if (!Number.isFinite(margin) || margin < 0) {
+            throw new OperationError("Margin must be greater than or equal to 0.");
+        }
+
         return generateQrCode(input, format, size, margin, errorCorrection);
     }
 

--- a/src/core/operations/PseudoRandomIntegerGenerator.mjs
+++ b/src/core/operations/PseudoRandomIntegerGenerator.mjs
@@ -80,6 +80,10 @@ class PseudoRandomIntegerGenerator extends Operation {
 
         if (minInt === null || maxInt === null) return "";
 
+        if (!Number.isSafeInteger(numInts) || numInts < 1) {
+            throw new OperationError("Number of Integers must be a positive integer.");
+        }
+
         const min = Math.ceil(minInt);
         const max = Math.floor(maxInt);
         const delim = Utils.charRep(delimiter || "Space");

--- a/src/core/operations/PseudoRandomNumberGenerator.mjs
+++ b/src/core/operations/PseudoRandomNumberGenerator.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import Utils from "../Utils.mjs";
 import forge from "node-forge";
 import BigNumber from "bignumber.js";
@@ -48,6 +49,10 @@ class PseudoRandomNumberGenerator extends Operation {
      */
     run(input, args) {
         const [numBytes, outputAs] = args;
+
+        if (!Number.isSafeInteger(numBytes) || numBytes < 0) {
+            throw new OperationError("Number of bytes must be a non-negative integer.");
+        }
 
         let bytes;
 

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -142,6 +142,7 @@ import "./tests/ParityBit.mjs";
 import "./tests/PHPSerialize.mjs";
 import "./tests/PowerSet.mjs";
 import "./tests/Protobuf.mjs";
+import "./tests/PseudoRandom.mjs";
 import "./tests/PubKeyFromCert.mjs";
 import "./tests/PubKeyFromPrivKey.mjs";
 import "./tests/Rabbit.mjs";

--- a/tests/operations/tests/GenerateQRCode.mjs
+++ b/tests/operations/tests/GenerateQRCode.mjs
@@ -64,4 +64,26 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "Generate QR Code: negative module size",
+        input: "a",
+        expectedOutput: "Module size must be greater than 0.",
+        recipeConfig: [
+            {
+                "op": "Generate QR Code",
+                "args": ["PNG", -5, 4, "Medium"]
+            },
+        ],
+    },
+    {
+        name: "Generate QR Code: negative margin",
+        input: "a",
+        expectedOutput: "Margin must be greater than or equal to 0.",
+        recipeConfig: [
+            {
+                "op": "Generate QR Code",
+                "args": ["PNG", 5, -4, "Medium"]
+            },
+        ],
+    },
 ]);

--- a/tests/operations/tests/PseudoRandom.mjs
+++ b/tests/operations/tests/PseudoRandom.mjs
@@ -1,0 +1,33 @@
+/**
+ * Pseudo-Random operation tests.
+ *
+ * @author paulolokaux-sudo
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Pseudo-Random Number Generator: negative byte count",
+        input: "",
+        expectedOutput: "Number of bytes must be a non-negative integer.",
+        recipeConfig: [
+            {
+                op: "Pseudo-Random Number Generator",
+                args: [-32, "Hex"]
+            }
+        ]
+    },
+    {
+        name: "Pseudo-Random Integer Generator: negative integer count",
+        input: "",
+        expectedOutput: "Number of Integers must be a positive integer.",
+        recipeConfig: [
+            {
+                op: "Pseudo-Random Integer Generator",
+                args: [-1, -10, -9, "Space", "Raw"]
+            }
+        ]
+    }
+]);


### PR DESCRIPTION
## Summary

Adds explicit input validation for three operation edge cases so invalid numeric arguments return clear CyberChef operation messages instead of unhandled `RangeError`s or silent empty output.

Fixes #2447.
Fixes #2448.
Fixes #2449.

## Changes

- Validate `Generate QR Code` module size and margin before calling `qr-image`.
- Validate `Pseudo-Random Number Generator` byte count before allocating/generating bytes.
- Validate `Pseudo-Random Integer Generator` count before generating output.
- Add operation tests for the invalid input recipes from the linked issues.

## Verification

- `npx grunt configTests`
- Targeted Chef checks for the issue reproduction recipes
- `npm run lint`
- `npm test`
  - Node API tests: 244/244 passing
  - Operation tests: 1940/1940 passing
- Browser verification via local `npm start` and Playwright MCP against the issue deep links
- `npm run build`

Note: `npm run build` completed successfully. During build, Webpack Bundle Analyzer printed existing ENOENT parsing warnings for worker bundle names while generating its report, then webpack compiled successfully and Grunt finished with `Done.`
