### PR TITLE
Validate Whirlpool rounds

### DIFF
--- a/src/core/operations/Whirlpool.mjs
+++ b/src/core/operations/Whirlpool.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import {runHash} from "../lib/Hash.mjs";
 
 /**
@@ -46,8 +47,13 @@ class Whirlpool extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const variant = args[0].toLowerCase();
-        return runHash(variant, input, {rounds: args[1]});
+        const variant = args[0].toLowerCase(),
+            rounds = args[1] ?? 10;
+
+        if (!Number.isInteger(rounds) || rounds < 1 || rounds > 10)
+            throw new OperationError("Rounds must be an integer between 1 and 10");
+
+        return runHash(variant, input, {rounds});
     }
 
 }

--- a/tests/operations/tests/Hash.mjs
+++ b/tests/operations/tests/Hash.mjs
@@ -339,6 +339,28 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Whirlpool rejects negative rounds",
+        input: "Hello, World!",
+        expectedOutput: "Rounds must be an integer between 1 and 10",
+        recipeConfig: [
+            {
+                "op": "Whirlpool",
+                "args": ["Whirlpool", -1]
+            }
+        ]
+    },
+    {
+        name: "Whirlpool rejects fractional rounds",
+        input: "Hello, World!",
+        expectedOutput: "Rounds must be an integer between 1 and 10",
+        recipeConfig: [
+            {
+                "op": "Whirlpool",
+                "args": ["Whirlpool", 1.2]
+            }
+        ]
+    },
+    {
         name: "Snefru 2 128",
         input: "Hello, World!",
         expectedOutput: "a4ad2b8848580511d0884fb4233a7e7a",


### PR DESCRIPTION
Fixes #2508.

Whirlpool exposes `Rounds` as a numeric option with a UI range of 1-10, but the operation accepted direct API/recipe values outside that range. Passing a negative round count through to `crypto-api` produced the reported all-zero Whirlpool output.

This adds runtime validation for integer rounds in the supported 1-10 range, while preserving existing recipes that omit the second argument by defaulting to 10 rounds.

AI disclosure:
- This change was prepared with assistance from OpenAI Codex.

Validation:
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs` passed: 1962 passing.
- `npx eslint src/core/operations/Whirlpool.mjs tests/operations/tests/Hash.mjs` passed.
- `npx grunt configTests` passed.
- `git diff --check` passed.