### PR TITLE
fix: prevent LM Hash crash on inputs that expand when uppercased (#1807)

### DIFF
--- a/src/core/operations/LMHash.mjs
+++ b/src/core/operations/LMHash.mjs
@@ -8,6 +8,12 @@ import Operation from "../Operation.mjs";
 import {smbhash} from "ntlm";
 
 /**
+ * The LAN Manager hashing algorithm only uses the first 14 characters of the
+ * uppercased password.
+ */
+const LM_HASH_MAX_LENGTH = 14;
+
+/**
  * LM Hash operation
  */
 class LMHash extends Operation {
@@ -33,7 +39,14 @@ class LMHash extends Operation {
      * @returns {string}
      */
     run(input, args) {
-        return smbhash.lmhash(input);
+        // Uppercase *before* truncating to 14 characters. Some characters
+        // expand when uppercased (e.g. "ß" -> "SS"), and the underlying ntlm
+        // library truncates first and then uppercases into a fixed 14-byte
+        // buffer, overflowing it and throwing a RangeError for such inputs
+        // (#1807). Normalising here preserves the library's 14-byte invariant
+        // and leaves every ASCII input's hash unchanged.
+        const password = input.toUpperCase().slice(0, LM_HASH_MAX_LENGTH);
+        return smbhash.lmhash(password);
     }
 
 }

--- a/tests/operations/tests/NTLM.mjs
+++ b/tests/operations/tests/NTLM.mjs
@@ -30,5 +30,23 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        // #1807: bytes that expand when uppercased (e.g. 0xDF -> "SS") used to
+        // overflow the library's fixed 14-byte buffer and throw a RangeError,
+        // which also broke the "Generate all hashes" operation.
+        name: "LM Hash: input with characters that expand when uppercased",
+        input: "cf df 26 2e 2d 2b 2c 30 21 25 21 53 28 2a",
+        expectedOutput: "98C1A4EB163B98D8DB93DECF17002EEE",
+        recipeConfig: [
+            {
+                op: "From Hex",
+                args: ["Auto"],
+            },
+            {
+                op: "LM Hash",
+                args: [],
+            },
+        ],
+    },
 
 ]);


### PR DESCRIPTION
**Description**

The "LM Hash" operation (and therefore "Generate all hashes", which aggregates every hash) throws an uncaught `RangeError` for certain inputs:

```
LM Hash - The value of "length" is out of range. It must be >= 0 && <= 14. Received 15
```

Root cause: `LMHash` delegates to `smbhash.lmhash` from the `ntlm` package, whose `lmhashbuf` does `inputstr.substring(0, 14).toUpperCase()` and writes the result into a fixed 14‑byte `Buffer`. It truncates to 14 characters **and only then** uppercases. Some characters expand when uppercased (e.g. `0xDF` "ß" → "SS"), so a 14‑character input can become 15 characters and overflow the 14‑byte buffer.

The fix uppercases **before** truncating to 14 characters, so the library's 14‑byte invariant always holds. This is done in CyberChef's operation because the overflow lives in the third‑party `ntlm` dependency. Every ASCII input (including the existing test vectors) hashes identically to before.

**Existing Issue**

Fixes #1807

**Screenshots**

N/A — no visual change (fixes a crash in a Crypto operation and its output).

**AI disclosure**

This change was written with assistance from an AI tool (Claude, by Anthropic). I have reviewed the code, understand it, and take responsibility for it.

**Test Coverage**

Added a test in `tests/operations/tests/NTLM.mjs` using one of the reporter‑confirmed inputs (`From Hex(Auto)` `cf df 26 2e 2d 2b 2c 30 21 25 21 53 28 2a` → `LM Hash`).

RED → GREEN (operation test suite):

- On unmodified `master` (only the new test added), the new test errors with the exact issue symptom:
  ```
  PASSING	2308
  ERRORING	1
  🔥  LM Hash: input with characters that expand when uppercased
  	LM Hash - The value of "length" is out of range. It must be >= 0 && <= 14. Received 15
  ```
- With the fix applied:
  ```
  PASSING	2309
  ```

No regressions: the existing `LM Hash` / `Generate all hashes` vectors are unchanged. `npx grunt lint`, `npm test` and `npm run testnodeconsumer` all pass on Node 24.
