### PR TITLE
fix: preserve anchor tags with pre-existing target attribute in RenderMarkdown

### DIFF
--- a/src/core/operations/RenderMarkdown.mjs
+++ b/src/core/operations/RenderMarkdown.mjs
@@ -87,7 +87,7 @@ class RenderMarkdown extends Operation {
             const token = tokens[idx];
             if (token.attrIndex("target") >= 0) {
                 // Target attribute already set, do not replace.
-                return;
+                return defaultRender(tokens, idx, options, env, self);
             }
             token.attrPush(["target", "_blank"]); // add new attribute
 

--- a/tests/node/tests/operations.mjs
+++ b/tests/node/tests/operations.mjs
@@ -36,6 +36,9 @@ import {
 import chef from "../../../src/node/index.mjs";
 import TestRegister from "../../lib/TestRegister.mjs";
 import File from "../../../src/node/File.mjs";
+import MarkdownIt from "markdown-it";
+import Token from "markdown-it/lib/token.mjs";
+import RenderMarkdown from "../../../src/core/operations/RenderMarkdown.mjs";
 
 global.File = File;
 
@@ -1201,6 +1204,18 @@ ExifImageHeight: 57`);
 
     }),
 
+    it("Render Markdown: makeLinksOpenInNewTab preserves tokens with pre-existing target", () => {
+        const op = new RenderMarkdown();
+        const md = new MarkdownIt();
+        op.makeLinksOpenInNewTab(md);
+
+        const token = new Token("link_open", "a", 1);
+        token.attrs = [["href", "https://example.com"], ["target", "_self"]];
+        const tokens = [token];
+
+        const rendered = md.renderer.rules.link_open(tokens, 0, {}, {}, md.renderer);
+        assert.strictEqual(rendered, '<a href="https://example.com" target="_self">');
+    }),
 
 ]);
 


### PR DESCRIPTION
**Description**
In `makeLinksOpenInNewTab`, the `link_open` renderer override returned `undefined` (a bare `return;`) when a link token already carried a `target` attribute, instead of falling through to `defaultRender`. Since markdown-it renders whatever the rule returns, this silently dropped the opening `<a>` tag while the link text and closing `</a>` still rendered — producing malformed HTML. This fix returns `defaultRender(tokens, idx, options, env,
self)` in that branch instead.

**Existing Issue**
Fixes gchq/CyberChef#2746 (item 2)

**Screenshots**
N/A — HTML output only, no UI change.

**AI disclosure**
I used Antigravity to help locate the bug, apply the
fix, and add a regression test. I reviewed the diff, manually verified the
before/after rendered output, and confirmed the test suite and linter pass
before submitting.

**Test Coverage**
Added a unit test in tests/node/tests/operations.mjs that constructs a link_open token with a pre-existing target attribute and asserts makeLinksOpenInNewTab's renderer rule returns the rendered anchor tag rather than undefined. This scenario isn't reachable through the operation's normal input/args surface (RenderMarkdown hardcodes html: false, so raw HTML anchors are escaped before reaching link_open), so a direct unit test on the renderer rule was used instead of a recipe-level TestRegister case. Verified the test fails with the bug reintroduced and passes with the fix, via npm test. Full suite (npm test) and linter (npm run lint) pass.