### PR TITLE
Add npm allowScripts policy for npm v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,14 @@
     "xregexp": "^5.1.2",
     "zlibjs": "^0.3.1"
   },
+  "allowScripts": {
+    "@nightwatch/nightwatch-inspector@1.0.1": true,
+    "chromedriver@150.0.3": true,
+    "core-js": false,
+    "core-js-pure": false,
+    "fsevents": false,
+    "tesseract.js": false
+  },
   "scripts": {
     "start": "npx grunt dev",
     "build": "npx grunt prod",


### PR DESCRIPTION
## Summary

Add an `allowScripts` policy to prepare the project for npm v12.

### Changes

Allowed:
- chromedriver
- @nightwatch/nightwatch-inspector

Denied:
- core-js
- core-js-pure
- tesseract.js
- fsevents

The existing Docker workflow remains unchanged, as discussed in #2639.

### Validation

- npm test ✅
- npm ci (npm 12) ✅

Close: #2639