### PR TITLE
Validate empty Show On Map options

### DIFF
--- a/src/core/operations/ShowOnMap.mjs
+++ b/src/core/operations/ShowOnMap.mjs
@@ -36,7 +36,8 @@ class ShowOnMap extends Operation {
             {
                 name: "Input Format",
                 type: "option",
-                value: ["Auto"].concat(FORMATS)
+                value: ["Auto"].concat(FORMATS),
+                allowEmpty: false
             },
             {
                 name: "Input Delimiter",
@@ -49,7 +50,8 @@ class ShowOnMap extends Operation {
                     "Comma",
                     "Semi-colon",
                     "Colon"
-                ]
+                ],
+                allowEmpty: false
             }
         ];
     }

--- a/tests/operations/tests/ShowOnMap.mjs
+++ b/tests/operations/tests/ShowOnMap.mjs
@@ -36,4 +36,26 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "Show on map: empty input format is rejected",
+        input: "1, 24",
+        expectedOutput: "Input Format cannot be empty.",
+        recipeConfig: [
+            {
+                op: "Show on map",
+                args: [13, "", "Auto"]
+            },
+        ],
+    },
+    {
+        name: "Show on map: empty input delimiter is rejected",
+        input: "1, 24",
+        expectedOutput: "Input Delimiter cannot be empty.",
+        recipeConfig: [
+            {
+                op: "Show on map",
+                args: [13, "Auto", ""]
+            },
+        ],
+    },
 ]);


### PR DESCRIPTION
Fixes #2421.

This change rejects empty Show On Map input format and delimiter values through ingredient metadata validation, so empty options return normal validation errors instead of reaching internal coordinate parsing and leaking a TypeError.

Changes:
- add `allowEmpty: false` to `Input Format`
- add `allowEmpty: false` to `Input Delimiter`
- add regression coverage for empty input format and empty delimiter with Auto format

Validation:
- `env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm ci`
- `env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx grunt configTests`
- focused Show On Map operation test: 4/4 passed
- full operation tests: 2058/2058 passed
- `env PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run lint`
- `git diff --check`

Notes:
- Work was done in the clean checkout `/Users/kirillvetrov/Documents/New project/CyberChef-2421` because the older CyberChef checkout has a corrupted remote ref.