### PR TITLE
Fix: Add input validation for XOR Checksum blocksize (#2537)

### DIFF
--- a/src/core/operations/XORChecksum.mjs
+++ b/src/core/operations/XORChecksum.mjs
@@ -7,7 +7,7 @@
 import Operation from "../Operation.mjs";
 import Utils from "../Utils.mjs";
 import { toHex } from "../lib/Hex.mjs";
-import OperationError from "../errors/OperationError.mjs"; // 1. Added import
+import OperationError from "../errors/OperationError.mjs"; // 1. Added import for error message 
 
 /**
  * XOR Checksum operation

--- a/src/core/operations/XORChecksum.mjs
+++ b/src/core/operations/XORChecksum.mjs
@@ -7,53 +7,60 @@
 import Operation from "../Operation.mjs";
 import Utils from "../Utils.mjs";
 import { toHex } from "../lib/Hex.mjs";
+import OperationError from "../errors/OperationError.mjs"; // 1. Added import
 
 /**
  * XOR Checksum operation
  */
 class XORChecksum extends Operation {
+  /**
+   * XORChecksum constructor
+   */
+  constructor() {
+    super();
 
-    /**
-     * XORChecksum constructor
-     */
-    constructor() {
-        super();
+    this.name = "XOR Checksum";
+    this.module = "Crypto";
+    this.description =
+      "XOR Checksum splits the input into blocks of a configurable size and performs the XOR operation on these blocks.";
+    this.infoURL = "https://wikipedia.org/wiki/XOR";
+    this.inputType = "ArrayBuffer";
+    this.outputType = "string";
+    this.args = [
+      {
+        name: "Blocksize",
+        type: "number",
+        value: 4,
+      },
+    ];
+  }
 
-        this.name = "XOR Checksum";
-        this.module = "Crypto";
-        this.description = "XOR Checksum splits the input into blocks of a configurable size and performs the XOR operation on these blocks.";
-        this.infoURL = "https://wikipedia.org/wiki/XOR";
-        this.inputType = "ArrayBuffer";
-        this.outputType = "string";
-        this.args = [
-            {
-                name: "Blocksize",
-                type: "number",
-                value: 4
-            },
-        ];
+  /**
+   * @param {ArrayBuffer} input
+   * @param {Object[]} args
+   * @returns {string}
+   */
+  run(input, args) {
+    const blocksize = args[0];
+
+    // 2. Added validation check
+    if (!Number.isInteger(blocksize) || blocksize <= 0) {
+      throw new OperationError("Blocksize must be a positive integer.");
     }
 
-    /**
-     * @param {ArrayBuffer} input
-     * @param {Object[]} args
-     * @returns {string}
-     */
-    run(input, args) {
-        const blocksize = args[0];
-        input = new Uint8Array(input);
+    input = new Uint8Array(input);
 
-        const res = Array(blocksize);
-        res.fill(0);
+    const res = Array(blocksize);
+    res.fill(0);
 
-        for (const chunk of Utils.chunked(input, blocksize)) {
-            for (let i = 0; i < blocksize; i++) {
-                res[i] ^= chunk[i];
-            }
-        }
-
-        return toHex(res, "");
+    for (const chunk of Utils.chunked(input, blocksize)) {
+      for (let i = 0; i < blocksize; i++) {
+        res[i] ^= chunk[i];
+      }
     }
+
+    return toHex(res, "");
+  }
 }
 
 export default XORChecksum;


### PR DESCRIPTION
**Description**
This pull request adds input validation to the **XOR Checksum** operation (`src/core/operations/XORChecksum.mjs`). Previously, entering a decimal (float) or a negative value as the `Blocksize` parameter would pass straight to the JavaScript array constructor (`Array(blocksize)`), triggering an uncaught `RangeError: invalid array length` and crashing the application's runtime.

This fix introduces an explicit check using `Number.isInteger()` and bounds validation (`<= 0`) right at the start of the `run` method. If the user passes an invalid block size, it now gracefully interrupts execution and throws a user-friendly `OperationError`, displaying a clear error message in the output panel instead of crashing.

**Existing Issue**
Fixes #2537

**Screenshots**
* **Before:** Entering `1.1` or `-1` causes a frozen screen or a blank output box, with a red `RangeError` appearing in the browser's developer console.
* **After:** Entering `1.1` or `-1` immediately shows a clean, red error banner in the output pane stating: `Blocksize must be a positive integer.`


**Test Coverage**
Tested manually via the local web server (`localhost:8080`) using the exact inputs from the bug report:
1. **Input:** `1.1` -> Successfully caught by validation, shows `Blocksize must be a positive integer.`
2. **Input:** `-1` -> Successfully caught by validation, shows `Blocksize must be a positive integer.`
3. **Input:** `4` (Valid integer) -> Runs successfully without errors, matching original expected behavior.