### PR TITLE
Add pass-through result to ROT13 Brute Force

### DIFF
--- a/AI_MARKER
+++ b/AI_MARKER
@@ -1,0 +1,1 @@
+This contribution was prepared with AI assistance from OpenCode.

--- a/src/core/operations/ROT13BruteForce.mjs
+++ b/src/core/operations/ROT13BruteForce.mjs
@@ -73,7 +73,7 @@ class ROT13BruteForce extends Operation {
         const cribLower = crib.toLowerCase();
         const lowerStart = "a".charCodeAt(0), upperStart = "A".charCodeAt(0), numStart = "0".charCodeAt(0);
         const result = [];
-        for (let amount = 1; amount < 26; amount++) {
+        for (let amount = 0; amount < 26; amount++) {
             const rotated = sample.slice();
             for (let i = 0; i < rotated.length; i++) {
                 if (rotateLower && lowerStart <= rotated[i] && rotated[i] < lowerStart + 26) {

--- a/tests/operations/tests/Rotate.mjs
+++ b/tests/operations/tests/Rotate.mjs
@@ -257,6 +257,28 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "ROT13 Brute Force: includes pass-through",
+        input: "Abc123",
+        expectedMatch: /^Amount = {2}0: Abc123\nAmount = {2}1:/,
+        recipeConfig: [
+            {
+                op: "ROT13 Brute Force",
+                args: [true, true, true, 100, 0, true, ""]
+            },
+        ],
+    },
+    {
+        name: "ROT13 Brute Force: filters a pass-through sample",
+        input: "__Ab1__",
+        expectedOutput: "Ab1",
+        recipeConfig: [
+            {
+                op: "ROT13 Brute Force",
+                args: [true, true, true, 3, 2, false, "ab1"]
+            },
+        ],
+    },
+    {
         name: "ROT47: nothing",
         input: "",
         expectedOutput: "",


### PR DESCRIPTION
**Description**

Include the unmodified input as `Amount = 0` in the ROT13 Brute Force output.

This allows the operation to be chained with other brute-force operations without discarding candidates that do not require a rotation at the current step.

The pass-through uses amount zero rather than amount 26 because rotating numbers by 26 would not be a no-op.

**Existing Issue**

Fixes #2437

**Screenshots**

Not applicable. This change does not modify the UI.

**AI disclosure**

OpenCode was used to assist with repository analysis, implementation, and test preparation. The resulting changes and test results were reviewed locally.

**Test Coverage**

Added regression tests covering:

- the `Amount = 0` pass-through result
- letter and number pass-through behavior
- sample offset and sample length handling
- crib filtering
- output with `Print amount` disabled

Validation performed with Node.js 24.18.0:

- `npm test`: 262 Node API tests and 2,243 operation tests passed
- `npm run lint`: passed with one pre-existing warning in `FromDecimal.mjs`
- `npm run node`: passed
- targeted ESLint: passed
- `git diff --check`: passed

The production Webpack build was attempted but is currently blocked on Windows by existing Jimp and BMFont loader errors unrelated to this change.
