### PR TITLE
fix/2444 TOTP input validation for correct otpauth uri generation

### DIFF
--- a/src/core/operations/GenerateTOTP.mjs
+++ b/src/core/operations/GenerateTOTP.mjs
@@ -26,22 +26,30 @@ class GenerateTOTP extends Operation {
             {
                 "name": "Name",
                 "type": "string",
-                "value": ""
+                "value": "Account",
+                "allowEmpty": false
             },
             {
                 "name": "Code length",
                 "type": "number",
-                "value": 6
+                "value": 6,
+                "min": 6,
+                "max": 8,
+                "integer": true
             },
             {
                 "name": "Epoch offset (T0)",
                 "type": "number",
-                "value": 0
+                "value": 0,
+                "min": 0,
+                "integer": true
             },
             {
                 "name": "Interval (T1)",
                 "type": "number",
-                "value": 30
+                "value": 30,
+                "min": 1,
+                "integer": true
             }
         ];
     }

--- a/tests/operations/tests/OTP.mjs
+++ b/tests/operations/tests/OTP.mjs
@@ -20,4 +20,81 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "Generate TOTP",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedMatch: /^URI: otpauth:\/\/totp\/Account\?secret=JBSWY3DPEHPK3PXP&algorithm=SHA1&digits=6&period=30\n\nPassword: \d{6}$/,
+        recipeConfig: [
+            {
+                op: "Generate TOTP",
+                args: ["Account", 6, 0, 30], // [Name, Code length, Epoch offset (T0), Interval (T1)]
+            },
+        ],
+    },
+    {
+        name: "Generate TOTP - empty name rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Name cannot be empty.",
+        recipeConfig: [
+            {
+                op: "Generate TOTP",
+                args: ["", 6, 0, 30],
+            },
+        ],
+    },
+    {
+        name: "Generate TOTP - code length below minimum rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Code length must be greater than or equal to 6.",
+        recipeConfig: [
+            {
+                op: "Generate TOTP",
+                args: ["Account", -6, 0, 30],
+            },
+        ],
+    },
+    {
+        name: "Generate TOTP - code length above maximum rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Code length must be less than or equal to 8.",
+        recipeConfig: [
+            {
+                op: "Generate TOTP",
+                args: ["Account", 9, 0, 30],
+            },
+        ],
+    },
+    {
+        name: "Generate TOTP - non-integer code length rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Code length must be an integer.",
+        recipeConfig: [
+            {
+                op: "Generate TOTP",
+                args: ["Account", 6.5, 0, 30],
+            },
+        ],
+    },
+    {
+        name: "Generate TOTP - negative interval rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Interval (T1) must be greater than or equal to 1.",
+        recipeConfig: [
+            {
+                op: "Generate TOTP",
+                args: ["Account", 6, 0, -1],
+            },
+        ],
+    },
+    {
+        name: "Generate TOTP - negative epoch offset rejected",
+        input: "JBSWY3DPEHPK3PXP",
+        expectedOutput: "Epoch offset (T0) must be greater than or equal to 0.",
+        recipeConfig: [
+            {
+                op: "Generate TOTP",
+                args: ["Account", 6, -1, 30],
+            },
+        ],
+    },
 ]);


### PR DESCRIPTION
**Description**
Fixes #2444 which reports that the Generate TOTP operation accepts invalid parameters — negative code lengths, zero or negative intervals, and an empty name — producing malformed otpauth URIs and nonsensical scientific-notation passwords (e.g. `1.2199775739678504e-8`).

The fix applies the same ingredient constraint pattern used for Generate HOTP (#2446), adding `min`, `max`, `integer`, and `allowEmpty` properties directly to the arg definitions so the validation framework rejects invalid values before `run()` is called.

Constraints applied:
- **Name** — `allowEmpty: false`, default changed from `""` to `"Account"`
- **Code length** — `min: 6, max: 8, integer: true` (RFC 6238 minimum of 6; otpauth URI spec valid values 6 or 8)
- **Epoch offset (T0)** — `min: 0, integer: true` (must be a non-negative whole number of seconds)
- **Interval (T1)** — `min: 1, integer: true` (must be a positive whole number of seconds; zero or negative intervals are meaningless)

### `src/core/operations/GenerateTOTP.mjs`

Each arg now carries its constraints:

```javascript
{ "name": "Name",             "type": "string", "value": "Account", "allowEmpty": false },
{ "name": "Code length",      "type": "number", "value": 6,  "min": 6, "max": 8, "integer": true },
{ "name": "Epoch offset (T0)","type": "number", "value": 0,  "min": 0,           "integer": true },
{ "name": "Interval (T1)",    "type": "number", "value": 30, "min": 1,           "integer": true },
```

**Existing Issue**
https://github.com/gchq/CyberChef/issues/2444

**Screenshots**
N/A — no visual changes.

**AI disclosure**
Claude Code was used to diagnose the root cause and generate test cases. Other code changes written by the submitter.

**Test Coverage**
Seven new test cases added to `tests/operations/tests/OTP.mjs`:

- `"Generate TOTP"` — baseline test using `expectedMatch` regex (`/^URI: otpauth:\/\/totp\/Account\?...\n\nPassword: \d{6}$/`) since the password is time-dependent
- `"Generate TOTP - empty name rejected"` → `"Name cannot be empty."`
- `"Generate TOTP - code length below minimum rejected"` → `"Code length must be greater than or equal to 6."`
- `"Generate TOTP - code length above maximum rejected"` → `"Code length must be less than or equal to 8."`
- `"Generate TOTP - non-integer code length rejected"` → `"Code length must be an integer."`
- `"Generate TOTP - negative interval rejected"` → `"Interval (T1) must be greater than or equal to 1."`
- `"Generate TOTP - negative epoch offset rejected"` → `"Epoch offset (T0) must be greater than or equal to 0."`

All 2063 operation tests pass (`npm test`).
