### PR TITLE
Handle invalid bcrypt salt errors in Bcrypt compare

### DIFF
--- a/src/core/operations/BcryptCompare.mjs
+++ b/src/core/operations/BcryptCompare.mjs
@@ -5,6 +5,7 @@
  */
 
 import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
 import bcrypt from "bcryptjs";
 import { isWorkerEnvironment } from "../Utils.mjs";
 
@@ -43,11 +44,16 @@ class BcryptCompare extends Operation {
     async run(input, args) {
         const hash = args[0];
 
-        const match = await bcrypt.compare(input, hash, undefined, p => {
-            // Progress callback
-            if (isWorkerEnvironment())
-                self.sendStatusMessage(`Progress: ${(p * 100).toFixed(0)}%`);
-        });
+        let match;
+        try {
+            match = await bcrypt.compare(input, hash, undefined, p => {
+                // Progress callback
+                if (isWorkerEnvironment())
+                    self.sendStatusMessage(`Progress: ${(p * 100).toFixed(0)}%`);
+            });
+        } catch (err) {
+            throw new OperationError(err.toString());
+        }
 
         return match ? "Match: " + input : "No match";
 

--- a/tests/operations/tests/Hash.mjs
+++ b/tests/operations/tests/Hash.mjs
@@ -994,6 +994,17 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Bcrypt compare: invalid salt version",
+        input: "password",
+        expectedOutput: "Error: Invalid salt version: $a",
+        recipeConfig: [
+            {
+                op: "Bcrypt compare",
+                args: ["$ab$04$K.H1WlFDQ/iIo/PiprT/puwluJ5rzuSE5q8D/Fk3NuLgU2aXiGR9m"]
+            }
+        ]
+    },
+    {
         name: "Scrypt: RFC test vector 1",
         input: "",
         expectedOutput: "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906",


### PR DESCRIPTION
## Summary

Close #2535.

`Bcrypt compare` currently allows bcryptjs validation errors from malformed hashes to escape as plain JavaScript errors. For example, an invalid bcrypt salt version such as `$ab$...` is reported through CyberChef's unexpected operation error path.

This change wraps bcryptjs validation failures in `OperationError`, so malformed bcrypt hashes are displayed as expected user-facing operation errors.

## Changes

* Import `OperationError` in `BcryptCompare.mjs`.
* Wrap only the `bcrypt.compare(...)` call.
* Re-throw bcryptjs validation failures as `OperationError`.
* Add regression coverage for an invalid bcrypt salt version.

## Validation

Passed:

```text
node --no-warnings --no-deprecation --openssl-legacy-provider --trace-uncaught tests/operations/index.mjs

TOTAL   2057
PASSING 2057
```

Passed:

```text
npx grunt lint
```

Passed:

```text
git diff --check
```

The Node API suite was also run. It reported one unrelated cleanup error from `NodeDish.mjs` failing to unlink a generated `test.txt` file with `EPERM`; the intended operation tests and lint checks passed.
