### PR TITLE
Fix Generate Image validation for fractional dimensions

### DIFF
--- a/src/core/operations/GenerateImage.mjs
+++ b/src/core/operations/GenerateImage.mjs
@@ -40,11 +40,13 @@ class GenerateImage extends Operation {
                 name: "Pixel Scale Factor",
                 type: "number",
                 value: 8,
+                integer: true,
             },
             {
                 name: "Pixels per row",
                 type: "number",
                 value: 64,
+                integer: true,
             },
         ];
     }

--- a/tests/operations/tests/Image.mjs
+++ b/tests/operations/tests/Image.mjs
@@ -57,6 +57,55 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Generate Image: valid integer pixels per row",
+        input: "00010203",
+        expectedMatch: /89504e470d0a1a0a/,
+        recipeConfig: [
+            {
+                op: "From Hex",
+                args: ["None"]
+            },
+            {
+                op: "Generate Image",
+                args: ["Greyscale", 1, 2]
+            },
+            {
+                op: "To Hex",
+                args: ["None"]
+            }
+        ]
+    },
+    {
+        name: "Generate Image: pixel scale factor must be an integer",
+        input: "00010203",
+        expectedOutput: "Pixel Scale Factor must be an integer.",
+        recipeConfig: [
+            {
+                op: "From Hex",
+                args: ["None"]
+            },
+            {
+                op: "Generate Image",
+                args: ["Greyscale", 1.2, 2]
+            }
+        ]
+    },
+    {
+        name: "Generate Image: pixels per row must be an integer",
+        input: "00010203",
+        expectedOutput: "Pixels per row must be an integer.",
+        recipeConfig: [
+            {
+                op: "From Hex",
+                args: ["None"]
+            },
+            {
+                op: "Generate Image",
+                args: ["Greyscale", 1, 1024.4]
+            }
+        ]
+    },
+    {
         name: "Extract EXIF: nothing",
         input: "",
         expectedOutput: "Found 0 tags.\n",


### PR DESCRIPTION
## Summary

Fix `Generate Image` so fractional dimension arguments are rejected early with clear validation errors.

Previously, `Generate Image` accepted fractional values for `Pixel Scale Factor` and `Pixels per row`. Values such as `1.2` or `1024.4` passed the existing positive-number validation and were later used as image geometry, which could result in invalid image construction and no usable output.

## Fix

This PR marks both dimension arguments as integer-only using CyberChef's existing ingredient validation:

* `Pixel Scale Factor`
* `Pixels per row`

This avoids rounding or truncating invalid dimensions and returns clear existing-style validation errors instead, for example:

```text
Pixels per row must be an integer.
```

## Tests

Added focused regression coverage for:

* valid integer `Pixels per row` still producing PNG output
* fractional `Pixel Scale Factor` producing a clear integer validation error
* fractional `Pixels per row` producing a clear integer validation error

## Validation

Executed the relevant Image operation tests:

```text
TOTAL    19
PASSING  19
```

Also ran:

```text
git diff --check
```

## Impact

Closes #2597.

The change is limited to argument validation for `Generate Image` and does not affect valid integer input.
