### PR TITLE
Fix Whirlpool variant validation

### DIFF
--- a/src/core/operations/Whirlpool.mjs
+++ b/src/core/operations/Whirlpool.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import {runHash} from "../lib/Hash.mjs";
 
 /**
@@ -46,8 +47,13 @@ class Whirlpool extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const variant = args[0].toLowerCase();
-        return runHash(variant, input, {rounds: args[1]});
+        const variant = args[0];
+
+        if (!this.args[0].value.includes(variant)) {
+            throw new OperationError("Invalid Whirlpool variant");
+        }
+
+        return runHash(variant.toLowerCase(), input, {rounds: args[1]});
     }
 
 }

--- a/tests/operations/tests/Hash.mjs
+++ b/tests/operations/tests/Hash.mjs
@@ -339,6 +339,17 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Whirlpool: invalid variant",
+        input: "a",
+        expectedOutput: "Invalid Whirlpool variant",
+        recipeConfig: [
+            {
+                "op": "Whirlpool",
+                "args": ["", 10]
+            }
+        ]
+    },
+    {
         name: "Snefru 2 128",
         input: "Hello, World!",
         expectedOutput: "a4ad2b8848580511d0884fb4233a7e7a",


### PR DESCRIPTION
## Summary

- Validate the Whirlpool variant before requesting a hasher from `crypto-api`.
- Convert invalid direct-link/API values such as `Whirlpool('', 10)` into a controlled operation error instead of an uncaught backend `TypeError`.
- Add operation regression coverage for the empty variant case.

Fixes #2507

## Checks

- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs`
- `npx eslint src/core/operations/Whirlpool.mjs tests/operations/tests/Hash.mjs`
- `npx grunt configTests`
- `git diff --check`