### PR TITLE
Add HMAC regression tests for Decimal key parsing

### DIFF
--- a/tests/operations/tests/Hash.mjs
+++ b/tests/operations/tests/Hash.mjs
@@ -723,6 +723,39 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "HMAC: Decimal key space-delimited matches Latin1 key (fromDecimal Auto delimiter regression)",
+        input: "Hello, World!",
+        expectedOutput: "9b641a008211bb0464a10899d5b37a24ab08ffcf839f5e74d17d99f856530957",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Decimal", "string": "65 65"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: Latin1 key matches space-delimited Decimal key (fromDecimal Auto delimiter regression)",
+        input: "Hello, World!",
+        expectedOutput: "9b641a008211bb0464a10899d5b37a24ab08ffcf839f5e74d17d99f856530957",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Latin1", "string": "AA"}, "SHA256"]
+            }
+        ]
+    },
+    {
+        name: "HMAC: Decimal key comma-delimited matches Latin1 key (fromDecimal Auto delimiter regression)",
+        input: "Hello, World!",
+        expectedOutput: "9b641a008211bb0464a10899d5b37a24ab08ffcf839f5e74d17d99f856530957",
+        recipeConfig: [
+            {
+                "op": "HMAC",
+                "args": [{"option": "Decimal", "string": "65,65"}, "SHA256"]
+            }
+        ]
+    },
+    {
         name: "MD5: Complex bytes",
         input: "10dc10e32010de10d010dc10d810d910d010e12e",
         expectedOutput: "4f4f02e2646545aa8fc42f613c9aa068",


### PR DESCRIPTION
**Description**
Adds three HMAC regression tests covering Decimal-format key parsing with the fromDecimal "Auto" delimiter, as requested by a maintainer when closing #2650:

- HMAC: Decimal key space-delimited matches Latin1 key — verifies a key of "65 65" (Decimal) produces the correct SHA256 digest (the case that was previously broken)
- HMAC: Latin1 key matches space-delimited Decimal key — the known-good Latin1 baseline ("AA"), producing the same digest
- HMAC: Decimal key comma-delimited matches Latin1 key — verifies Auto also handles comma-separated input ("65,65")

The underlying bug was fixed by the merge of #2270, so these tests pass against current master; they guard against future regressions of the Auto-delimiter behaviour. No operational code is changed — this PR only adds tests to [Hash.mjs]

**Existing Issue**
Relates to #2139 and #2217 (both resolved by #2270). Tests originally proposed in #2650 and split out into this stand-alone PR at a maintainer's request.

**Screenshots**
N/A — no visual changes.

**AI disclosure**
GitHub Copilot (Claude) was used to isolate these tests from the original PR branch and prepare this submission. The tests have been reviewed and verified manually.

**Test Coverage**
This PR consists entirely of test coverage. Full non-UI suite passes locally: 2244/2244 operation tests and 262/262 Node API tests.