### PR TITLE
Fix SHA2 size validation

### DIFF
--- a/src/core/operations/SHA2.mjs
+++ b/src/core/operations/SHA2.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import {runHash} from "../lib/Hash.mjs";
 
 /**
@@ -83,6 +84,11 @@ class SHA2 extends Operation {
      */
     run(input, args) {
         const size = args[0];
+
+        if (!this.args[0].value.some(option => option.name === size)) {
+            throw new OperationError("Invalid SHA2 size");
+        }
+
         const rounds = (size === "256" || size === "224") ? args[1] : args[2];
         return runHash("sha" + size, input, {rounds: rounds});
     }

--- a/tests/operations/tests/Hash.mjs
+++ b/tests/operations/tests/Hash.mjs
@@ -141,6 +141,17 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "SHA2: invalid size",
+        input: "hi",
+        expectedOutput: "Invalid SHA2 size",
+        recipeConfig: [
+            {
+                "op": "SHA2",
+                "args": ["", 64, 13]
+            }
+        ]
+    },
+    {
         name: "SHA3 224",
         input: "Hello, World!",
         expectedOutput: "853048fb8b11462b6100385633c0cc8dcdc6e2b8e376c28102bc84f2",


### PR DESCRIPTION
## Summary

- Validate the SHA2 size argument before requesting a hasher from `crypto-api`.
- Convert invalid direct-link/API values such as `SHA2('', 64, 13)` into a controlled operation error instead of an uncaught backend `TypeError`.
- Add operation regression coverage for the empty size case.

Fixes #2505

## Checks

- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs`
- `npx eslint src/core/operations/SHA2.mjs tests/operations/tests/Hash.mjs`
- `npx grunt configTests`
- `git diff --check`