### PR TITLE
fix: support Webpack 5.110+ worker builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,7 @@
         "prompt": "^1.3.0",
         "sitemap": "^9.0.1",
         "terser": "^5.51.2",
-        "webpack": "^5.110.0",
+        "webpack": "^5.110.3",
         "webpack-bundle-analyzer": "^5.3.2",
         "webpack-dev-server": "^5.2.6",
         "webpack-node-externals": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,7 @@
         "prompt": "^1.3.0",
         "sitemap": "^9.0.1",
         "terser": "^5.51.2",
-        "webpack": "^5.109.2",
+        "webpack": "^5.110.0",
         "webpack-bundle-analyzer": "^5.3.2",
         "webpack-dev-server": "^5.2.6",
         "webpack-node-externals": "^3.0.0",
@@ -9429,30 +9429,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-scope/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -13854,16 +13830,16 @@
       }
     },
     "node_modules/minimizer-webpack-plugin": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
-      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.10.0.tgz",
+      "integrity": "sha512-2//60T4S0X1Ug/dqLDOgDaGlZsN1Lv8hf8oB0NOV/KIHSaXlPwXBBIbim79dE2Z7NEs52ES8YHoSv6Lmsk+XNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jridgewell/trace-mapping": "^0.3.31",
         "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
+        "schema-utils": "^4.3.3",
+        "terser": "^5.51.0"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -13877,6 +13853,9 @@
       },
       "peerDependenciesMeta": {
         "@minify-html/node": {
+          "optional": true
+        },
+        "@napi-rs/image": {
           "optional": true
         },
         "@swc/core": {
@@ -13903,10 +13882,19 @@
         "html-minifier-terser": {
           "optional": true
         },
+        "imagemin": {
+          "optional": true
+        },
         "lightningcss": {
           "optional": true
         },
         "postcss": {
+          "optional": true
+        },
+        "sharp": {
+          "optional": true
+        },
+        "svgo": {
           "optional": true
         },
         "uglify-js": {
@@ -18753,9 +18741,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.109.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
-      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
+      "version": "5.110.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
+      "integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18769,11 +18757,10 @@
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.24.4",
         "es-module-lexer": "^2.1.0",
-        "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "graceful-fs": "^4.2.11",
         "mime-db": "^1.54.0",
-        "minimizer-webpack-plugin": "^5.6.1",
+        "minimizer-webpack-plugin": "^5.7.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "prompt": "^1.3.0",
     "sitemap": "^9.0.1",
     "terser": "^5.51.2",
-    "webpack": "^5.110.0",
+    "webpack": "^5.110.3",
     "webpack-bundle-analyzer": "^5.3.2",
     "webpack-dev-server": "^5.2.6",
     "webpack-node-externals": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "prompt": "^1.3.0",
     "sitemap": "^9.0.1",
     "terser": "^5.51.2",
-    "webpack": "^5.109.2",
+    "webpack": "^5.110.0",
     "webpack-bundle-analyzer": "^5.3.2",
     "webpack-dev-server": "^5.2.6",
     "webpack-node-externals": "^3.0.0",

--- a/src/web/workers/InputWorker.mjs
+++ b/src/web/workers/InputWorker.mjs
@@ -11,6 +11,8 @@
 import Utils from "../../core/Utils.mjs";
 import loglevelMessagePrefix from "loglevel-message-prefix";
 
+const workerScope = self;
+
 loglevelMessagePrefix(log, {
     prefixes: [],
     staticPrefixes: ["InputWorker"]
@@ -525,7 +527,7 @@ self.updateInputValue = function(inputData) {
     if (!("stringSample" in inputData)) {
         inputData.stringSample = Utils.arrayBufferToStr(inputData.buffer.slice(0, 4096));
     }
-    self.inputs[inputNum].stringSample = inputData.stringSample;
+    workerScope.inputs[inputNum].stringSample = inputData.stringSample;
     self.inputs[inputNum].status = "loaded";
     self.inputs[inputNum].progress = 100;
 };
@@ -780,7 +782,7 @@ self.addInput = function(
             log.error(`Invalid input type '${type}'.`);
             return -1;
     }
-    self.inputs[inputNum] = newInputObj;
+    workerScope.inputs[inputNum] = newInputObj;
 
     // Tell the inputWaiter we've added an input, so it can create a tab to display it
     self.postMessage({

--- a/src/web/workers/ZipWorker.mjs
+++ b/src/web/workers/ZipWorker.mjs
@@ -18,6 +18,7 @@ loglevelMessagePrefix(log, {
 });
 
 const Zlib = zip.Zlib;
+const workerScope = self;
 
 /**
  * Respond to message from parent thread.
@@ -49,7 +50,7 @@ self.setOption = function(...args) {};
  * @param {string} filename
  * @param {string} fileExtension
  */
-self.zipFiles = async function(outputs, filename, fileExtension) {
+workerScope.zipFiles = async function(outputs, filename, fileExtension) {
     const zip = new Zlib.Zip();
     const inputNums = Object.keys(outputs);
 


### PR DESCRIPTION
**Description**
Fixes production builds with Webpack 5.110.0 and later by avoiding Babel's rewrite of worker-global `self` assignment targets in `InputWorker` and `ZipWorker`. The patch uses stable local worker-scope references for the affected assignments and updates the Webpack dependency to `^5.110.0`.

**Existing Issue**
Fixes #2778

**Screenshots**
N/A

**Test Coverage**
- `npm run lint`
- `npm test` - 279 Node API tests and 2,308 operation tests passed
- `npm run testnodeconsumer`
- `npm run build` on Node 26 with Webpack 5.110.3
- `npx grunt webpack:web` on Node 24 with Webpack 5.110.3
- Clean `npm ci` followed by a production Webpack build on Webpack 5.110.3
