### PR TITLE
Avoid stale app bundles after updating CyberChef

### DIFF
--- a/AI_MARKER
+++ b/AI_MARKER
@@ -1,0 +1,1 @@
+AI-assisted contribution prepared for human review and submission.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,7 +137,7 @@ module.exports = function (grunt) {
                 output: {
                     path: __dirname + "/build/prod",
                     filename: chunkData => {
-                        return chunkData.chunk.name === "main" ? "assets/[name].js" : "[name].js";
+                        return chunkData.chunk.name === "main" ? "assets/[name].[contenthash].js" : "[name].js";
                     },
                     globalObject: "this"
                 },

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "build": "npx grunt prod",
     "node": "npx grunt node",
     "repl": "node --no-warnings src/node/repl.mjs",
-    "test": "npx grunt configTests && node --no-warnings --no-deprecation --openssl-legacy-provider tests/node/index.mjs && node --no-warnings --no-deprecation --openssl-legacy-provider --trace-uncaught tests/operations/index.mjs",
+    "test": "npx grunt configTests && node --test tests/build-config/*.mjs && node --no-warnings --no-deprecation --openssl-legacy-provider tests/node/index.mjs && node --no-warnings --no-deprecation --openssl-legacy-provider --trace-uncaught tests/operations/index.mjs",
     "testnodeconsumer": "npx grunt testnodeconsumer",
     "testui": "npx grunt testui",
     "testuidev": "npx nightwatch --env=dev",

--- a/tests/build-config/BuildCache.mjs
+++ b/tests/build-config/BuildCache.mjs
@@ -1,0 +1,65 @@
+/**
+ * Regression coverage for production bundle cache invalidation.
+ *
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { runInNewContext } from "node:vm";
+
+const require = createRequire(import.meta.url);
+const grunt = require("grunt");
+const webpack = require("webpack");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+require("../../Gruntfile.js")(grunt);
+const productionFilename = grunt.config.get("webpack.web.output.filename");
+const compile = promisify(webpack);
+
+test("production HTML invalidates cached JavaScript when the build time changes", async t => {
+    const directory = await mkdtemp(path.join(tmpdir(), "cyberchef-build-cache-"));
+    t.after(() => rm(directory, { recursive: true, force: true }));
+    const entry = path.join(directory, "entry.js");
+    await writeFile(entry, "globalThis.compileTime = COMPILE_TIME;\n");
+    const scriptUrls = [];
+    const buildTimes = ["09/09/2024 12:00:00 UTC", "09/09/2026 12:00:00 UTC", "09/09/2026 12:00:00 UTC"];
+
+    for (const [index, compileTime] of buildTimes.entries()) {
+        const outputPath = path.join(directory, String(index));
+        const stats = await compile({
+            mode: "production",
+            target: "web",
+            entry: { main: entry, ChefWorker: entry, "modules/Default": entry },
+            output: { path: outputPath, filename: productionFilename, publicPath: "" },
+            plugins: [
+                new webpack.DefinePlugin({ COMPILE_TIME: JSON.stringify(compileTime) }),
+                new HtmlWebpackPlugin({
+                    chunks: ["main"],
+                    templateContent: `<html><body>Compile time: ${compileTime}</body></html>`
+                })
+            ]
+        });
+        assert.equal(stats.hasErrors(), false, stats.toString({ all: false, errors: true }));
+        const html = await readFile(path.join(outputPath, "index.html"), "utf8");
+        const scriptUrl = stats.toJson({ all: false, entrypoints: true })
+            .entrypoints.main.assets.find(asset => asset.name.endsWith(".js")).name;
+        assert.ok(html.includes(scriptUrl), "HTML must reference the emitted app bundle");
+        scriptUrls.push(scriptUrl);
+        const context = {};
+        runInNewContext(await readFile(path.join(outputPath, scriptUrl), "utf8"), context);
+        assert.equal(context.compileTime, compileTime);
+        assert.ok(html.includes(`Compile time: ${compileTime}`));
+        // Worker and operation module names are consumed separately and must stay unchanged.
+        await readFile(path.join(outputPath, "ChefWorker.js"));
+        await readFile(path.join(outputPath, "modules/Default.js"));
+    }
+
+    assert.notEqual(scriptUrls[0], scriptUrls[1], "a newer build must not reuse the old cached bundle URL");
+    assert.equal(scriptUrls[1], scriptUrls[2], "identical bundles should retain the same cache key");
+});


### PR DESCRIPTION
## Summary
Related to #2788.

Content-hash the production app bundle so updated HTML cannot reuse an older cached `assets/main.js`. Preserve existing worker/module filenames and standalone ZIP packaging.

The regression compiles three builds using the actual production filename configuration: changed build metadata changes the bundle URL, while identical content retains it. It fails with the original filenames.

## Validation
- Clean locked dependency installation.
- Build regression, 279 Node API tests and 2,309 operation tests passed.
- 2,063 browser assertions, lint and production build passed.
- Hosted and standalone HTML reference the packaged hashed bundle.

The reporter's nginx configuration was not available; this fixes a reproduced caching path that can cause the reported mismatch, rather than claiming to verify that specific installation.
