### PR TITLE
Fix: Create BigNumber with NaN value in Dish.valid

### DIFF
--- a/src/core/Dish.mjs
+++ b/src/core/Dish.mjs
@@ -292,7 +292,7 @@ class Dish {
                     and reinitialise it as a BigNumber object.
                 */
                 if (Object.keys(this.value).sort().equals(["c", "e", "s"])) {
-                    const temp = new BigNumber();
+                    const temp = new BigNumber(NaN);
                     temp.c = this.value.c;
                     temp.e = this.value.e;
                     temp.s = this.value.s;

--- a/tests/node/tests/Dish.mjs
+++ b/tests/node/tests/Dish.mjs
@@ -8,5 +8,8 @@ TestRegister.addApiTests([
         const dish = new Dish();
         assert(dish.presentAs);
     }),
-
+    it("Disk - valid: should not err on serialized big_number", () => {
+        const dish = new Dish({ c: 0, e: 0, s: 0 }, Dish.BIG_NUMBER);
+        assert(dish.valid());
+    })
 ]);


### PR DESCRIPTION
**Description**
The constructor expects the default value but we are not passing it. So it was throwing undefined error. Now passing NaN as default value.


**Existing Issue**
#2567 

**Screenshots**
<img width="1319" height="877" alt="image" src="https://github.com/user-attachments/assets/fdcdb005-5dff-4fd3-ab86-50d3a7415a87" />

Console error
```javascript
Uncaught Error: [BigNumber Error] BigNumber, string, number, or BigInt expected: undefined
    P https://gchq.github.io/CyberChef/assets/main.js:2
    value https://gchq.github.io/CyberChef/assets/main.js:2
    value https://gchq.github.io/CyberChef/assets/main.js:2
    e https://gchq.github.io/CyberChef/assets/main.js:2
    value https://gchq.github.io/CyberChef/assets/main.js:2
    value https://gchq.github.io/CyberChef/assets/main.js:2
    value https://gchq.github.io/CyberChef/assets/main.js:2
```

**AI disclosure**
Didn't use AI.

**Test Coverage**
Added a test.
