### PR TITLE
Validate Wrap line width

### DIFF
--- a/src/core/operations/Wrap.mjs
+++ b/src/core/operations/Wrap.mjs
@@ -5,7 +5,6 @@
  */
 
 import Operation from "../Operation.mjs";
-import OperationError from "../errors/OperationError.mjs";
 
 const MAX_LINE_WIDTH = 65536;
 
@@ -45,16 +44,6 @@ class Wrap extends Operation {
     run(input, args) {
         if (!input) return "";  // Handle empty input
         const lineWidth = args[0];
-
-        if (!Number.isInteger(lineWidth))
-            throw new OperationError("Line Width must be an integer.");
-
-        if (lineWidth < 1)
-            throw new OperationError("Line Width must be greater than or equal to 1.");
-
-        if (lineWidth > MAX_LINE_WIDTH)
-            throw new OperationError(`Line Width must be less than or equal to ${MAX_LINE_WIDTH}.`);
-
         const regex = new RegExp(`.{1,${lineWidth}}`, "g");
         return input.match(regex).join("\n");
     }

--- a/src/core/operations/Wrap.mjs
+++ b/src/core/operations/Wrap.mjs
@@ -5,6 +5,9 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+
+const MAX_LINE_WIDTH = 65536;
 
 /**
  * Wrap operation
@@ -27,6 +30,9 @@ class Wrap extends Operation {
                 "name": "Line Width",
                 "type": "number",
                 "value": 64,
+                "min": 1,
+                "max": MAX_LINE_WIDTH,
+                "integer": true,
             },
         ];
     }
@@ -39,6 +45,16 @@ class Wrap extends Operation {
     run(input, args) {
         if (!input) return "";  // Handle empty input
         const lineWidth = args[0];
+
+        if (!Number.isInteger(lineWidth))
+            throw new OperationError("Line Width must be an integer.");
+
+        if (lineWidth < 1)
+            throw new OperationError("Line Width must be greater than or equal to 1.");
+
+        if (lineWidth > MAX_LINE_WIDTH)
+            throw new OperationError(`Line Width must be less than or equal to ${MAX_LINE_WIDTH}.`);
+
         const regex = new RegExp(`.{1,${lineWidth}}`, "g");
         return input.match(regex).join("\n");
     }

--- a/tests/operations/tests/Wrap.mjs
+++ b/tests/operations/tests/Wrap.mjs
@@ -40,5 +40,49 @@ TestRegister.addTests([
                 "args": [10]
             },
         ],
+    },
+    {
+        name: "Wrap rejects zero line width",
+        input: "hello",
+        expectedOutput: "Line Width must be greater than or equal to 1.",
+        recipeConfig: [
+            {
+                "op": "Wrap",
+                "args": [0]
+            },
+        ],
+    },
+    {
+        name: "Wrap rejects negative line width",
+        input: "hello",
+        expectedOutput: "Line Width must be greater than or equal to 1.",
+        recipeConfig: [
+            {
+                "op": "Wrap",
+                "args": [-1]
+            },
+        ],
+    },
+    {
+        name: "Wrap rejects non-integer line width",
+        input: "hello",
+        expectedOutput: "Line Width must be an integer.",
+        recipeConfig: [
+            {
+                "op": "Wrap",
+                "args": [1.1]
+            },
+        ],
+    },
+    {
+        name: "Wrap rejects excessive line width",
+        input: "hello",
+        expectedOutput: "Line Width must be less than or equal to 65536.",
+        recipeConfig: [
+            {
+                "op": "Wrap",
+                "args": [65537]
+            },
+        ],
     }
 ]);

--- a/tests/operations/tests/Wrap.mjs
+++ b/tests/operations/tests/Wrap.mjs
@@ -40,38 +40,5 @@ TestRegister.addTests([
                 "args": [10]
             },
         ],
-    },
-    {
-        name: "Wrap rejects negative line width",
-        input: "hi, how about you",
-        expectedOutput: "Line Width must be greater than or equal to 1.",
-        recipeConfig: [
-            {
-                "op": "Wrap",
-                "args": [-1]
-            },
-        ],
-    },
-    {
-        name: "Wrap rejects floating-point line width",
-        input: "hi, how about you",
-        expectedOutput: "Line Width must be an integer.",
-        recipeConfig: [
-            {
-                "op": "Wrap",
-                "args": [1.1]
-            },
-        ],
-    },
-    {
-        name: "Wrap rejects excessively large line width",
-        input: "hi, how about you",
-        expectedOutput: "Line Width must be less than or equal to 65536.",
-        recipeConfig: [
-            {
-                "op": "Wrap",
-                "args": [1.1761717177171882e+23]
-            },
-        ],
     }
 ]);

--- a/tests/operations/tests/Wrap.mjs
+++ b/tests/operations/tests/Wrap.mjs
@@ -40,5 +40,38 @@ TestRegister.addTests([
                 "args": [10]
             },
         ],
+    },
+    {
+        name: "Wrap rejects negative line width",
+        input: "hi, how about you",
+        expectedOutput: "Line Width must be greater than or equal to 1.",
+        recipeConfig: [
+            {
+                "op": "Wrap",
+                "args": [-1]
+            },
+        ],
+    },
+    {
+        name: "Wrap rejects floating-point line width",
+        input: "hi, how about you",
+        expectedOutput: "Line Width must be an integer.",
+        recipeConfig: [
+            {
+                "op": "Wrap",
+                "args": [1.1]
+            },
+        ],
+    },
+    {
+        name: "Wrap rejects excessively large line width",
+        input: "hi, how about you",
+        expectedOutput: "Line Width must be less than or equal to 65536.",
+        recipeConfig: [
+            {
+                "op": "Wrap",
+                "args": [1.1761717177171882e+23]
+            },
+        ],
     }
 ]);


### PR DESCRIPTION
Fixes #2593.

This change validates the Wrap line width before constructing the wrapping regex, so invalid widths return normal validation errors instead of leaking an internal TypeError.

Changes:
- add min/max/integer constraints for the Line Width argument
- add runtime guards in `Wrap.run()`
- add regression coverage for negative, floating-point, and excessively large line widths

Validation:
- focused Wrap operation test: 6 total, 0 failed
- full operation tests: 2057/2057 passed
- `npm run lint`
- `git diff --check`

Notes:
- Direct `Wrap.run()` error messages now match CyberChef’s generated ingredient validation messages.