### PR TITLE
Ensure theme switches to preferred colour scheme on first load

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -46,7 +46,7 @@ function main() {
         showErrors:          true,
         errorTimeout:        4000,
         attemptHighlight:    true,
-        theme:               "classic",
+        theme:               undefined,
         useMetaKey:          false,
         logLevel:            "info",
         autoMagic:           true,


### PR DESCRIPTION
**Description**
Currently opening the page for the first time does not correctly apply the users preferred colour scheme.

In `OptionsWaiter`, we do this to apply the theme:

https://github.com/gchq/CyberChef/blob/d735496641493725fbdf64f1c0064296c7f3fdac/src/web/waiters/OptionsWaiter.mjs#L177-L184

However, `themeFromStorage` is already set to "classic" at this point, assigned here:

https://github.com/gchq/CyberChef/blob/d735496641493725fbdf64f1c0064296c7f3fdac/src/web/App.mjs#L36

The fix is set the default theme to `undefined` and let it be set from either localStorage or `getPreferredColorScheme()`.

Related issues: #1921, #1901 

**AI disclosure**
No AI was used in the creation of this pull request.
