### PR TITLE
Fix Swap endianness data format validation

### DIFF
--- a/src/core/operations/SwapEndianness.mjs
+++ b/src/core/operations/SwapEndianness.mjs
@@ -71,7 +71,7 @@ class SwapEndianness extends Operation {
                 data = Utils.strToByteArray(input);
                 break;
             default:
-                data = input;
+                throw new OperationError("Data format must be Hex or Raw");
         }
 
         // Split up into words

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -174,6 +174,7 @@ import "./tests/StripTCPHeader.mjs";
 import "./tests/StripUDPHeader.mjs";
 import "./tests/Subsection.mjs";
 import "./tests/SwapCase.mjs";
+import "./tests/SwapEndianness.mjs";
 import "./tests/SymmetricDifference.mjs";
 import "./tests/TakeNthBytes.mjs";
 import "./tests/Template.mjs";

--- a/tests/operations/tests/SwapEndianness.mjs
+++ b/tests/operations/tests/SwapEndianness.mjs
@@ -1,0 +1,33 @@
+/**
+ * Swap endianness tests.
+ *
+ * @author marko1olo
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Swap endianness: Hex data",
+        input: "0123456789abcdef",
+        expectedOutput: "67 45 23 01 ef cd ab 89",
+        recipeConfig: [
+            {
+                op: "Swap endianness",
+                args: ["Hex", 4, true],
+            },
+        ],
+    },
+    {
+        name: "Swap endianness: empty data format",
+        input: "hello",
+        expectedOutput: "Data format must be Hex or Raw",
+        recipeConfig: [
+            {
+                op: "Swap endianness",
+                args: ["", 2, true],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
## Summary

Fix `Swap endianness` so an invalid or empty data format argument produces a controlled operation error instead of falling through with the raw input string and later throwing `word.push is not a function`.

This covers the issue reproduction from #2495, where a deep link can pass an empty first argument: `Swap_endianness('',2,true)`.

## Test plan

- `npx grunt configTests`
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs` -> `TOTAL 1962`, `PASSING 1962`
- `npx eslint src/core/operations/SwapEndianness.mjs tests/operations/index.mjs tests/operations/tests/SwapEndianness.mjs`
- `git diff --cached --check` before commit

Note: the first `npm ci` attempt hit a network `ECONNRESET`, and a retry timed out locally. The dependencies installed far enough for the targeted lint, config generation, and full operation test suite above to pass.

Fixes #2495.