### PR TITLE
Fix flaky autobake UI test

### DIFF
--- a/tests/browser/01_io.js
+++ b/tests/browser/01_io.js
@@ -178,19 +178,21 @@ module.exports = {
         browser.click("#auto-bake-label");
         browser.expect.element("#auto-bake").to.be.selected.before(1000);
 
-        // Add content to the input
+        // Add content to the input and wait until a bake is actually running.
+        // The output loader is deliberately delayed and is not a reliable synchronisation point.
         browser.pause(100);
         browser.sendKeys("#input-text .cm-content", "1");
-        browser.waitForElementVisible("#output-loader");
+        browser.expect.element("#bake span").text.to.equal("CANCEL").before(1000);
         browser.pause(500);
 
         // Make another change while the previous input is being baked
+        browser.sendKeys("#input-text .cm-content", "2");
+
+        // Ensure the restarted autobake completes with the latest input
+        browser.expect.element("#output-text .cm-content").text.to.equal("input12").before(10000);
         browser
-            .sendKeys("#input-text .cm-content", "2")
             .waitForElementNotVisible("#stale-indicator")
             .waitForElementNotVisible("#output-loader");
-
-        // Ensure we got the latest input baked
         utils.expectOutput(browser, "input12");
 
         // Turn autobake off again


### PR DESCRIPTION
Fixes #2774.

The `Autobaking the latest input` browser test used `#output-loader` as a synchronisation point. That loader is intentionally delayed before it becomes visible, so the test can miss the transient state even though the bake is running normally.

This changes the test to wait for stable, user-visible behaviour instead:

- wait for the Bake control to enter `CANCEL`, confirming a bake is active
- make the second edit while that bake is running
- wait for the output editor to reach `input12`, confirming the restarted autobake processed the newest input

The existing stale/output-loader completion checks and final output assertion are retained.

Validation on Node 26.8.1 / Chrome 152:

- affected test passed 5/5 repeated runs against the current official build
- affected test passed against a fresh production build from this branch
- full `npm run build` completed successfully, including ESLint and Webpack
- `npx eslint tests/browser/01_io.js`
- `git diff --check`
