### PR TITLE
Fix operation description rendering

### DIFF
--- a/src/web/HTMLOperation.mjs
+++ b/src/web/HTMLOperation.mjs
@@ -56,9 +56,10 @@ class HTMLOperation {
 
         if (this.description) {
             const infoLink = this.infoURL ? `<hr>${titleFromWikiLink(this.infoURL)}` : "";
+            const content = Utils.escapeHtml(this.description + infoLink);
 
             html += ` data-container='body' data-toggle='popover' data-placement='right'
-                data-content="${this.description}${infoLink}" data-html='true' data-trigger='hover'
+                data-content="${content}" data-html='true' data-trigger='hover'
                 data-boundary='viewport' role='button'`;
         }
 

--- a/tests/browser/00_nightwatch.js
+++ b/tests/browser/00_nightwatch.js
@@ -60,10 +60,15 @@ module.exports = {
     },
 
     "Operation popover descriptions render HTML safely": browser => {
-        const op = "//li[contains(@class, 'operation') and text()='Escape Smart Characters']";
+        const favouritesCat = "//a[contains(@class, 'category-title') and contains(@data-target, '#catFavourites')]",
+            op = "//ul[@id='search-results']//li[contains(@class, 'operation') and contains(., 'Escape Smart Characters')]";
 
         browser
+            .useCss()
+            .clearValue("#search")
+            .setValue("#search", "Escape Smart Characters")
             .useXpath()
+            .waitForElementVisible(op, 1000)
             .moveToElement(op, 10, 10)
             .useCss()
             .waitForElementVisible(".popover-body code:last-of-type", 1000)
@@ -72,7 +77,11 @@ module.exports = {
         browser
             .useCss()
             .moveToElement("#operations .title", 1, 1)
-            .waitForElementNotPresent(".popover-body", 1000);
+            .waitForElementNotPresent(".popover-body", 1000)
+            .clearValue("#search")
+            .useXpath()
+            .getLocationInView(favouritesCat)
+            .click(favouritesCat);
     },
 
     "Recipe can be run": browser => {

--- a/tests/browser/00_nightwatch.js
+++ b/tests/browser/00_nightwatch.js
@@ -56,6 +56,23 @@ module.exports = {
         browser.expect.element("//li[contains(@class, 'operation') and text()='Play Media']").to.be.present;
         browser.expect.element("//li[contains(@class, 'operation') and text()='Disassemble x86']").to.be.present;
         browser.expect.element("//li[contains(@class, 'operation') and text()='Register']").to.be.present;
+        browser.expect.element("//li[contains(@class, 'operation') and text()='Escape Smart Characters']").to.be.present;
+    },
+
+    "Operation popover descriptions render HTML safely": browser => {
+        const op = "//li[contains(@class, 'operation') and text()='Escape Smart Characters']";
+
+        browser
+            .useXpath()
+            .moveToElement(op, 10, 10)
+            .useCss()
+            .waitForElementVisible(".popover-body code:last-of-type", 1000)
+            .expect.element(".popover-body code:last-of-type").text.to.contain("\"Hello\" -- world...");
+
+        browser
+            .useCss()
+            .moveToElement("#operations .title", 1, 1)
+            .waitForElementNotPresent(".popover-body", 1000);
     },
 
     "Recipe can be run": browser => {


### PR DESCRIPTION
**Description**
Fix the rendering of operation descriptions containing special characters. Escape the description before placing it in `data-content`.

**Existing Issue**
#2575 

**Screenshots**
<img width="577" height="242" alt="image" src="https://github.com/user-attachments/assets/c1a33e63-4c9b-402a-9c6f-d5f348197912" />


**AI disclosure**
gpt-5.5

**Test Coverage**
Yes