### PR TITLE
Fix Snefru size validation

### DIFF
--- a/src/core/operations/Snefru.mjs
+++ b/src/core/operations/Snefru.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import {runHash} from "../lib/Hash.mjs";
 
 /**
@@ -30,7 +31,7 @@ class Snefru extends Operation {
                 type: "number",
                 value: 128,
                 min: 32,
-                max: 480,
+                max: 448,
                 step: 32
             },
             {
@@ -47,8 +48,14 @@ class Snefru extends Operation {
      * @returns {string}
      */
     run(input, args) {
+        const size = args[0];
+
+        if (!Number.isInteger(size) || size < 32 || size > 448 || size % 32 !== 0) {
+            throw new OperationError("Size must be a multiple of 32 between 32 and 448");
+        }
+
         return runHash("snefru", input, {
-            length: args[0],
+            length: size,
             rounds: args[1]
         });
     }

--- a/tests/operations/tests/Hash.mjs
+++ b/tests/operations/tests/Hash.mjs
@@ -405,6 +405,28 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Snefru rejects negative size",
+        input: "hello",
+        expectedOutput: "Size must be a multiple of 32 between 32 and 448",
+        recipeConfig: [
+            {
+                "op": "Snefru",
+                "args": [-32, "8"]
+            }
+        ]
+    },
+    {
+        name: "Snefru rejects out-of-range size",
+        input: "hello",
+        expectedOutput: "Size must be a multiple of 32 between 32 and 448",
+        recipeConfig: [
+            {
+                "op": "Snefru",
+                "args": [480, "8"]
+            }
+        ]
+    },
+    {
         name: "SM3 256 64",
         input: "Hello, World!",
         expectedOutput: "7ed26cbf0bee4ca7d55c1e64714c4aa7d1f163089ef5ceb603cd102c81fbcbc5",


### PR DESCRIPTION
Fixes #2509.

## Summary
- validate Snefru size before passing it to `crypto-api`
- reject negative sizes with a controlled `OperationError` instead of an uncaught `RangeError` or empty output
- lower the operation metadata max from `480` to `448`, because the current implementation also throws at `480`
- add regression coverage for the reported negative boundary and the previous exposed max

## Checks
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs` -> 1962 passing
- `npx eslint src/core/operations/Snefru.mjs tests/operations/tests/Hash.mjs`
- `npx grunt configTests`
- `git diff --check`