### PR TITLE
feat: add expected algorithm to JWT Verify

### DIFF
--- a/src/core/operations/JWTVerify.mjs
+++ b/src/core/operations/JWTVerify.mjs
@@ -32,6 +32,11 @@ class JWTVerify extends Operation {
                 type: "text",
                 value: "secret"
             },
+            {
+                name: "Expected signing algorithm",
+                type: "option",
+                value: ["Auto", ...JWT_ALGORITHMS]
+            },
         ];
     }
 
@@ -41,9 +46,11 @@ class JWTVerify extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        const [key] = args;
-        const algos = JWT_ALGORITHMS;
-        algos[algos.indexOf("None")] = "none";
+        const [key, algorithm="Auto"] = args;
+        const expectedAlgorithm = algorithm || "Auto";
+        const algos = expectedAlgorithm === "Auto" ?
+            JWT_ALGORITHMS.map(algo => algo === "None" ? "none" : algo) :
+            [expectedAlgorithm === "None" ? "none" : expectedAlgorithm];
 
         try {
             const verified = jwt.verify(input, key, { algorithms: algos });

--- a/tests/operations/tests/JWTVerify.mjs
+++ b/tests/operations/tests/JWTVerify.mjs
@@ -74,6 +74,17 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "JWT Verify: rejects unexpected algorithm",
+        input: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJTdHJpbmciOiJTb21lU3RyaW5nIiwiTnVtYmVyIjo0MiwiaWF0IjoxfQ.0ha6-j4FwvEIKPVZ-hf3S_R9Hy_UtXzq4dnedXcUrXk",
+        expectedOutput: "JsonWebTokenError: invalid algorithm",
+        recipeConfig: [
+            {
+                op: "JWT Verify",
+                args: [hsKey, "RS256"],
+            }
+        ],
+    },
+    {
         name: "JWT Verify: ES",
         input: "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJTdHJpbmciOiJTb21lU3RyaW5nIiwiTnVtYmVyIjo0MiwiaWF0IjoxfQ.WkECT51jSfpRkcpQ4x0h5Dwe7CFBI6u6Et2gWp91HC7mpN_qCFadRpsvJLtKubm6cJTLa68xtei0YrDD8fxIUA",
         expectedOutput: outputObject,


### PR DESCRIPTION
**Description**
Adds an "Expected signing algorithm" option to JWT Verify. `Auto` preserves existing recipe behaviour, while selecting a specific algorithm restricts verification to that algorithm and rejects tokens whose header specifies a different one. The change also avoids mutating the shared JWT algorithm list.

**Existing Issue**
Fixes #624

**Screenshots**
N/A

**Test Coverage**
- Regression test added for rejecting an HS256 token when RS256 is expected
- `npm run lint`
- `npm test`: 279 Node API tests and 2,309 operation tests passed
- `npm run testnodeconsumer`
- `npm run build` on Node 26 with Webpack 5.109.2
- `git diff --check`
