### PR TITLE
Handle empty Generate Image mode

### DIFF
--- a/src/core/operations/GenerateImage.mjs
+++ b/src/core/operations/GenerateImage.mjs
@@ -74,11 +74,11 @@ class GenerateImage extends Operation {
             Bits: 1 / 8,
         };
 
-        const bytesPerPixel = bytePerPixelMap[mode];
-
-        if (bytesPerPixel === undefined) {
+        if (!Object.hasOwn(bytePerPixelMap, mode)) {
             throw new OperationError(`Unsupported Mode: (${mode})`);
         }
+
+        const bytesPerPixel = bytePerPixelMap[mode];
 
         if (bytesPerPixel > 0 && input.length % bytesPerPixel !== 0) {
             throw new OperationError(

--- a/src/core/operations/GenerateImage.mjs
+++ b/src/core/operations/GenerateImage.mjs
@@ -76,6 +76,10 @@ class GenerateImage extends Operation {
 
         const bytesPerPixel = bytePerPixelMap[mode];
 
+        if (bytesPerPixel === undefined) {
+            throw new OperationError(`Unsupported Mode: (${mode})`);
+        }
+
         if (bytesPerPixel > 0 && input.length % bytesPerPixel !== 0) {
             throw new OperationError(
                 `Number of bytes is not a divisor of ${bytesPerPixel}`,

--- a/tests/operations/tests/Image.mjs
+++ b/tests/operations/tests/Image.mjs
@@ -46,6 +46,17 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Generate Image: empty mode",
+        input: "",
+        expectedOutput: "Unsupported Mode: ()",
+        recipeConfig: [
+            {
+                op: "Generate Image",
+                args: ["", 8, 64]
+            }
+        ]
+    },
+    {
         name: "Extract EXIF: nothing",
         input: "",
         expectedOutput: "Found 0 tags.\n",


### PR DESCRIPTION
Fixes #2595.

This change validates the Generate Image mode before deriving image dimensions, so an empty or unsupported mode returns a normal `OperationError` instead of leaking an internal Jimp/Zod/RangeError.

Changes:
- validate `mode` immediately after lookup in `bytePerPixelMap`
- throw `OperationError` for unsupported/empty modes before computing `height`
- add a regression test for empty Generate Image mode

Validation:
- `env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm ci`
- `env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx grunt configTests`
- focused Image operation test: 16 total, 0 failed
- full operation tests: 2054/2054 passed
- `env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run lint`
- `git diff --check`

Notes:
- The operation test expects the normal `OperationError` message as output because CyberChef’s recipe runner converts `OperationError` into an output string in this test harness.