### PR TITLE
Fix spurious error messages generated during webpack build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,7 +144,8 @@ module.exports = function (grunt) {
                     new BundleAnalyzerPlugin({
                         analyzerMode: "static",
                         reportFilename: "BundleAnalyzerReport.html",
-                        openAnalyzer: false
+                        openAnalyzer: false,
+                        excludeAssets: /.*Worker.js/
                     }),
                 ]
             };


### PR DESCRIPTION
**Description**
Gets rid of messages like "Error parsing bundle asset "/home/runner/work/CyberChef/CyberChef/build/prod/ChefWorker.js": no such file" which occur whilst running the webpack-bundle-analyzer plugin at the end of the webpack build

It works around a bug in webpack-bundle-analyzer plugin which interprets .js.LICENCE.txt as .js and then fails to find the file.

As there are no files named "*Worker.js" in the build, the bundle analyser can safely be told to ignore files matching the regex /.*Worker.js/

**AI disclosure**
No use of AI

**Test Coverage**
Does not affect the actual build or code anyway as it is only the analysis of the bundle that is affected. However all existing tests pass, and the build log has been manually verified to no longer contain these error messages.
