### PR TITLE
fix: validate text encoding options

### DIFF
--- a/src/core/operations/DecodeText.mjs
+++ b/src/core/operations/DecodeText.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import cptable from "codepage";
 import {CHR_ENC_CODE_PAGES} from "../lib/ChrEnc.mjs";
 
@@ -48,6 +49,9 @@ class DecodeText extends Operation {
      */
     run(input, args) {
         const format = CHR_ENC_CODE_PAGES[args[0]];
+        if (!format) {
+            throw new OperationError("Invalid encoding");
+        }
         return cptable.utils.decode(format, new Uint8Array(input));
     }
 

--- a/src/core/operations/EncodeText.mjs
+++ b/src/core/operations/EncodeText.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import cptable from "codepage";
 import {CHR_ENC_CODE_PAGES} from "../lib/ChrEnc.mjs";
 
@@ -48,6 +49,9 @@ class EncodeText extends Operation {
      */
     run(input, args) {
         const format = CHR_ENC_CODE_PAGES[args[0]];
+        if (!format) {
+            throw new OperationError("Invalid encoding");
+        }
         const encoded = cptable.utils.encode(format, input);
         return new Uint8Array(encoded).buffer;
     }

--- a/tests/operations/tests/CharEnc.mjs
+++ b/tests/operations/tests/CharEnc.mjs
@@ -69,6 +69,32 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "Encode text: empty encoding",
+        input: "hello",
+        expectedOutput: "Invalid encoding",
+        recipeConfig: [
+            {
+                "op": "Encode text",
+                "args": [""]
+            },
+        ],
+    },
+    {
+        name: "Decode text: empty encoding",
+        input: "68 65 6c 6c 6f",
+        expectedOutput: "Invalid encoding",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["Space"]
+            },
+            {
+                "op": "Decode text",
+                "args": [""]
+            },
+        ],
+    },
+    {
         name: "Generate Base64 Windows PowerShell",
         input: "ZABpAHIAIAAiAGMAOgBcAHAAcgBvAGcAcgBhAG0AIABmAGkAbABlAHMAIgAgAA==",
         expectedOutput: "dir \"c:\\program files\" ",


### PR DESCRIPTION
**Description**
This PR adds validation for the selected encoding in the `Encode text` and `Decode text` operations.

Previously, malformed recipes such as `Encode_text('')` or `Decode_text('')` could pass an empty encoding argument into the operation. This caused `CHR_ENC_CODE_PAGES[args[0]]` to resolve to `undefined`, which was then passed into the `codepage` library and surfaced as an uncaught `Unrecognized CP: undefined` error.

The change now checks whether the selected encoding resolves to a supported codepage before calling `codepage`, and returns a controlled `OperationError` when the encoding is invalid.

Regression tests have also been added for both operations.

**Existing Issue**
Fixes #2493  
Fixes #2494

**Screenshots**
N/A. This PR did not have any changes to any visual aspects of CyberChef.

**AI disclosure**
AI tools were used while preparing this PR. These were the tools that I used:
- ChatGPT for issue analysis and review
- Codex to identify repo scope and recon

I reviewed the changes, ran the relevant tests, and take responsibility for the submitted code.

**Test Coverage**
Added operation tests in `tests/operations/tests/CharEnc.mjs` covering empty encoding arguments for:
- `Encode text`
- `Decode text`

Test command run:
```bash
npm run test
```

**Result:**
Node API tests: 244/244 passing
Operation tests: 1942/1942 passing