### PR TITLE
fix: rehydrate serialized BigNumber dishes

### DIFF
--- a/src/core/Dish.mjs
+++ b/src/core/Dish.mjs
@@ -292,7 +292,7 @@ class Dish {
                     and reinitialise it as a BigNumber object.
                 */
                 if (Object.keys(this.value).sort().equals(["c", "e", "s"])) {
-                    const temp = new BigNumber();
+                    const temp = new BigNumber(0);
                     temp.c = this.value.c;
                     temp.e = this.value.e;
                     temp.s = this.value.s;

--- a/tests/node/tests/Dish.mjs
+++ b/tests/node/tests/Dish.mjs
@@ -9,4 +9,14 @@ TestRegister.addApiTests([
         assert(dish.presentAs);
     }),
 
+    it("Dish - isValid: rehydrates serialized BigNumber values", () => {
+        const dish = new Dish({ c: [1], e: 0, s: 1 }, Dish.BIG_NUMBER);
+        assert.strictEqual(dish.value.toString(), "1");
+    }),
+
+    it("Dish - isValid: rehydrates serialized NaN BigNumber values", () => {
+        const dish = new Dish({ c: null, e: null, s: null }, Dish.BIG_NUMBER);
+        assert.strictEqual(dish.value.toString(), "NaN");
+    }),
+
 ]);


### PR DESCRIPTION
**Description**
Fixes serialized `BigNumber` dish rehydration so worker-returned `BigNumber` values are reconstructed without constructing `BigNumber` with an undefined value first.

This prevents invalid Subtract input from surfacing as a hidden console-only `[BigNumber Error]` when the `NaN` `BigNumber` result is passed back through the dish validation path.

**Existing Issue**
Fixes #2592

**Screenshots**
N/A

**AI disclosure**
This pull request was created with assistance from Hermes Agent (Nous Research).

**Test Coverage**
Added node API coverage for serialized finite and `NaN` `BigNumber` dish values.

Verified with:
- `node --input-type=module` targeted Dish regression check
- `npx eslint src/core/Dish.mjs tests/node/tests/Dish.mjs`
- `git diff --check`

Note: `npx grunt configTests && node --no-warnings --no-deprecation --openssl-legacy-provider tests/node/index.mjs` is currently blocked in this local Node 22 environment by existing ESM resolution failures in `crypto-api`/generated `src/node/index.mjs`; the package declares Node `>=24 <25`.
