### PR TITLE
Validate Bit shift left amount

### DIFF
--- a/src/core/operations/BitShiftLeft.mjs
+++ b/src/core/operations/BitShiftLeft.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 
 /**
  * Bit shift left operation
@@ -27,7 +28,8 @@ class BitShiftLeft extends Operation {
             {
                 "name": "Amount",
                 "type": "number",
-                "value": 1
+                "value": 1,
+                "min": 0
             }
         ];
     }
@@ -39,6 +41,9 @@ class BitShiftLeft extends Operation {
      */
     run(input, args) {
         const amount = args[0];
+        if (amount < 0) {
+            throw new OperationError("Amount must be non-negative.");
+        }
         input = new Uint8Array(input);
 
         return input.map(b => {

--- a/tests/operations/tests/BitwiseOp.mjs
+++ b/tests/operations/tests/BitwiseOp.mjs
@@ -22,6 +22,15 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Bit shift left rejects negative amount",
+        input: "a",
+        expectedOutput: "Amount must be non-negative.",
+        recipeConfig: [
+            { "op": "Bit shift left",
+                "args": [-1] }
+        ]
+    },
+    {
         name: "Bit shift right: Logical shift",
         input: "01010101 10101010 11111111 00000000 11110000 00001111 00110011 11001100",
         expectedOutput: "00101010 01010101 01111111 00000000 01111000 00000111 00011001 01100110",


### PR DESCRIPTION
## Summary

- Reject negative `Bit shift left` amounts before JavaScript shift coercion can turn them into invalid null-byte output.
- Set the operation argument minimum to `0` so the UI metadata matches the runtime validation.
- Add a regression test for `Bit shift left(-1)` returning a clear error message.

Closes gchq/CyberChef#2482.

## Testing

- Red check before fix: `Bit shift left(-1)` on input `a` returned `\u0000`.
- `npx grunt configTests`
- `node --no-warnings --no-deprecation --openssl-legacy-provider --trace-uncaught tests/operations/index.mjs`
- `npm run lint`
- `npm run build`
- `git diff --check`
