### PR TITLE
fix(ToBase85): do not use the z shortcut for a partial final group

### DIFF
--- a/src/core/operations/ToBase85.mjs
+++ b/src/core/operations/ToBase85.mjs
@@ -69,7 +69,9 @@ class ToBase85 extends Operation {
             ) >>> 0;
 
             // A decoder reads 'z' as four zero bytes, so a short final group cannot use it.
-            if (encoding !== "Standard" || block > 0 || input.length < i + 4) {
+            const isPartialGroup = input.length < i + 4;
+
+            if (encoding !== "Standard" || block > 0 || isPartialGroup) {
                 let digits = [];
                 for (let j = 0; j < 5; j++) {
                     digits.push(block % 85);
@@ -78,7 +80,7 @@ class ToBase85 extends Operation {
 
                 digits = digits.reverse();
 
-                if (input.length < i + 4) {
+                if (isPartialGroup) {
                     digits.splice(input.length - (i + 4), 4);
                 }
 

--- a/src/core/operations/ToBase85.mjs
+++ b/src/core/operations/ToBase85.mjs
@@ -68,7 +68,8 @@ class ToBase85 extends Operation {
                 ((input[i + 3] || 0))
             ) >>> 0;
 
-            if (encoding !== "Standard" || block > 0) {
+            // A decoder reads 'z' as four zero bytes, so a short final group cannot use it.
+            if (encoding !== "Standard" || block > 0 || input.length < i + 4) {
                 let digits = [];
                 for (let j = 0; j < 5; j++) {
                     digits.push(block % 85);

--- a/tests/operations/tests/Base85.mjs
+++ b/tests/operations/tests/Base85.mjs
@@ -67,4 +67,31 @@ TestRegister.addTests([
                 "args": ["!-u", true, "z"] }
         ]
     },
+    {
+        name: "To Base85: partial group of zero bytes",
+        input: "\x00\x00\x00",
+        expectedOutput: "!!!!",
+        recipeConfig: [
+            { "op": "To Base85",
+                "args": ["!-u"] }
+        ]
+    },
+    {
+        name: "To Base85: full group of zero bytes followed by a partial one",
+        input: "\x00\x00\x00\x00\x00",
+        expectedOutput: "z!!",
+        recipeConfig: [
+            { "op": "To Base85",
+                "args": ["!-u"] }
+        ]
+    },
+    {
+        name: "From Base85: partial group of zero bytes",
+        input: "z!!",
+        expectedOutput: "\x00\x00\x00\x00\x00",
+        recipeConfig: [
+            { "op": "From Base85",
+                "args": ["!-u", true, "z"] }
+        ]
+    },
 ]);


### PR DESCRIPTION
**Description**
`To Base85` used the `z` shortcut for any four byte group that encoded to zero, including a short final group. A decoder reads `z` as four zero bytes, so one, two or three trailing zero bytes came back as four and CyberChef could not decode its own output.

Three trailing zero bytes encoded to `z` instead of `!!!!`. Five zero bytes encoded to `zz` instead of `z!!`.

The fix adds one condition in `src/core/operations/ToBase85.mjs` so the shortcut is only used when a full four byte group remains. Only the Standard (`!-u`) alphabet is affected, as that is the only one the shortcut applies to. Output now matches Python's `base64.a85encode` and Go's `encoding/ascii85`.

**Existing Issue**
None open for this. #1123 is on the same operation but asks a different question, about emitting `z` for a full group of four zero bytes, which master already does. This PR does not change that behaviour and does not close it.

**Screenshots**
No visual changes.

**AI disclosure**
I used Claude Code to help design the fix and run the test. It was a mix of Opus and Fable.

**Test Coverage**
Three tests added to `tests/operations/tests/Base85.mjs`. Applying only the test file to master fails the two encoding tests (`z` for `!!!!`, `zz` for `z!!`); the decoding test passes there, as `From Base85` already handled this correctly. With the fix the operation suite is 2304 passing, up from 2301 on master, and `npx grunt lint` is clean.
