### PR TITLE
Fix From BCD scheme validation

### DIFF
--- a/src/core/operations/FromBCD.mjs
+++ b/src/core/operations/FromBCD.mjs
@@ -70,6 +70,10 @@ class FromBCD extends Operation {
             inputFormat = args[3],
             nibbles = [];
 
+        if (!encoding) {
+            throw new OperationError("Invalid BCD encoding scheme");
+        }
+
         let output = "",
             byteArray;
 

--- a/tests/operations/tests/BCD.mjs
+++ b/tests/operations/tests/BCD.mjs
@@ -86,6 +86,17 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "From BCD: invalid encoding scheme",
+        input: "1000",
+        expectedOutput: "Invalid BCD encoding scheme",
+        recipeConfig: [
+            {
+                "op": "From BCD",
+                "args": ["", true, false, "Nibbles"]
+            }
+        ]
+    },
+    {
         name: "BCD: raw 4 2 2 1, packed, signed",
         input: "1234567890",
         expectedOutput: "1234567890",


### PR DESCRIPTION
## Summary

- Validate the From BCD encoding scheme before using the lookup table.
- Convert invalid direct-link/API values such as `From_BCD('', true, false, 'Nibbles')` into a controlled operation error instead of an uncaught `TypeError`.
- Add operation regression coverage for the empty scheme case.

Fixes #2489

## Checks

- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs`
- `npx eslint src/core/operations/FromBCD.mjs tests/operations/tests/BCD.mjs`
- `npx grunt configTests`
- `git diff --check`