### PR TITLE
Feature: automatically expire PRs if CLA remains unsigned for an extended period

### DIFF
--- a/.github/workflows/cla-close-stale.yml
+++ b/.github/workflows/cla-close-stale.yml
@@ -1,0 +1,61 @@
+name: Close Stale Unsigned CLA PRs
+
+on:
+  schedule:
+    # Runs daily at 01:30 UTC.
+    - cron: '30 1 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+# Configurable intervals (days).
+#   INTERVAL_1 = grace period before the warning comment.
+#   INTERVAL_2 = further period after the warning before closing.
+env:
+  INTERVAL_1: 14
+  INTERVAL_2: 14
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale unsigned-CLA PRs
+        uses: actions/stale@v9
+        with:
+          # ---- Guards: only act on PRs carrying the CLA label ----
+          only-labels: 'awaiting cla'
+
+          # Never touch issues — PRs only.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # ---- Timing ----
+          # INTERVAL_1: days of inactivity before the warning comment.
+          days-before-pr-stale: ${{ env.INTERVAL_1 }}
+          # INTERVAL_2: days after being marked stale before closing.
+          days-before-pr-close: ${{ env.INTERVAL_2 }}
+
+          # ---- Warning comment (posted once when marked stale) ----
+          stale-pr-message: >
+            This PR will be automatically closed if the CLA is not signed
+            within ${{ env.INTERVAL_2 }} days.
+
+          # ---- Close comment ----
+          close-pr-message: >
+            This PR has been automatically closed as the CLA has not been
+            signed. We are happy to have it reopened if the CLA is signed
+            subsequently.
+
+          # A dedicated marker label so we can track stale state without
+          # interfering with the "awaiting cla" label.
+          stale-pr-label: 'cla-stale'
+
+          # If the PR is updated after being marked stale, remove the marker
+          # so the warning-then-close cycle restarts cleanly.
+          remove-pr-stale-when-updated: true
+
+          # Process enough PRs per run for busy repos.
+          operations-per-run: 200

--- a/.github/workflows/cla-close-stale.yml
+++ b/.github/workflows/cla-close-stale.yml
@@ -12,18 +12,18 @@ permissions:
   issues: write
 
 # Configurable intervals (days).
-#   INTERVAL_1 = grace period before the warning comment.
-#   INTERVAL_2 = further period after the warning before closing.
+#   DAYS_BEFORE_WARNING = grace period before the warning comment.
+#   DAYS_BEFORE_CLOSURE = further period after the warning before closing.
 env:
-  INTERVAL_1: 14
-  INTERVAL_2: 14
+  DAYS_BEFORE_WARNING: 7
+  DAYS_BEFORE_CLOSURE: 21
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
       - name: Close stale unsigned-CLA PRs
-        uses: actions/stale@v9
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 #v10.3.0
         with:
           # ---- Guards: only act on PRs carrying the CLA label ----
           only-labels: 'awaiting cla'
@@ -33,21 +33,22 @@ jobs:
           days-before-issue-close: -1
 
           # ---- Timing ----
-          # INTERVAL_1: days of inactivity before the warning comment.
-          days-before-pr-stale: ${{ env.INTERVAL_1 }}
-          # INTERVAL_2: days after being marked stale before closing.
-          days-before-pr-close: ${{ env.INTERVAL_2 }}
+          # DAYS_BEFORE_WARNING: days of inactivity before the warning comment.
+          days-before-pr-stale: ${{ env.DAYS_BEFORE_WARNING }}
+          # DAYS_BEFORE_CLOSURE: days after being marked stale before closing.
+          days-before-pr-close: ${{ env.DAYS_BEFORE_CLOSURE }}
 
           # ---- Warning comment (posted once when marked stale) ----
           stale-pr-message: >
-            This PR will be automatically closed if the CLA is not signed
-            within ${{ env.INTERVAL_2 }} days.
+            As we are unable to accept contributions unless the CLA has
+            been signed, this PR will be automatically closed if the CLA
+            is not signed within ${{ env.DAYS_BEFORE_CLOSURE }} days.
 
           # ---- Close comment ----
           close-pr-message: >
-            This PR has been automatically closed as the CLA has not been
-            signed. We are happy to have it reopened if the CLA is signed
-            subsequently.
+            This PR has been automatically closed as the CLA remains
+            unsigned. We will be happy to have it reopened if the CLA
+            is signed subsequently.
 
           # A dedicated marker label so we can track stale state without
           # interfering with the "awaiting cla" label.


### PR DESCRIPTION
**Description**
Add a workflow that runs periodically and closes PRs where the CLA remains unsigned for an extended period (28 days in total).

This workflow uses the "awaiting cla" label as set/cleared by #2627.

**Existing Issue**
Closes: #2626
See also PR #2627 

**AI disclosure**
This workflow was initially created using Clause Opus 4.8.

Subsequently checked and neatened by hand. I understand, and accept responsibility for, all the resulting code.

**Test Coverage**
Please ensure you have added test coverage for your changes.
