### PR TITLE
fix: render Rison Decode option correctly

### DIFF
--- a/src/core/operations/RisonDecode.mjs
+++ b/src/core/operations/RisonDecode.mjs
@@ -28,7 +28,7 @@ class RisonDecode extends Operation {
         this.args = [
             {
                 name: "Decode Option",
-                type: "editableOption",
+                type: "option",
                 value: ["Decode", "Decode Object", "Decode Array"]
             },
         ];

--- a/tests/node/tests/operations.mjs
+++ b/tests/node/tests/operations.mjs
@@ -39,6 +39,7 @@ import File from "../../../src/node/File.mjs";
 import MarkdownIt from "markdown-it";
 import Token from "markdown-it/lib/token.mjs";
 import RenderMarkdown from "../../../src/core/operations/RenderMarkdown.mjs";
+import RisonDecode from "../../../src/core/operations/RisonDecode.mjs";
 
 global.File = File;
 
@@ -1202,6 +1203,11 @@ ExifImageHeight: 57`);
             });
         });
 
+    }),
+
+    it("Rison Decode: decode option uses a standard option ingredient", () => {
+        const op = new RisonDecode();
+        assert.strictEqual(op.args[0].type, "option");
     }),
 
     it("Render Markdown: makeLinksOpenInNewTab preserves tokens with pre-existing target", () => {


### PR DESCRIPTION
**Description**
Fixes the Rison Decode "Decode Option" control by using a standard `option` ingredient. `editableOption` expects `{name, value}` objects, while Rison Decode supplies plain strings, which causes the dropdown entries to render as `undefined`.

Adds a regression that checks the operation exposes the correct ingredient type.

**Existing Issue**
Fixes #1827

**Screenshots**
N/A

**Test Coverage**
- Regression fails on current `master` with `editableOption` and passes after the fix
- `npm run lint`
- `npm test` — 280 Node API tests and 2,308 operation tests passed
- `npm run testnodeconsumer`
- `npm run build`
- `git diff --check`
