### PR TITLE
Fix uncaught TypeError in To BCD with empty encoding scheme

### DIFF
--- a/src/core/operations/FromBCD.mjs
+++ b/src/core/operations/FromBCD.mjs
@@ -73,6 +73,9 @@ class FromBCD extends Operation {
         let output = "",
             byteArray;
 
+        if (encoding === undefined)
+            throw new OperationError("Invalid encoding scheme");
+
         // Normalise the input
         switch (inputFormat) {
             case "Nibbles":

--- a/src/core/operations/ToBCD.mjs
+++ b/src/core/operations/ToBCD.mjs
@@ -67,6 +67,9 @@ class ToBCD extends Operation {
             signed = args[2],
             outputFormat = args[3];
 
+        if (encoding === undefined)
+            throw new OperationError("Invalid encoding scheme");
+
         // Split input number up into separate digits
         const digits = input.toFixed().split("");
 

--- a/tests/operations/tests/BCD.mjs
+++ b/tests/operations/tests/BCD.mjs
@@ -100,4 +100,26 @@ TestRegister.addTests([
             }
         ]
     },
+    {
+        name: "To BCD: invalid (empty) encoding scheme",
+        input: "43",
+        expectedOutput: "Invalid encoding scheme",
+        recipeConfig: [
+            {
+                "op": "To BCD",
+                "args": ["", true, false, "Nibbles"]
+            }
+        ]
+    },
+    {
+        name: "From BCD: invalid (empty) encoding scheme",
+        input: "0100 0011",
+        expectedOutput: "Invalid encoding scheme",
+        recipeConfig: [
+            {
+                "op": "From BCD",
+                "args": ["", true, false, "Nibbles"]
+            }
+        ]
+    },
 ]);


### PR DESCRIPTION
## Description

The **To BCD** operation throws an uncaught `TypeError` when its **Scheme**
argument is empty or unrecognised. This can be triggered via a recipe URL where
the first argument is an empty string, e.g.:

https://gchq.github.io/CyberChef/#recipe=To_BCD('',true,false,'Nibbles')&input=NDM

```
To BCD - TypeError in blob:... on line 2.
Message: can't access property 4, n is undefined
```

### Root cause

In `src/core/operations/ToBCD.mjs`, the encoding lookup is performed with:

```js
const encoding = ENCODING_LOOKUP[args[0]];
```

`args[0]` is the **Scheme** option. When it is an empty string (or any value not
present in `ENCODING_LOOKUP`), `encoding` is `undefined`. The code then does
`encoding[n]` while mapping over the input digits, which throws the uncaught
`TypeError` because a property is being accessed on `undefined`.

`From BCD` (`src/core/operations/FromBCD.mjs`) shares the same pattern: it calls
`encoding.indexOf(n)`, which would throw `TypeError: encoding.indexOf is not a
function` for the same reason.

### The solution

Both operations now validate the encoding scheme immediately after the lookup and
throw a friendly `OperationError` instead of letting an uncaught `TypeError`
crash the bake:

```js
if (encoding === undefined)
    throw new OperationError("Invalid encoding scheme");
```

This mirrors the existing validation style already used in `To BCD` (e.g. the
`input.isNaN()` and fractional-value guards) and the approach taken by other
recent fixes that convert uncaught `TypeError`s into actionable errors. As with
those existing `OperationError`s, the message is surfaced to the user as the
operation output rather than crashing the bake.

## Existing Issue

Fixes #2488

## Screenshots

No visual/UI changes — this only replaces a crash with a handled error message.

## AI disclosure

This code was written with the assistance of an AI coding assistant (Qoder). The
logic, fix, and tests have been reviewed and verified against the existing
codebase conventions and the `Recipe.execute` error-handling flow.

## Test Coverage

Added regression tests to `tests/operations/tests/BCD.mjs` covering both
operations with an empty scheme:

- `To BCD: invalid (empty) encoding scheme` — input `43`, expects output
  `Invalid encoding scheme`.
- `From BCD: invalid (empty) encoding scheme` — input `0100 0011`, expects
  output `Invalid encoding scheme`.

Because an `OperationError` is caught by `Recipe.execute` and its message is
returned as the operation output, these tests assert the message directly
(`expectedOutput: "Invalid encoding scheme"`). Without the fix, both cases
produce an uncaught `TypeError` instead of this message, so the tests fail
without the fix and pass with it.