### PR TITLE
Fix BLAKE3 size validation

### DIFF
--- a/src/core/operations/BLAKE3.mjs
+++ b/src/core/operations/BLAKE3.mjs
@@ -47,6 +47,11 @@ class BLAKE3 extends Operation {
     run(input, args) {
         const key = args[1];
         const size = args[0];
+
+        if (!Number.isInteger(size) || size < 0) {
+            throw new OperationError("Size must be a non-negative integer");
+        }
+
         const opts = { dkLen: size };
         const inputBytes = new Uint8Array(Utils.strToArrayBuffer(input));
         if (key !== "") {

--- a/tests/operations/tests/BLAKE3.mjs
+++ b/tests/operations/tests/BLAKE3.mjs
@@ -35,6 +35,24 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "BLAKE3: negative size",
+        input: "hello",
+        expectedOutput: "Size must be a non-negative integer",
+        recipeConfig: [
+            { "op": "BLAKE3",
+                "args": [-6, ""] }
+        ]
+    },
+    {
+        name: "BLAKE3: fractional size",
+        input: "hello",
+        expectedOutput: "Size must be a non-negative integer",
+        recipeConfig: [
+            { "op": "BLAKE3",
+                "args": [1.2, ""] }
+        ]
+    },
+    {
         name: "BLAKE3: Key Test",
         input: "Hello world",
         expectedOutput: "59dd23ac9d025690",


### PR DESCRIPTION
Fixes #2512.

## Summary
- validate the BLAKE3 output size before passing it to `@noble/hashes`
- convert negative and fractional size values into a controlled `OperationError`
- add regression coverage for `-6` and `1.2` size values

## Checks
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs` -> 1962 passing
- `npx eslint src/core/operations/BLAKE3.mjs tests/operations/tests/BLAKE3.mjs`
- `npx grunt configTests`
- `git diff --check`