### PR TITLE
fix: validate To BCD scheme option

### DIFF
--- a/src/core/operations/ToBCD.mjs
+++ b/src/core/operations/ToBCD.mjs
@@ -67,6 +67,10 @@ class ToBCD extends Operation {
             signed = args[2],
             outputFormat = args[3];
 
+        if (!encoding) {
+            throw new OperationError("Invalid BCD encoding scheme");
+        }
+
         // Split input number up into separate digits
         const digits = input.toFixed().split("");
 

--- a/tests/operations/tests/BCD.mjs
+++ b/tests/operations/tests/BCD.mjs
@@ -53,6 +53,17 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "To BCD: invalid scheme",
+        input: "43",
+        expectedOutput: "Invalid BCD encoding scheme",
+        recipeConfig: [
+            {
+                "op": "To BCD",
+                "args": ["", true, false, "Nibbles"]
+            }
+        ]
+    },
+    {
         name: "From BCD: default 0",
         input: "0000",
         expectedOutput: "0",


### PR DESCRIPTION
**Description**

Adds validation for the To BCD scheme argument so malformed recipe URLs with an empty scheme return a controlled operation error instead of an uncaught TypeError.

**Existing Issue**

Closes #2488

**Screenshots**

N/A

**AI disclosure**

I used OpenAI Codex to inspect the existing BCD operation/tests, add the regression test, and run verification. I reviewed the code and test output.

**Test Coverage**

- `node --no-warnings --no-deprecation --openssl-legacy-provider --input-type=module -e 'import TestRegister from "./tests/lib/TestRegister.mjs"; await import("./tests/operations/tests/BCD.mjs"); const results = await TestRegister.runTests(); const failed = results.filter(r => r.status !== "passing"); console.log(JSON.stringify(failed.map(r => ({name: r.test.name, status: r.status, output: r.output})), null, 2)); process.exit(failed.length ? 1 : 0);'`
- `npm test`
- `npm run lint`
- `git diff --check`
