### PR TITLE
Feat/powershell -e encode decode

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -64,6 +64,7 @@
             "Change IP format",
             "Encode text",
             "Decode text",
+            "PowerShell -e Encode/Decode",
             "Text Encoding Brute Force",
             "Swap endianness",
             "To MessagePack",

--- a/src/core/operations/PowerShellEncodeDecode.mjs
+++ b/src/core/operations/PowerShellEncodeDecode.mjs
@@ -1,0 +1,71 @@
+/**
+ * @author neoreo
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import cptable from "codepage";
+import {toBase64, fromBase64} from "../lib/Base64.mjs";
+
+// PowerShell -EncodedCommand uses UTF-16LE (code page 1200)
+const UTF16LE = 1200;
+
+/**
+ * PowerShell -e Encode/Decode operation
+ */
+class PowerShellEncodeDecode extends Operation {
+
+    /**
+     * PowerShellEncodeDecode constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "PowerShell -e Encode/Decode";
+        this.module = "Encodings";
+        this.description = [
+            "Encodes or decodes a PowerShell <code>-EncodedCommand</code> (<code>-e</code>) payload in a single operation.",
+            "<br><br>",
+            "PowerShell's <code>-EncodedCommand</code> parameter expects the command encoded as UTF-16LE and then Base64'd. ",
+            "This operation combines both steps so you don't have to chain 'Encode text' and 'To Base64' (or their decode equivalents) yourself.",
+            "<br><br>",
+            "<b>Encode:</b> <code>whoami</code> becomes <code>dwBoAG8AYQBtAGkA</code>, runnable as <code>powershell -e dwBoAG8AYQBtAGkA</code>.",
+            "<br>",
+            "<b>Decode:</b> <code>dwBoAG8AYQBtAGkA</code> becomes <code>whoami</code>."
+        ].join("\n");
+        this.infoURL = "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe#-encodedcommand-base64encodedcommand";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Mode",
+                type: "option",
+                value: ["Encode", "Decode"]
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const [mode] = args;
+
+        if (mode === "Encode") {
+            const encoded = cptable.utils.encode(UTF16LE, input);
+            return toBase64(new Uint8Array(encoded).buffer);
+        } else if (mode === "Decode") {
+            const bytes = fromBase64(input, "A-Za-z0-9+/=", "byteArray");
+            return cptable.utils.decode(UTF16LE, new Uint8Array(bytes));
+        } else {
+            throw new OperationError("Invalid mode");
+        }
+    }
+
+}
+
+export default PowerShellEncodeDecode;

--- a/src/core/operations/PowerShellEncodeDecode.mjs
+++ b/src/core/operations/PowerShellEncodeDecode.mjs
@@ -5,12 +5,11 @@
  */
 
 import Operation from "../Operation.mjs";
-import OperationError from "../errors/OperationError.mjs";
 import cptable from "codepage";
 import {toBase64, fromBase64} from "../lib/Base64.mjs";
 
 // PowerShell -EncodedCommand uses UTF-16LE (code page 1200)
-const UTF16LE = 1200;
+const UTF_16LE = 1200;
 
 /**
  * PowerShell -e Encode/Decode operation
@@ -56,14 +55,11 @@ class PowerShellEncodeDecode extends Operation {
         const [mode] = args;
 
         if (mode === "Encode") {
-            const encoded = cptable.utils.encode(UTF16LE, input);
+            const encoded = cptable.utils.encode(UTF_16LE, input);
             return toBase64(new Uint8Array(encoded).buffer);
-        } else if (mode === "Decode") {
-            const bytes = fromBase64(input, "A-Za-z0-9+/=", "byteArray");
-            return cptable.utils.decode(UTF16LE, new Uint8Array(bytes));
-        } else {
-            throw new OperationError("Invalid mode");
         }
+        const bytes = fromBase64(input, "A-Za-z0-9+/=", "byteArray");
+        return cptable.utils.decode(UTF_16LE, new Uint8Array(bytes));
     }
 
 }

--- a/tests/node/tests/nodeApi.mjs
+++ b/tests/node/tests/nodeApi.mjs
@@ -168,7 +168,7 @@ TestRegister.addApiTests([
 
     it("chef.help: returns multiple results", () => {
         const result = chef.help("base 64");
-        assert.strictEqual(result.length, 14);
+        assert.strictEqual(result.length, 15);
     }),
 
     it("chef.help: looks in description for matches too", () => {

--- a/tests/operations/tests/PowerShellEncodeDecode.mjs
+++ b/tests/operations/tests/PowerShellEncodeDecode.mjs
@@ -57,4 +57,30 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "PowerShell -e Encode/Decode: round trip with non-ASCII characters",
+        input: "Write-Host \"café ☕\"",
+        expectedOutput: "Write-Host \"café ☕\"",
+        recipeConfig: [
+            {
+                op: "PowerShell -e Encode/Decode",
+                args: ["Encode"],
+            },
+            {
+                op: "PowerShell -e Encode/Decode",
+                args: ["Decode"],
+            },
+        ],
+    },
+    {
+        name: "PowerShell -e Encode/Decode: decode ignores characters outside the Base64 alphabet",
+        input: "!!!@@@###",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                op: "PowerShell -e Encode/Decode",
+                args: ["Decode"],
+            },
+        ],
+    },
 ]);

--- a/tests/operations/tests/PowerShellEncodeDecode.mjs
+++ b/tests/operations/tests/PowerShellEncodeDecode.mjs
@@ -1,0 +1,60 @@
+/**
+ * PowerShell -e Encode/Decode tests.
+ *
+ * @author neoreo
+ *
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "PowerShell -e Encode/Decode: encode nothing",
+        input: "",
+        expectedOutput: "",
+        recipeConfig: [
+            {
+                op: "PowerShell -e Encode/Decode",
+                args: ["Encode"],
+            },
+        ],
+    },
+    {
+        name: "PowerShell -e Encode/Decode: encode whoami",
+        input: "whoami",
+        expectedOutput: "dwBoAG8AYQBtAGkA",
+        recipeConfig: [
+            {
+                op: "PowerShell -e Encode/Decode",
+                args: ["Encode"],
+            },
+        ],
+    },
+    {
+        name: "PowerShell -e Encode/Decode: decode whoami",
+        input: "dwBoAG8AYQBtAGkA",
+        expectedOutput: "whoami",
+        recipeConfig: [
+            {
+                op: "PowerShell -e Encode/Decode",
+                args: ["Decode"],
+            },
+        ],
+    },
+    {
+        name: "PowerShell -e Encode/Decode: round trip",
+        input: "Get-Process | Where-Object {$_.CPU -gt 10}",
+        expectedOutput: "Get-Process | Where-Object {$_.CPU -gt 10}",
+        recipeConfig: [
+            {
+                op: "PowerShell -e Encode/Decode",
+                args: ["Encode"],
+            },
+            {
+                op: "PowerShell -e Encode/Decode",
+                args: ["Decode"],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
**Description**

Adds a new **PowerShell -e Encode/Decode**.

 `powershell -e` parameter expects the command to be encoded as **UTF-16LE** + **Base64**. Those 2 encodings have to be chained manually which is not really fun to set back every time. So this adds encoding/decoding as a single block.

Examples :

- **Encode:** `whoami` → `dwBoAG8AYQBtAGkA`, runnable as `powershell -e dwBoAG8AYQBtAGkA`.
- **Decode:** `dwBoAG8AYQBtAGkA` → `whoami`.

**Existing Issue**

N/A

**Screenshots**

N/A

**AI disclosure**

This code was written with the assistance of **Claude Opus 4.8** (via Claude Code). I have reviewed the code, understand how it works, and take full responsibility for it.

**Test Coverage**

Test coverage is included in `tests/operations/tests/PowerShellEncodeDecode.mjs`, covering:
- encoding an empty input,
- encoding a known command (`whoami` → `dwBoAG8AYQBtAGkA`),
- decoding that same value back,
- a round-trip (encode → decode) of a more complex command containing spaces and special characters.

All operation tests pass locally (`npm test`).