### PR TITLE
fix: handle invalid luhn checksum input

### DIFF
--- a/src/core/operations/LuhnChecksum.mjs
+++ b/src/core/operations/LuhnChecksum.mjs
@@ -81,8 +81,15 @@ class LuhnChecksum extends Operation {
             throw new OperationError("Error: Radix argument must be divisible by 2");
         }
 
-        const checkSum = this.checksum(input, radix).toString(radix);
-        let checkDigit = this.checksum(input + "0", radix);
+        let checkSum, checkDigit;
+
+        try {
+            checkSum = this.checksum(input, radix).toString(radix);
+            checkDigit = this.checksum(input + "0", radix);
+        } catch (err) {
+            throw new OperationError(err.message);
+        }
+
         checkDigit = checkDigit === 0 ? 0 : (radix - checkDigit);
         checkDigit = checkDigit.toString(radix);
 

--- a/tests/operations/tests/LuhnChecksum.mjs
+++ b/tests/operations/tests/LuhnChecksum.mjs
@@ -433,4 +433,15 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "Luhn Checksum on invalid radix character",
+        input: "o",
+        expectedOutput: "Character: o is not valid in radix 4.",
+        recipeConfig: [
+            {
+                op: "Luhn Checksum",
+                args: [4]
+            },
+        ],
+    },
 ]);


### PR DESCRIPTION
## Problem

Luhn Checksum currently lets invalid input characters escape as a raw JavaScript error when the character is not valid for the selected radix. For example, `Luhn_Checksum(4)` with input `o` reports `Character: o is not valid in radix 4.` as an unhandled error.

## Solution

I wrapped the checksum/check-digit calculation in the operation runner and rethrow validation failures as `OperationError`, matching the existing controlled operation error path used for invalid radix arguments. I also added regression coverage for the radix 4 invalid-character case from #2536.

Fixes #2536.

## Testing

- `npx grunt configTests`
- `node --no-warnings --no-deprecation --openssl-legacy-provider tests\operations\index.mjs --grep Luhn`
- `npx eslint src\core\operations\LuhnChecksum.mjs tests\operations\tests\LuhnChecksum.mjs`
- `git diff --check`