### PR TITLE
Fix BLAKE2 output encoding validation

### DIFF
--- a/src/core/operations/BLAKE2b.mjs
+++ b/src/core/operations/BLAKE2b.mjs
@@ -70,7 +70,7 @@ class BLAKE2b extends Operation {
             case "Raw":
                 return Utils.arrayBufferToStr(blakejs.blake2b(input, key, outSize / 8).buffer);
             default:
-                return new OperationError("Unsupported Output Type");
+                throw new OperationError("Unsupported Output Type");
         }
     }
 

--- a/src/core/operations/BLAKE2s.mjs
+++ b/src/core/operations/BLAKE2s.mjs
@@ -71,7 +71,7 @@ class BLAKE2s extends Operation {
             case "Raw":
                 return Utils.arrayBufferToStr(blakejs.blake2s(input, key, outSize / 8).buffer);
             default:
-                return new OperationError("Unsupported Output Type");
+                throw new OperationError("Unsupported Output Type");
         }
     }
 

--- a/tests/operations/tests/BLAKE2b.mjs
+++ b/tests/operations/tests/BLAKE2b.mjs
@@ -52,5 +52,14 @@ TestRegister.addTests([
             { "op": "BLAKE2b",
                 "args": ["128", "Hex", {string: "pseudorandom key", option: "UTF8"}] }
         ]
+    },
+    {
+        name: "BLAKE2b: missing output encoding",
+        input: "hello",
+        expectedOutput: "Unsupported Output Type",
+        recipeConfig: [
+            { "op": "BLAKE2b",
+                "args": ["512", "", {string: "", option: "UTF8"}] }
+        ]
     }
 ]);

--- a/tests/operations/tests/BLAKE2s.mjs
+++ b/tests/operations/tests/BLAKE2s.mjs
@@ -43,5 +43,14 @@ TestRegister.addTests([
             { "op": "BLAKE2s",
                 "args": ["128", "Hex", {string: "", option: "UTF8"}] }
         ]
+    },
+    {
+        name: "BLAKE2s: missing output encoding",
+        input: "hello",
+        expectedOutput: "Unsupported Output Type",
+        recipeConfig: [
+            { "op": "BLAKE2s",
+                "args": ["256", "", {string: "", option: "UTF8"}] }
+        ]
     }
 ]);


### PR DESCRIPTION
Fixes #2510.
Fixes #2511.

## Summary
- throw `OperationError` for unsupported BLAKE2b/BLAKE2s output encodings instead of returning it as operation output
- avoid the follow-on `Data is not a valid string: {"type":"OperationError"}` error
- add regression coverage for empty output encoding values for both operations

## Checks
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs` -> 1962 passing
- `npx eslint src/core/operations/BLAKE2b.mjs src/core/operations/BLAKE2s.mjs tests/operations/tests/BLAKE2b.mjs tests/operations/tests/BLAKE2s.mjs`
- `npx grunt configTests`
- `git diff --check`