### PR TITLE
Fix BigNumber deserialisation in Dish, and add tests

### DIFF
--- a/src/core/Dish.mjs
+++ b/src/core/Dish.mjs
@@ -292,11 +292,7 @@ class Dish {
                     and reinitialise it as a BigNumber object.
                 */
                 if (Object.keys(this.value).sort().equals(["c", "e", "s"])) {
-                    const temp = new BigNumber();
-                    temp.c = this.value.c;
-                    temp.e = this.value.e;
-                    temp.s = this.value.s;
-                    this.value = temp;
+                    this.value = new BigNumber({ s: this.value.s, e: this.value.e, c: this.value.c, _isBigNumber: true});
                     return true;
                 }
                 return false;

--- a/tests/browser/02_ops.js
+++ b/tests/browser/02_ops.js
@@ -346,8 +346,8 @@ module.exports = {
         // testOp(browser, "Strip HTTP headers", "test input", "test_output");
         // testOp(browser, "Subsection", "test input", "test_output");
         // testOp(browser, "Substitute", "test input", "test_output");
-        // testOp(browser, "Subtract", "test input", "test_output");
-    // testOp(browser, "Sum", "test input", "test_output");
+        testOp(browser, "Subtract", "321,123,test", "198", ["Comma"]);
+        testOp(browser, "Sum", "321,123,test", "444", ["Comma"]);
         // testOp(browser, "Swap endianness", "test input", "test_output");
         // testOp(browser, "Symmetric Difference", "test input", "test_output");
         testOpHtml(browser, "Syntax highlighter", "var a = [4,5,6]", ".hljs-selector-attr", "[4,5,6]");

--- a/tests/node/tests/Dish.mjs
+++ b/tests/node/tests/Dish.mjs
@@ -9,4 +9,23 @@ TestRegister.addApiTests([
         assert(dish.presentAs);
     }),
 
+    it("Disk - should not error on serialized BigNumber (0)", () => {
+        const dish = new Dish({ s: 1, e: 0, c: [0] }, Dish.BIG_NUMBER);
+        assert.strictEqual(dish.value.toString(), "0");
+    }),
+
+    it("Dish - should not error on serialized BigNumber (1)", () => {
+        const dish = new Dish({ c: [1], e: 0, s: 1 }, Dish.BIG_NUMBER);
+        assert.strictEqual(dish.value.toString(), "1");
+    }),
+
+    it("Dish - should not error on serialized BigNumber (-100)", () => {
+        const dish = new Dish({ s: -1, e: 2, c: [100] }, Dish.BIG_NUMBER);
+        assert.strictEqual(dish.value.toString(), "-100");
+    }),
+
+    it("Dish - should not error on serialized BigNumber (NaN)", () => {
+        const dish = new Dish({ s: null, e: null, c: null }, Dish.BIG_NUMBER);
+        assert.strictEqual(dish.value.toString(), "NaN");
+    }),
 ]);

--- a/tests/operations/tests/Arithmetic.mjs
+++ b/tests/operations/tests/Arithmetic.mjs
@@ -1,0 +1,33 @@
+/**
+ * Tests for arithmetical operations
+ *
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Subtract",
+        input: "321,123,test",
+        expectedOutput: "198",
+        recipeConfig: [
+            {
+                "op": "Subtract",
+                "args": ["Comma"]
+            },
+        ],
+    },
+    {
+        name: "Subtract - no valid input",
+        input: "test",
+        expectedOutput: "NaN",
+        recipeConfig: [
+            {
+                "op": "Subtract",
+                "args": ["Comma"]
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
**Description**
Resolves an error in Dish handling, where BigNumbers were being incorrectly deserialised 

**Existing Issue**
Fixes: #2567
Fixes: #2592

**AI disclosure**
None used

**Acknowledgements**
Inspired by #2571 (@sivachandran) and #2604 (@cyphercodes)

Built on initial insight from those PRs but with a more complete fix and additional tests.

**Test Coverage**
Tests added for the low level functionality and for the higher level Operations where the bug was detected.