### PR TITLE
feat: add option to sort operations alphabetically within categories

### DIFF
--- a/src/web/App.mjs
+++ b/src/web/App.mjs
@@ -285,6 +285,11 @@ class App {
                 cat.addOperation(op);
             }
 
+            // Favourites are deliberately kept in the user's chosen order
+            if (this.options.sortOperations && catConf.name !== "Favourites") {
+                cat.sortOperations();
+            }
+
             html += cat.toHtml();
         }
 

--- a/src/web/HTMLCategory.mjs
+++ b/src/web/HTMLCategory.mjs
@@ -33,6 +33,14 @@ class HTMLCategory {
 
 
     /**
+     * Sorts the operations in this category alphabetically by name.
+     */
+    sortOperations() {
+        this.opList.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+
+    /**
      * Renders the category and all operations within it in HTML.
      *
      * @returns {string}

--- a/src/web/Manager.mjs
+++ b/src/web/Manager.mjs
@@ -232,6 +232,7 @@ class Manager {
         this.addDynamicListener(".option-item input[type=checkbox]#wordWrap", "change", this.options.setWordWrap, this.options);
         this.addDynamicListener(".option-item input[type=checkbox]#useMetaKey", "change", this.bindings.updateKeybList, this.bindings);
         this.addDynamicListener(".option-item input[type=checkbox]#showCatCount", "change", this.ops.setCatCount, this.ops);
+        this.addDynamicListener(".option-item input[type=checkbox]#sortOperations", "change", this.ops.setSortOperations, this.ops);
         this.addDynamicListener(".option-item input[type=number]", "keyup", this.options.numberChange, this.options);
         this.addDynamicListener(".option-item input[type=number]", "change", this.options.numberChange, this.options);
         this.addDynamicListener(".option-item select", "change", this.options.selectChange, this.options);

--- a/src/web/html/index.html
+++ b/src/web/html/index.html
@@ -529,6 +529,13 @@
                                 Show the number of operations in each category
                             </label>
                         </div>
+
+                        <div class="checkbox option-item">
+                            <label for="sortOperations">
+                                <input type="checkbox" option="sortOperations" id="sortOperations">
+                                Sort operations within each category alphabetically
+                            </label>
+                        </div>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" id="reset-options">Reset options to default</button>

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -53,6 +53,7 @@ function main() {
         imagePreview:        true,
         syncTabs:            true,
         showCatCount:        false,
+        sortOperations:      false,
     };
 
     document.removeEventListener("DOMContentLoaded", main, false);

--- a/src/web/waiters/OperationsWaiter.mjs
+++ b/src/web/waiters/OperationsWaiter.mjs
@@ -317,6 +317,15 @@ class OperationsWaiter {
 
 
     /**
+     * Rebuilds the operations list so the sortOperations option takes effect immediately.
+     */
+    setSortOperations() {
+        this.app.populateOperationsList();
+        this.manager.recipe.initialiseOperationDragNDrop();
+    }
+
+
+    /**
      * Sets whether operation counts are displayed next to a category title
      */
     setCatCount() {

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -25,6 +25,7 @@ import "./tests/Operation.mjs";
 import "./tests/NodeDish.mjs";
 import "./tests/Utils.mjs";
 import "./tests/Categories.mjs";
+import "./tests/HTMLCategory.mjs";
 import "./tests/ToHTMLEntity.mjs";
 import "./tests/lib/BigIntUtils.mjs";
 import "./tests/lib/ChartsProtocolPrototypePollution.mjs";

--- a/tests/node/tests/HTMLCategory.mjs
+++ b/tests/node/tests/HTMLCategory.mjs
@@ -1,0 +1,30 @@
+/**
+ * HTMLCategory tests.
+ *
+ * @author Ben Younes
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+/* eslint no-console: 0 */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+import HTMLCategory from "../../../src/web/HTMLCategory.mjs";
+import it from "../assertionHandler.mjs";
+import assert from "assert";
+
+TestRegister.addApiTests([
+    it("HTMLCategory: sortOperations orders operations alphabetically by name", () => {
+        const cat = new HTMLCategory("Data format", true);
+        ["To Hexdump", "From Hexdump", "To Base64", "From Base64"].forEach(name => cat.addOperation({name}));
+
+        const before = cat.opList.map(op => op.name);
+        cat.sortOperations();
+        const after = cat.opList.map(op => op.name);
+
+        console.log("Before sort:", before.join(", "));
+        console.log("After sort: ", after.join(", "));
+
+        assert.deepStrictEqual(after, ["From Base64", "From Hexdump", "To Base64", "To Hexdump"]);
+    }),
+]);


### PR DESCRIPTION
Adds an opt-in 'Sort operations within each category alphabetically' option (default off) to help users navigate the large operation list. Sorting is applied per-category (Favourites keep their user-chosen order) and re-renders live when toggled.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
Running Node API tests...
TypeError: cat.sortOperations is not a function
    at file:///home/ousama/contribute-work/gchq__CyberChef/tests/node/tests/HTMLCategory.mjs:22:13
    at Object.run (file:///home/ousama/contribute-work/gchq__CyberChef/tests/node/assertionHandler.mjs:20:15)
    at TestRegister.runApiTests (file:///home/ousama/contribute-work/gchq__CyberChef/tests/lib/TestRegister.mjs:166:28)
    at file:///home/ousama/contribute-work/gchq__CyberChef/[eval1]:1:139
    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:272:26)
    at async ModuleLoader.executeModuleJob (node:internal/modules/esm/loader:268:20)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
FAIL - Node API: HTMLCategory: sortOperations orders operations alphabetically by name
cat.sortOperations is not a function
Error: TypeError: cat.sortOperations is not a function
    at file:///home/ousama/contribute-work/gchq__CyberChef/tests/node/tests/HTMLCategory.mjs:22:13
    at Object.run (file:///home/ousama/contribute-work/gchq__CyberChef/tests/node/assertionHandler.mjs:20:15)
    at TestRegister.runApiTests (file:///home/ousama/contribute-work/gchq__CyberChef/tests/lib/TestRegister.mjs:166:28)
    at file:///home/ousama/contribute-work/gchq__CyberChef/[eval1]:1:139
    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:272:26)
    at async ModuleLoader.executeModuleJob (node:internal/modules/esm/loader:268:20)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```

With the fix applied, the test passes (GREEN):

```
GREEN attempt 1/2 (exit 0)
Running Node API tests...
Before sort: To Hexdump, From Hexdump, To Base64, From Base64
After sort:  From Base64, From Hexdump, To Base64, To Hexdump
PASS - Node API: HTMLCategory: sortOperations orders operations alphabetically by name
```

## Full local suite

Command: `npx grunt lint && npm test`

```
Written Compression module
Written Code module
Written Diff module
Written Shellcode module
Written Charts module
Written Regex module
Written PGP module
Written PublicKey module
Written Jq module
Written OCR module
Written URL module
Written UserAgent module
Written Protobuf module
Written File module
Written Handlebars module
Written Yara module
Written OpModules.mjs
--- Config scripts finished. ---


Running "exec:generateNodeIndex" (exec) task

--- Regenerating node index ---
--- Node index generated. ---


Done.
Running Node API tests...
Before sort: To Hexdump, From Hexdump, To Base64, From Base64
After sort:  From Base64, From Hexdump, To Base64, To Hexdump

TOTAL	280
PASSING	280


Running operation tests...
'A1Z26 Cipher Decode: basic decode' took 2.3s to complete

TOTAL	2309
PASSING	2309
```

Fix #2701
