### PR TITLE
Fix To Base radix validation

### DIFF
--- a/src/core/operations/ToBase.mjs
+++ b/src/core/operations/ToBase.mjs
@@ -43,7 +43,7 @@ class ToBase extends Operation {
             throw new OperationError("Error: Input must be a number");
         }
         const radix = args[0];
-        if (radix < 2 || radix > 36) {
+        if (!Number.isInteger(radix) || radix < 2 || radix > 36) {
             throw new OperationError("Error: Radix argument must be between 2 and 36");
         }
         return input.toString(radix);

--- a/tests/operations/index.mjs
+++ b/tests/operations/index.mjs
@@ -21,6 +21,7 @@ import "./tests/AnalyseUUID.mjs";
 import "./tests/AlternatingCaps.mjs";
 import "./tests/AvroToJSON.mjs";
 import "./tests/BaconCipher.mjs";
+import "./tests/Base.mjs";
 import "./tests/Base32.mjs";
 import "./tests/Base45.mjs";
 import "./tests/Base58.mjs";

--- a/tests/operations/tests/Base.mjs
+++ b/tests/operations/tests/Base.mjs
@@ -1,0 +1,33 @@
+/**
+ * Base conversion tests
+ *
+ * @author marko1olo
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "To Base: base 2",
+        input: "63",
+        expectedOutput: "111111",
+        recipeConfig: [
+            {
+                "op": "To Base",
+                "args": [2]
+            }
+        ]
+    },
+    {
+        name: "To Base: fractional radix",
+        input: "63",
+        expectedOutput: "Error: Radix argument must be between 2 and 36",
+        recipeConfig: [
+            {
+                "op": "To Base",
+                "args": [2.2]
+            }
+        ]
+    },
+]);


### PR DESCRIPTION
## Summary

- Reject fractional radix values before passing them to `BigNumber#toString()`.
- Convert values such as `To_Base(2.2)` into the existing controlled radix validation error instead of an uncaught BigNumber error.
- Add operation coverage for normal base-2 conversion and the fractional radix regression.

Fixes #2487

## Checks

- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs`
- `npx eslint src/core/operations/ToBase.mjs tests/operations/index.mjs tests/operations/tests/Base.mjs`
- `npx grunt configTests`
- `git diff --check`