### PR TITLE
fix: validate hexdump width upper bound

### DIFF
--- a/src/core/operations/ToHexdump.mjs
+++ b/src/core/operations/ToHexdump.mjs
@@ -8,6 +8,8 @@ import Operation from "../Operation.mjs";
 import Utils from "../Utils.mjs";
 import OperationError from "../errors/OperationError.mjs";
 
+const MAX_WIDTH = 65536;
+
 /**
  * To Hexdump operation
  */
@@ -30,7 +32,8 @@ class ToHexdump extends Operation {
                 "name": "Width",
                 "type": "number",
                 "value": 16,
-                "min": 1
+                "min": 1,
+                "max": MAX_WIDTH
             },
             {
                 "name": "Upper case hex",
@@ -62,6 +65,9 @@ class ToHexdump extends Operation {
 
         if (length < 1 || Math.round(length) !== length)
             throw new OperationError("Width must be a positive integer");
+
+        if (length > MAX_WIDTH)
+            throw new OperationError(`Width must be no more than ${MAX_WIDTH}`);
 
         const lines = [];
         for (let i = 0; i < data.length; i += length) {

--- a/tests/operations/tests/Hexdump.mjs
+++ b/tests/operations/tests/Hexdump.mjs
@@ -127,6 +127,17 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "To Hexdump: Width too large",
+        input: "H",
+        expectedOutput: "Width must be no more than 65536",
+        recipeConfig: [
+            {
+                op: "To Hexdump",
+                args: [155555555555555, false, false, false]
+            }
+        ],
+    },
+    {
         name: "From Hexdump: xxd",
         input: `00000000: 0001 0203 0405 0607 0809 0a0b 0c0d 0e0f  ................
 00000010: 1011 1213 1415 1617 1819 1a1b 1c1d 1e1f  ................


### PR DESCRIPTION
## Summary
- cap the `To Hexdump` width argument at a documented maximum
- return an `OperationError` for oversized widths instead of surfacing a runtime `RangeError`
- add a regression test for the width value from #2483

## Why
A very large width value can reach `String.padEnd()` and throw an uncaught `RangeError` before CyberChef can present a normal operation error. Validating the width keeps the operation failure user-facing and bounded.

Fixes #2483.

## Checks
- `npm ci`
- `npm run lint`
- `npm test`
- focused Hexdump operation test (`13` passing)
- `git diff --check`
