### PR TITLE
Validate To Binary byte length

### DIFF
--- a/src/core/lib/Binary.mjs
+++ b/src/core/lib/Binary.mjs
@@ -9,6 +9,7 @@
 import Utils from "../Utils.mjs";
 import OperationError from "../errors/OperationError.mjs";
 
+export const MAX_BINARY_PADDING = 65536;
 
 /**
  * Convert a byte array into a binary string.
@@ -31,6 +32,10 @@ import OperationError from "../errors/OperationError.mjs";
 export function toBinary(data, delim="Space", padding=8) {
     if (data === undefined || data === null)
         throw new OperationError("Unable to convert to binary: Empty input data enocuntered");
+
+    padding = Number(padding);
+    if (!Number.isFinite(padding) || padding < 0 || Math.round(padding) !== padding || padding > MAX_BINARY_PADDING)
+        throw new OperationError(`Byte length must be an integer between 0 and ${MAX_BINARY_PADDING}`);
 
     delim = Utils.charRep(delim);
     let output = "";
@@ -77,4 +82,3 @@ export function fromBinary(data, delim="Space", byteLen=8) {
     }
     return output;
 }
-

--- a/src/core/operations/ToBinary.mjs
+++ b/src/core/operations/ToBinary.mjs
@@ -7,7 +7,7 @@
 import Operation from "../Operation.mjs";
 import Utils from "../Utils.mjs";
 import {BIN_DELIM_OPTIONS} from "../lib/Delim.mjs";
-import {toBinary} from "../lib/Binary.mjs";
+import {MAX_BINARY_PADDING, toBinary} from "../lib/Binary.mjs";
 
 /**
  * To Binary operation
@@ -35,6 +35,8 @@ class ToBinary extends Operation {
             {
                 "name": "Byte Length",
                 "type": "number",
+                "min": 1,
+                "max": MAX_BINARY_PADDING,
                 "value": 8
             }
         ];

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -178,6 +178,7 @@ import "./tests/TakeNthBytes.mjs";
 import "./tests/Template.mjs";
 import "./tests/TextEncodingBruteForce.mjs";
 import "./tests/TextIntegerConverter.mjs";
+import "./tests/ToBinary.mjs";
 import "./tests/ToFromInsensitiveRegex.mjs";
 import "./tests/TranslateDateTimeFormat.mjs";
 import "./tests/Typex.mjs";

--- a/tests/operations/tests/ToBinary.mjs
+++ b/tests/operations/tests/ToBinary.mjs
@@ -1,0 +1,33 @@
+/**
+ * To Binary tests
+ *
+ * @author n1474335 [n1474335@gmail.com]
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "To Binary: custom byte length",
+        input: "hello",
+        expectedOutput: "01101000 01100101 01101100 01101100 01101111",
+        recipeConfig: [
+            {
+                "op": "To Binary",
+                "args": ["Space", 8]
+            }
+        ]
+    },
+    {
+        name: "To Binary: byte length too large",
+        input: "hello",
+        expectedOutput: "Byte length must be an integer between 0 and 65536",
+        recipeConfig: [
+            {
+                "op": "To Binary",
+                "args": ["Space", "8111111111111111111"]
+            }
+        ]
+    }
+]);


### PR DESCRIPTION
Fixes #2484

## Summary
- validate To Binary padding before calling `padStart`
- add min/max metadata for the Byte Length argument
- add To Binary regression coverage for oversized byte length input

## Tests
- `npm_config_cache=/tmp/cyberchef-2484-npm-cache npx grunt configTests`
- `node --no-warnings --no-deprecation --openssl-legacy-provider --input-type=module -e 'import "./tests/operations/tests/ToBinary.mjs"; import "./tests/operations/tests/BitwiseOp.mjs"; import "./tests/operations/tests/ParityBit.mjs"; import TestRegister from "./tests/lib/TestRegister.mjs"; const results = await TestRegister.runTests(); console.log(JSON.stringify(results.map(({test,status,output}) => ({name: test.name, status, output})), null, 2)); if (results.some((result) => result.status !== "passing")) process.exit(1);'`\n- `node --no-warnings --no-deprecation --openssl-legacy-provider --trace-uncaught tests/operations/index.mjs`\n- `npm_config_cache=/tmp/cyberchef-2484-npm-cache npx grunt lint`\n- `git diff --check`