### PR TITLE
Fixes #2446 hotp otpauth uri validation

### DIFF
--- a/src/core/operations/GenerateHOTP.mjs
+++ b/src/core/operations/GenerateHOTP.mjs
@@ -27,17 +27,23 @@ class GenerateHOTP extends Operation {
             {
                 "name": "Name",
                 "type": "string",
-                "value": ""
+                "value": "Account",
+                "allowEmpty": false
             },
             {
                 "name": "Code length",
                 "type": "number",
-                "value": 6
+                "value": 6,
+                "min": 6,
+                "max": 8,
+                "integer": true
             },
             {
                 "name": "Counter",
                 "type": "number",
-                "value": 0
+                "value": 0,
+                "min": 0,
+                "integer": true
             }
         ];
     }
@@ -47,7 +53,9 @@ class GenerateHOTP extends Operation {
      */
     run(input, args) {
         const secretStr = new TextDecoder("utf-8").decode(input).trim();
-        const secret = secretStr ? secretStr.toUpperCase().replace(/\s+/g, "") : "";
+        const secret = secretStr ?
+            OTPAuth.Secret.fromBase32(secretStr.toUpperCase().replace(/\s+/g, "")) :
+            new OTPAuth.Secret();
 
         const hotp = new OTPAuth.HOTP({
             issuer: "",
@@ -55,7 +63,7 @@ class GenerateHOTP extends Operation {
             algorithm: "SHA1",
             digits: args[1],
             counter: args[2],
-            secret: OTPAuth.Secret.fromBase32(secret)
+            secret
         });
 
         const uri = hotp.toString();

--- a/tests/node/tests/operations.mjs
+++ b/tests/node/tests/operations.mjs
@@ -605,8 +605,9 @@ Top Drawer`, {
 
     it("Generate HOTP", () => {
         const result = chef.generateHOTP("JBSWY3DPEHPK3PXP", {
+            name: "Account",
         });
-        const expected = `URI: otpauth://hotp/?secret=JBSWY3DPEHPK3PXP&algorithm=SHA1&digits=6&counter=0
+        const expected = `URI: otpauth://hotp/Account?secret=JBSWY3DPEHPK3PXP&algorithm=SHA1&digits=6&counter=0
 
 Password: 282760`;
         assert.strictEqual(result.toString(), expected);

--- a/tests/operations/tests/OTP.mjs
+++ b/tests/operations/tests/OTP.mjs
@@ -12,11 +12,77 @@ TestRegister.addTests([
     {
         name: "Generate HOTP",
         input: "JBSWY3DPEHPK3PXP",
-        expectedOutput: `URI: otpauth://hotp/?secret=JBSWY3DPEHPK3PXP&algorithm=SHA1&digits=6&counter=0\n\nPassword: 282760`,
+        expectedOutput: `URI: otpauth://hotp/Account?secret=JBSWY3DPEHPK3PXP&algorithm=SHA1&digits=6&counter=0\n\nPassword: 282760`,
         recipeConfig: [
             {
                 op: "Generate HOTP",
-                args: ["", 6, 0], // [Name, Code length, Counter]
+                args: ["Account", 6, 0], // [Name, Code length, Counter]
+            },
+        ],
+    },
+    {
+        name: "Generate HOTP - empty name rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Name cannot be empty.",
+        recipeConfig: [
+            {
+                op: "Generate HOTP",
+                args: ["", 6, 0],
+            },
+        ],
+    },
+    {
+        name: "Generate HOTP - code length below minimum rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Code length must be greater than or equal to 6.",
+        recipeConfig: [
+            {
+                op: "Generate HOTP",
+                args: ["Account", -6, 0],
+            },
+        ],
+    },
+    {
+        name: "Generate HOTP - code length above maximum rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Code length must be less than or equal to 8.",
+        recipeConfig: [
+            {
+                op: "Generate HOTP",
+                args: ["Account", 9, 0],
+            },
+        ],
+    },
+    {
+        name: "Generate HOTP - non-integer code length rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Code length must be an integer.",
+        recipeConfig: [
+            {
+                op: "Generate HOTP",
+                args: ["Account", 6.5, 0],
+            },
+        ],
+    },
+    {
+        name: "Generate HOTP - negative counter rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Counter must be greater than or equal to 0.",
+        recipeConfig: [
+            {
+                op: "Generate HOTP",
+                args: ["Account", 6, -1],
+            },
+        ],
+    },
+    {
+        name: "Generate HOTP - special characters in name are URI-encoded",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: `URI: otpauth://hotp/user%40example.com?secret=JBSWY3DPEHPK3PXP&algorithm=SHA1&digits=6&counter=0\n\nPassword: 282760`,
+        recipeConfig: [
+            {
+                op: "Generate HOTP",
+                args: ["user@example.com", 6, 0],
             },
         ],
     },


### PR DESCRIPTION
**Description**
The Generate HOTP operation accepts invalid argument values — negative or non-integer code lengths and counters, and an empty name — that produce malformed otpauth URIs. For example, a code length of -6 yields a floating-point password like 6.333301788086568e-8, and an empty name produces a URI with no label (otpauth://hotp/?secret=...), which violates the otp auth URI specification. Additionally, leaving the input blank was documented to generate a random secret but instead produced an empty one.

Root cause: the operation had no constraints on its numeric or string arguments, and passed a blank string directly to OTPAuth.Secret.fromBase32("") rather than new OTPAuth.Secret().

The fix adds min, max, integer, and allowEmpty constraints to the three arguments using CyberChef's built-in ingredient validation framework (introduced in #2561), and corrects the secret generation so blank input produces a cryptographically random 20-byte secret as documented. Constraints applied: Name allowEmpty: false; Code length min: 6, max: 8, integer: true (per RFC 4226 minimum of 6 digits and the otpauth URI specification's valid values of 6 or 8); Counter min: 0, integer: true.

Validation rules based on IETF scheme https://www.ietf.org/archive/id/draft-andesco-otpauth-uri-00.html and https://datatracker.ietf.org/doc/html/rfc4226 (note: while HOTP specification suggests 7+ characters for the code and 9 is accepted, otp auth requires that it is limited to 8).

**Existing Issue**
Fixes #2446 

**Screenshots**
N/A — no visual changes.

**AI disclosure**
Claude Code (claude.ai/code) was used to assist in diagnosing the root cause, implementing the fix, and generating test cases. All code has been reviewed and understood by the submitter.

**Test Coverage**
Six new test cases have been added to tests/operations/tests/OTP.mjs covering: empty name rejection, code length below minimum (−6), code length above maximum (9), non-integer code length (6.5), negative counter (−1), and URI encoding of special characters in the name (user@example.com → user%40example.com). The existing baseline test has been updated to use the new default name "Account". All 2070 operation tests pass (npm test).