### PR TITLE
fix(bcrypt): handle invalid rounds by throwing OperationError

### DIFF
--- a/src/core/operations/Bcrypt.mjs
+++ b/src/core/operations/Bcrypt.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import bcrypt from "bcryptjs";
 import { isWorkerEnvironment } from "../Utils.mjs";
 
@@ -41,13 +42,17 @@ class Bcrypt extends Operation {
      */
     async run(input, args) {
         const rounds = args[0];
-        const salt = await bcrypt.genSalt(rounds);
+        try {
+            const salt = await bcrypt.genSalt(rounds);
 
-        return await bcrypt.hash(input, salt, undefined, p => {
-            // Progress callback
-            if (isWorkerEnvironment())
-                self.sendStatusMessage(`Progress: ${(p * 100).toFixed(0)}%`);
-        });
+            return await bcrypt.hash(input, salt, undefined, p => {
+                // Progress callback
+                if (isWorkerEnvironment())
+                    self.sendStatusMessage(`Progress: ${(p * 100).toFixed(0)}%`);
+            });
+        } catch (err) {
+            throw new OperationError(err.toString());
+        }
 
     }
 

--- a/src/core/operations/BcryptCompare.mjs
+++ b/src/core/operations/BcryptCompare.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import bcrypt from "bcryptjs";
 import { isWorkerEnvironment } from "../Utils.mjs";
 
@@ -43,13 +44,17 @@ class BcryptCompare extends Operation {
     async run(input, args) {
         const hash = args[0];
 
-        const match = await bcrypt.compare(input, hash, undefined, p => {
-            // Progress callback
-            if (isWorkerEnvironment())
-                self.sendStatusMessage(`Progress: ${(p * 100).toFixed(0)}%`);
-        });
+        try {
+            const match = await bcrypt.compare(input, hash, undefined, p => {
+                // Progress callback
+                if (isWorkerEnvironment())
+                    self.sendStatusMessage(`Progress: ${(p * 100).toFixed(0)}%`);
+            });
 
-        return match ? "Match: " + input : "No match";
+            return match ? "Match: " + input : "No match";
+        } catch (err) {
+            throw new OperationError(err.toString());
+        }
 
     }
 

--- a/tests/operations/tests/Hash.mjs
+++ b/tests/operations/tests/Hash.mjs
@@ -994,6 +994,17 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Bcrypt compare: invalid rounds",
+        input: "hello",
+        expectedOutput: "Error: Illegal number of rounds (4-31): 34",
+        recipeConfig: [
+            {
+                op: "Bcrypt compare",
+                args: ["$2b$34$K.H1WlFDQ/iIo/PiprT/puwluJ5rzuSE5q8D/Fk3NuLgU2aXiGR9m"]
+            }
+        ]
+    },
+    {
         name: "Scrypt: RFC test vector 1",
         input: "",
         expectedOutput: "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906",


### PR DESCRIPTION
**Description**
Provide a description of the pull request and the changes that it makes.

**Existing Issue**
If this pull request relates to an existing issue in the repository, please link it here.

**Screenshots**
If the pull request changes any visual aspects of CyberChef, please include screenshots.

**AI disclosure**
If you have used any AI tools while creating this code, **you must declare your usage along with the name of the tools that you used**.
Regardless of AI tool usage, you are responsible for any code that you submit, and we expect you to have checked the code and have enough of an understanding of it to answer any questions we might have.

**Test Coverage**
Please ensure you have added test coverage for your changes.



Fixes #2534

### Description
This PR fixes an issue where attempting to hash or compare with an invalid number of bcrypt rounds (e.g. `<4` or `>31`) would result in an uncaught exception from the `bcryptjs` dependency, completely breaking the operation execution instead of bubbling the error to the user interface.

### Changes Made
- Wrapped the core functions (`bcrypt.compare`, `bcrypt.genSalt`, and `bcrypt.hash`) in `Bcrypt.mjs` and `BcryptCompare.mjs` with `try/catch` blocks.
- When an error is caught, it now correctly throws an `OperationError`, which matches the established architectural pattern in CyberChef (and aligns with `BcryptParse.mjs`). This allows the error message (e.g., `Illegal number of rounds (4-31)`) to safely display in the output panel.
- Added a new unit test in `Hash.mjs` (`Bcrypt compare: invalid rounds`) to verify that the out-of-bounds error is properly caught. Verified that the test runner correctly passes this using the expected string output.