### PR TITLE
Fix HMAC empty hash function validation

### DIFF
--- a/src/core/operations/HMAC.mjs
+++ b/src/core/operations/HMAC.mjs
@@ -6,6 +6,7 @@
 
 import Operation from "../Operation.mjs";
 import Utils from "../Utils.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import CryptoApi from "crypto-api/src/crypto-api.mjs";
 
 /**
@@ -67,6 +68,10 @@ class HMAC extends Operation {
      * @returns {string}
      */
     run(input, args) {
+        if (!args[1]) {
+            throw new OperationError("Hashing function must be selected.");
+        }
+
         const key = Utils.convertToByteString(args[0].string || "", args[0].option),
             hashFunc = args[1].toLowerCase(),
             msg = Utils.arrayBufferToStr(input, false),

--- a/tests/node/tests/operations.mjs
+++ b/tests/node/tests/operations.mjs
@@ -661,6 +661,22 @@ WWFkYSBZYWRh\r
         assert.strictEqual(chef.HMAC("On Cloud Nine", {key: "idea"}).toString(), "e15c268b4ee755c9e52db094ed50add7");
     }),
 
+    it("HMAC rejects an empty hashing function", () => {
+        assert.throws(
+            () => chef.HMAC("hi", {
+                key: {
+                    option: "UTF8",
+                    string: "",
+                },
+                hashingFunction: "",
+            }),
+            {
+                type: "OperationError",
+                message: "Hashing function must be selected.",
+            }
+        );
+    }),
+
     it("JPathExpression", () => {
         assert.strictEqual(chef.JPathExpression("{\"key\" : \"value\"}", {query: "$.key"}).toString(), "\"value\"");
     }),
@@ -1178,4 +1194,3 @@ ExifImageHeight: 57`);
 
 
 ]);
-


### PR DESCRIPTION
Fixes #2513.

## Summary
- validate the selected HMAC hashing function before calling `toLowerCase()`
- return a controlled `OperationError` for empty hash function values instead of an uncaught `TypeError`
- add a Node API regression test for `chef.HMAC(..., { hashingFunction: "" })`

## Checks
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/node/index.mjs` -> 246 passing
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs` -> 1960 passing
- `npx eslint src/core/operations/HMAC.mjs tests/node/tests/operations.mjs tests/operations/tests/Hash.mjs`
- `npx grunt configTests`
- `git diff --check`