### PR TITLE
feat: add Manchester encode and decode operations

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -18,6 +18,8 @@
             "From Float",
             "To Binary",
             "From Binary",
+            "Manchester Encode",
+            "Manchester Decode",
             "To Octal",
             "From Octal",
             "To Base32",

--- a/src/core/lib/Manchester.mjs
+++ b/src/core/lib/Manchester.mjs
@@ -1,0 +1,3 @@
+export const MANCHESTER_IEEE_802_3 = "IEEE 802.3 (0 = 10, 1 = 01)";
+export const MANCHESTER_G_E_THOMAS = "G. E. Thomas (0 = 01, 1 = 10)";
+export const MANCHESTER_CONVENTIONS = [MANCHESTER_IEEE_802_3, MANCHESTER_G_E_THOMAS];

--- a/src/core/operations/ManchesterDecode.mjs
+++ b/src/core/operations/ManchesterDecode.mjs
@@ -1,0 +1,65 @@
+/**
+ * @author JasonYuan869 [github.com/JasonYuan869]
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import { MANCHESTER_IEEE_802_3, MANCHESTER_CONVENTIONS } from "../lib/Manchester.mjs";
+
+/**
+ * Manchester Decode operation
+ */
+class ManchesterDecode extends Operation {
+
+    /**
+     * ManchesterDecode constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Manchester Decode";
+        this.module = "Default";
+        this.description = "Decodes Manchester line coding into a string of binary digits.<br><br>Input must contain only 0, 1 and whitespace. Whitespace is ignored before pairing signal levels from the start of the input. Incomplete pairs and pairs without a transition (00 or 11) cause an error. Output is a bit string, with no byte padding; use From Binary afterwards to convert complete bytes to text.<br><br>Select the same convention used to encode the signal.";
+        this.infoURL = "https://wikipedia.org/wiki/Manchester_code";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Convention",
+                type: "option",
+                value: MANCHESTER_CONVENTIONS
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        input = input.replace(/\s/g, "");
+        if (/[^01]/.test(input)) {
+            throw new OperationError("Input must contain only binary digits (0 and 1) and whitespace.");
+        }
+
+        if (input.length % 2 !== 0) {
+            throw new OperationError("Manchester input must contain an even number of signal levels.");
+        }
+
+        const zero = args[0] === MANCHESTER_IEEE_802_3 ? "10" : "01";
+        let output = "";
+        for (let i = 0; i < input.length; i += 2) {
+            const pair = input.slice(i, i + 2);
+            if (pair[0] === pair[1]) {
+                throw new OperationError(`Invalid Manchester pair '${pair}' at bit offset ${i} (whitespace excluded).`);
+            }
+            output += pair === zero ? "0" : "1";
+        }
+        return output;
+    }
+}
+
+export default ManchesterDecode;

--- a/src/core/operations/ManchesterEncode.mjs
+++ b/src/core/operations/ManchesterEncode.mjs
@@ -1,0 +1,53 @@
+/**
+ * @author JasonYuan869 [github.com/JasonYuan869]
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import { MANCHESTER_IEEE_802_3, MANCHESTER_CONVENTIONS } from "../lib/Manchester.mjs";
+
+/**
+ * Manchester Encode operation
+ */
+class ManchesterEncode extends Operation {
+
+    /**
+     * ManchesterEncode constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Manchester Encode";
+        this.module = "Default";
+        this.description = "Encodes a string of binary digits using Manchester line coding, representing each bit with a transition between two signal levels.<br><br>Input must contain only 0, 1 and whitespace. Whitespace is ignored. Output contains two signal levels per input bit, with no separators. Use To Binary first to encode text or bytes.<br><br>Select the convention to choose the mapping of bits to signal levels.";
+        this.infoURL = "https://wikipedia.org/wiki/Manchester_code";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Convention",
+                type: "option",
+                value: MANCHESTER_CONVENTIONS
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        input = input.replace(/\s/g, "");
+        if (/[^01]/.test(input)) {
+            throw new OperationError("Input must contain only binary digits (0 and 1) and whitespace.");
+        }
+
+        const zero = args[0] === MANCHESTER_IEEE_802_3 ? "10" : "01";
+        return input.replace(/[01]/g, bit => bit === "0" ? zero : zero[1] + zero[0]);
+    }
+}
+
+export default ManchesterEncode;

--- a/tests/operations/tests/ManchesterDecode.mjs
+++ b/tests/operations/tests/ManchesterDecode.mjs
@@ -1,0 +1,367 @@
+/**
+ * @author JasonYuan869 [github.com/JasonYuan869]
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        "name": "Manchester Decode: empty input",
+        "input": "",
+        "expectedOutput": "",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: whitespace only",
+        "input": " \t\r\n ",
+        "expectedOutput": "",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: IEEE convention",
+        "input": "1001011001",
+        "expectedOutput": "01101",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: single zero",
+        "input": "10",
+        "expectedOutput": "0",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: single one",
+        "input": "01",
+        "expectedOutput": "1",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: leading zeroes and non-byte-aligned output",
+        "input": "1010101001",
+        "expectedOutput": "00001",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: whitespace within pairs",
+        "input": "1 0\t0 1\r\n01 10 01",
+        "expectedOutput": "01101",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: repeated bits",
+        "input": "101010010101",
+        "expectedOutput": "000111",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: Thomas convention",
+        "input": "0110100110",
+        "expectedOutput": "01101",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: Thomas zero",
+        "input": "01",
+        "expectedOutput": "0",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: Thomas one",
+        "input": "10",
+        "expectedOutput": "1",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: reject 00 (IEEE 802.3 (0 = 10, 1 = 01))",
+        "input": "01 00",
+        "expectedOutput": "Invalid Manchester pair '00' at bit offset 2 (whitespace excluded).",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: reject 11 (IEEE 802.3 (0 = 10, 1 = 01))",
+        "input": "01 11",
+        "expectedOutput": "Invalid Manchester pair '11' at bit offset 2 (whitespace excluded).",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: odd length (IEEE 802.3 (0 = 10, 1 = 01))",
+        "input": "01 1",
+        "expectedOutput": "Manchester input must contain an even number of signal levels.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: reject 00 (G. E. Thomas (0 = 01, 1 = 10))",
+        "input": "01 00",
+        "expectedOutput": "Invalid Manchester pair '00' at bit offset 2 (whitespace excluded).",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: reject 11 (G. E. Thomas (0 = 01, 1 = 10))",
+        "input": "01 11",
+        "expectedOutput": "Invalid Manchester pair '11' at bit offset 2 (whitespace excluded).",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: odd length (G. E. Thomas (0 = 01, 1 = 10))",
+        "input": "01 1",
+        "expectedOutput": "Manchester input must contain an even number of signal levels.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: single signal level",
+        "input": "0",
+        "expectedOutput": "Manchester input must contain an even number of signal levels.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: round trip (IEEE 802.3 (0 = 10, 1 = 01))",
+        "input": "00010111001",
+        "expectedOutput": "00010111001",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            },
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: round trip (G. E. Thomas (0 = 01, 1 = 10))",
+        "input": "00010111001",
+        "expectedOutput": "00010111001",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            },
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: reject non-binary input 012",
+        "input": "012",
+        "expectedOutput": "Input must contain only binary digits (0 and 1) and whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: reject non-binary input 0x01",
+        "input": "0x01",
+        "expectedOutput": "Input must contain only binary digits (0 and 1) and whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: reject non-binary input 01,10",
+        "input": "01,10",
+        "expectedOutput": "Input must contain only binary digits (0 and 1) and whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: reject non-binary input hello",
+        "input": "hello",
+        "expectedOutput": "Input must contain only binary digits (0 and 1) and whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Decode: text round trip through binary operations",
+        "input": "Hello, 世界!\u0000",
+        "expectedOutput": "Hello, 世界!\u0000",
+        "recipeConfig": [
+            {
+                "op": "To Binary",
+                "args": [
+                    "Space",
+                    8
+                ]
+            },
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            },
+            {
+                "op": "Manchester Decode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            },
+            {
+                "op": "From Binary",
+                "args": [
+                    "None",
+                    8
+                ]
+            }
+        ]
+    }
+]);

--- a/tests/operations/tests/ManchesterEncode.mjs
+++ b/tests/operations/tests/ManchesterEncode.mjs
@@ -1,0 +1,205 @@
+/**
+ * @author JasonYuan869 [github.com/JasonYuan869]
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        "name": "Manchester Encode: empty input",
+        "input": "",
+        "expectedOutput": "",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: whitespace only",
+        "input": " \t\r\n ",
+        "expectedOutput": "",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: IEEE convention",
+        "input": "01101",
+        "expectedOutput": "1001011001",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: single zero",
+        "input": "0",
+        "expectedOutput": "10",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: single one",
+        "input": "1",
+        "expectedOutput": "01",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: leading zeroes and non-byte-aligned input",
+        "input": "00001",
+        "expectedOutput": "1010101001",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: whitespace",
+        "input": "0 1\t1\r\n0 1",
+        "expectedOutput": "1001011001",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: repeated bits",
+        "input": "000111",
+        "expectedOutput": "101010010101",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: Thomas convention",
+        "input": "01101",
+        "expectedOutput": "0110100110",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: Thomas zero",
+        "input": "0",
+        "expectedOutput": "01",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: Thomas one",
+        "input": "1",
+        "expectedOutput": "10",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "G. E. Thomas (0 = 01, 1 = 10)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: reject non-binary input 012",
+        "input": "012",
+        "expectedOutput": "Input must contain only binary digits (0 and 1) and whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: reject non-binary input 0x01",
+        "input": "0x01",
+        "expectedOutput": "Input must contain only binary digits (0 and 1) and whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: reject non-binary input 01,10",
+        "input": "01,10",
+        "expectedOutput": "Input must contain only binary digits (0 and 1) and whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Manchester Encode: reject non-binary input hello",
+        "input": "hello",
+        "expectedOutput": "Input must contain only binary digits (0 and 1) and whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Manchester Encode",
+                "args": [
+                    "IEEE 802.3 (0 = 10, 1 = 01)"
+                ]
+            }
+        ]
+    }
+]);


### PR DESCRIPTION
**Description**

https://en.wikipedia.org/wiki/Manchester_code

Support IEEE 802.3 and G. E. Thomas conventions for bit strings, ignore whitespace, and report malformed input with OperationError. Register both operations under Data format and add 40 recipe tests.

**Existing Issue**
Addresses #1104 (no activity since May).

**AI disclosure**
Code and test cases by OpenAI Codex. Human code review + manual QA in local.

**Test Coverage**
- Empty and whitespace-only input
- IEEE and G.E. Thomas encoding/decoding with individual bits, leading zeroes, non-byte-aligned data, whitespace, and repeated bits
- Invalid characters
- Invalid Manchester pairs (`00`/`11`) and odd length strings
- Various encode/decode round trips

