### PR TITLE
test: recognise handled operation errors

### DIFF
--- a/tests/lib/TestRegister.mjs
+++ b/tests/lib/TestRegister.mjs
@@ -84,9 +84,12 @@ class TestRegister {
                 duration: result.duration
             };
 
-            if (result.error) {
-                if (test.expectedError) {
-                    if (result.error.displayStr === test.expectedOutput) {
+            const stoppedOnHandledError = !result.error && result.progress < test.recipeConfig.length;
+
+            if (test.expectedError) {
+                if (result.error || stoppedOnHandledError) {
+                    const actualError = result.error ? result.error.displayStr : result.result;
+                    if (test.expectedOutput === undefined || actualError === test.expectedOutput) {
                         ret.status = "passing";
                     } else {
                         ret.status = "failing";
@@ -94,18 +97,18 @@ class TestRegister {
                             "Expected",
                             "\t" + test.expectedOutput.replace(/\n/g, "\n\t"),
                             "Received",
-                            "\t" + result.error.displayStr.replace(/\n/g, "\n\t"),
+                            "\t" + actualError.replace(/\n/g, "\n\t"),
                         ].join("\n");
                     }
                 } else {
-                    ret.status = "erroring";
-                    ret.output = result.error.displayStr;
-                }
-            } else {
-                if (test.expectedError) {
                     ret.status = "failing";
                     ret.output = "Expected an error but did not receive one.";
-                } else if (result.result === test.expectedOutput) {
+                }
+            } else if (result.error) {
+                ret.status = "erroring";
+                ret.output = result.error.displayStr;
+            } else {
+                if (result.result === test.expectedOutput) {
                     ret.status = "passing";
                 } else if ("expectedMatch" in test && test.expectedMatch.test(result.result)) {
                     ret.status = "passing";

--- a/tests/operations/tests/GenerateLoremIpsum.mjs
+++ b/tests/operations/tests/GenerateLoremIpsum.mjs
@@ -9,6 +9,17 @@ import TestRegister from "../../lib/TestRegister.mjs";
 
 TestRegister.addTests([
     {
+        name: "Generate Lorem Ipsum: expected OperationError",
+        input: "",
+        expectedError: true,
+        recipeConfig: [
+            {
+                "op": "Generate Lorem Ipsum",
+                "args": [0, "Words"]
+            },
+        ],
+    },
+    {
         name: "Generate Lorem Ipsum: Exceeds Word Limit",
         input: "",
         expectedOutput: "Length must be less than 100000",


### PR DESCRIPTION
**Description**
Updates the operation test harness so `expectedError: true` recognises handled operation errors as failures of the recipe, rather than requiring a raw thrown exception.

CyberChef intentionally converts `OperationError` into normal recipe output and stops the recipe early. The test harness now recognises that existing handled-error signal while still checking `expectedOutput` when an exact error message is supplied.

Adds a regression using a current `OperationError` path.

**Existing Issue**
Fixes #2227

**Screenshots**
N/A

**Test Coverage**
- Regression fails on current `master` with "Expected an error but did not receive one" and passes after the fix
- `npm run lint`
- `npm test` — 279 Node API tests and 2,309 operation tests passed
- `npm run testnodeconsumer`
- `npm run build`
- `git diff --check`
