### PR TITLE
Fix MD2 rounds validation

### DIFF
--- a/src/core/operations/MD2.mjs
+++ b/src/core/operations/MD2.mjs
@@ -6,6 +6,7 @@
 
 import Operation from "../Operation.mjs";
 import {runHash} from "../lib/Hash.mjs";
+import OperationError from "../errors/OperationError.mjs";
 
 /**
  * MD2 operation
@@ -40,7 +41,12 @@ class MD2 extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        return runHash("md2", input, {rounds: args[0]});
+        const rounds = args[0] ?? 18;
+
+        if (!Number.isInteger(rounds) || rounds < 0)
+            throw new OperationError("Rounds must be a non-negative integer");
+
+        return runHash("md2", input, {rounds});
     }
 
 }

--- a/tests/operations/tests/Hash.mjs
+++ b/tests/operations/tests/Hash.mjs
@@ -20,6 +20,28 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "MD2 rejects negative rounds",
+        input: "Hello, World!",
+        expectedOutput: "Rounds must be a non-negative integer",
+        recipeConfig: [
+            {
+                "op": "MD2",
+                "args": [-1]
+            }
+        ]
+    },
+    {
+        name: "MD2 rejects fractional rounds",
+        input: "Hello, World!",
+        expectedOutput: "Rounds must be a non-negative integer",
+        recipeConfig: [
+            {
+                "op": "MD2",
+                "args": [1.2]
+            }
+        ]
+    },
+    {
         name: "MD4",
         input: "Hello, World!",
         expectedOutput: "94e3cb0fa9aa7a5ee3db74b79e915989",


### PR DESCRIPTION
Fixes #2506.

## Summary
- Validate the MD2 `rounds` option before invoking the hash implementation.
- Reject negative and fractional round counts with an `OperationError` instead of producing invalid output.
- Add regression coverage for negative and fractional MD2 rounds.

## Tests
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests/operations/index.mjs`
- `npx eslint src/core/operations/MD2.mjs tests/operations/tests/Hash.mjs`
- `npx grunt configTests`
- `git diff --check`

This change was prepared with OpenAI Codex.