### PR TITLE
fix: stop Parse QR Code from participating in Magic (#2610)

### DIFF
--- a/src/core/operations/ParseQRCode.mjs
+++ b/src/core/operations/ParseQRCode.mjs
@@ -33,15 +33,11 @@ class ParseQRCode extends Operation {
                 value: false,
             },
         ];
-        this.checks = [
-            {
-                pattern:
-                    "^(?:\\xff\\xd8\\xff|\\x89\\x50\\x4e\\x47|\\x47\\x49\\x46|.{8}\\x57\\x45\\x42\\x50|\\x42\\x4d)",
-                flags: "",
-                args: [false],
-                useful: true,
-            },
-        ];
+        // No Magic checks: detecting a QR code in arbitrary image data requires
+        // actually attempting to parse one, which is expensive and produces
+        // spurious "Could not read a QR code from the image" log messages for
+        // any image input via Magic. Users can add Parse QR Code manually when
+        // they know the image contains a QR code. See issue #2610.
     }
 
     /**

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -26,6 +26,7 @@ import "./tests/Utils.mjs";
 import "./tests/Categories.mjs";
 import "./tests/lib/BigIntUtils.mjs";
 import "./tests/lib/ChartsProtocolPrototypePollution.mjs";
+import "./tests/ParseQRCode.mjs";
 
 const testStatus = {
     allTestsPassing: true,

--- a/tests/node/tests/ParseQRCode.mjs
+++ b/tests/node/tests/ParseQRCode.mjs
@@ -1,0 +1,35 @@
+/**
+ * ParseQRCode API tests.
+ *
+ * @author Sanjays2402
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+import OperationConfig from "../../../src/core/config/OperationConfig.json" with { type: "json" };
+import it from "../assertionHandler.mjs";
+import assert from "assert";
+
+TestRegister.addApiTests([
+    /*
+     * Regression test for #2610.
+     *
+     * Parse QR Code used to declare a `checks` regex that matched any JPEG,
+     * PNG, GIF, WEBP or BMP magic bytes. Magic aggregates every operation
+     * with a `checks` property, so any image input ran through a full QR
+     * parse attempt, which in turn emitted a "Could not read a QR code from
+     * the image" warning to the browser console for every image. There is
+     * no cheap way to detect a QR code without attempting a full parse, so
+     * Parse QR Code must not participate in Magic; users can add it
+     * manually when they know an image contains a QR code.
+     */
+    it("Parse QR Code: must not participate in Magic (#2610)", () => {
+        const op = OperationConfig["Parse QR Code"];
+        assert(op, "Parse QR Code operation is missing from OperationConfig");
+        assert(
+            !op.checks || op.checks.length === 0,
+            "Parse QR Code must not declare `checks`; otherwise Magic will run a " +
+                "QR parse on every image and spam the console (see issue #2610)."
+        );
+    }),
+]);


### PR DESCRIPTION
**Description**

`Parse QR Code` declared a `checks` regex that matched any JPEG, PNG, GIF, WEBP or BMP magic bytes. `Magic._generateOpCriteria` (in `src/core/lib/Magic.mjs`) aggregates every operation that exposes a `checks` property and runs each against the input, so any image fed to Magic (which happens implicitly whenever `Magic` is in the recipe, including via the URL/QueryString demo) triggered a full QR parse. The QR decoder then logged `[BGChefWorker]:  Could not read a QR code from the image.` to the browser console for every image that didn't contain a QR code.

This PR removes the `this.checks` array from `ParseQRCode`'s constructor (leaving a comment that points at the issue). There is no cheap way to know an image contains a QR code without actually attempting to decode one, so it can't be a sensible Magic candidate. The operation itself is unchanged and every other operation is unaffected; only Magic's automatic dispatch stops attempting QR parsing. Users who know their image has a QR code can still add `Parse QR Code` to the recipe manually.

Behaviour before: loading the 1px-PNG demo URL from the issue with DevTools open prints `[BGChefWorker]:  Could not read a QR code from the image.`
Behaviour after: same URL, console is silent; Magic still recognises the input as an image and lists the usual image-render suggestions.

**Existing Issue**

Fixes #2610.

**Screenshots**

No visual changes to CyberChef. The only observable difference is the absence of a console error message; no UI is affected.

**AI disclosure**

This change was written with the assistance of Claude. I have reviewed the diff and the test, understand the root cause and the fix, and take responsibility for the submitted code.

**Test Coverage**

Adds `tests/node/tests/ParseQRCode.mjs` with an API-level regression test asserting that `OperationConfig["Parse QR Code"]` declares no `checks`. The test fails on `master` with the original `checks` regex and passes with this change (verified both directions). The full node and operations suites still pass locally (255 and 2057 tests respectively).
