### PR TITLE
feat: add Cron Schedule Decoder operation

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -383,6 +383,7 @@
             "Windows Filetime to UNIX Timestamp",
             "UNIX Timestamp to Windows Filetime",
             "DateTime Delta",
+            "Cron Schedule Decoder",
             "Extract dates",
             "Get Time",
             "Sleep"

--- a/src/core/operations/CronScheduleDecoder.mjs
+++ b/src/core/operations/CronScheduleDecoder.mjs
@@ -77,9 +77,13 @@ class CronScheduleDecoder extends Operation {
 
         for (const part of field.split(",")) {
             if (part.includes("/")) {
-                const [rangePart, stepStr] = part.split("/");
+                const slashParts = part.split("/");
+                if (slashParts.length !== 2) {
+                    throw new OperationError(`Invalid step expression '${part}' in ${fieldName} field`);
+                }
+                const [rangePart, stepStr] = slashParts;
                 const step = parseInt(stepStr, 10);
-                if (isNaN(step) || step <= 0) {
+                if (String(step) !== stepStr || isNaN(step) || step <= 0) {
                     throw new OperationError(`Invalid step value '${stepStr}' in ${fieldName} field`);
                 }
 
@@ -87,7 +91,11 @@ class CronScheduleDecoder extends Operation {
                 let rangeMax = max;
                 if (rangePart !== "*") {
                     if (rangePart.includes("-")) {
-                        const [rMin, rMax] = rangePart.split("-").map(Number);
+                        const dashParts = rangePart.split("-");
+                        if (dashParts.length !== 2) {
+                            throw new OperationError(`Invalid range '${rangePart}' in ${fieldName} field`);
+                        }
+                        const [rMin, rMax] = dashParts.map(Number);
                         if (isNaN(rMin) || isNaN(rMax) || rMin < min || rMax > max || rMin > rMax) {
                             throw new OperationError(`Invalid range '${rangePart}' in ${fieldName} field`);
                         }
@@ -95,7 +103,7 @@ class CronScheduleDecoder extends Operation {
                         rangeMax = rMax;
                     } else {
                         const val = parseInt(rangePart, 10);
-                        if (isNaN(val) || val < min || val > max) {
+                        if (String(val) !== rangePart || isNaN(val) || val < min || val > max) {
                             throw new OperationError(`Invalid value '${rangePart}' in ${fieldName} field`);
                         }
                         rangeMin = val;
@@ -107,7 +115,11 @@ class CronScheduleDecoder extends Operation {
                     values.add(i);
                 }
             } else if (part.includes("-")) {
-                const [rMin, rMax] = part.split("-").map(Number);
+                const dashParts = part.split("-");
+                if (dashParts.length !== 2) {
+                    throw new OperationError(`Invalid range '${part}' in ${fieldName} field`);
+                }
+                const [rMin, rMax] = dashParts.map(Number);
                 if (isNaN(rMin) || isNaN(rMax) || rMin < min || rMax > max || rMin > rMax) {
                     throw new OperationError(`Invalid range '${part}' in ${fieldName} field`);
                 }
@@ -120,7 +132,7 @@ class CronScheduleDecoder extends Operation {
                 }
             } else {
                 const val = parseInt(part, 10);
-                if (isNaN(val) || val < min || val > max) {
+                if (String(val) !== part || isNaN(val) || val < min || val > max) {
                     throw new OperationError(`Invalid value '${part}' in ${fieldName} field`);
                 }
                 values.add(val);

--- a/src/core/operations/CronScheduleDecoder.mjs
+++ b/src/core/operations/CronScheduleDecoder.mjs
@@ -1,0 +1,256 @@
+/**
+ * @author mmustafasenoglu
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const MONTHS = ["", "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"];
+
+/**
+ * Cron Schedule Decoder operation
+ */
+class CronScheduleDecoder extends Operation {
+
+    /**
+     * CronScheduleDecoder constructor
+     */
+    constructor() {
+        super();
+
+        this.name = "Cron Schedule Decoder";
+        this.module = "Default";
+        this.description = "Decodes a standard 5-field cron expression into a human-readable description.<br><br>e.g. <code>0 0,12 1 */2 *</code> becomes <code>At minute 0 past hour 0 and 12 on day-of-month 1 in every 2nd month</code><br><br>Supports <code>*</code> (any), <code>,</code> (list), <code>-</code> (range), and <code>/</code> (step) operators in each field.";
+        this.infoURL = "https://en.wikipedia.org/wiki/Cron";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     *
+     * @throws {OperationError} if the cron expression is invalid
+     */
+    run(input, args) {
+        const expr = input.trim();
+        const parts = expr.split(/\s+/);
+
+        if (parts.length !== 5) {
+            throw new OperationError(
+                `Invalid cron expression: expected 5 fields, got ${parts.length}. ` +
+                `Format: minute hour day-of-month month day-of-week`
+            );
+        }
+
+        const [minPart, hourPart, domPart, monthPart, dowPart] = parts;
+
+        const minute = this.parseField(minPart, 0, 59, "minute");
+        const hour = this.parseField(hourPart, 0, 23, "hour");
+        const dom = this.parseField(domPart, 1, 31, "day-of-month");
+        const month = this.parseField(monthPart, 1, 12, "month");
+        const dow = this.parseField(dowPart, 0, 7, "day-of-week");
+
+        if (dow.has(7)) {
+            dow.add(0);
+            dow.delete(7);
+        }
+
+        return this.buildDescription(minute, hour, dom, month, dow, minPart, hourPart, domPart, monthPart, dowPart);
+    }
+
+    /**
+     * Parses a single cron field into a Set of valid values.
+     */
+    parseField(field, min, max, fieldName) {
+        if (!field || field.length === 0) {
+            throw new OperationError(`Empty ${fieldName} field`);
+        }
+
+        const values = new Set();
+
+        for (const part of field.split(",")) {
+            if (part.includes("/")) {
+                const [rangePart, stepStr] = part.split("/");
+                const step = parseInt(stepStr, 10);
+                if (isNaN(step) || step <= 0) {
+                    throw new OperationError(`Invalid step value '${stepStr}' in ${fieldName} field`);
+                }
+
+                let rangeMin = min;
+                let rangeMax = max;
+                if (rangePart !== "*") {
+                    if (rangePart.includes("-")) {
+                        const [rMin, rMax] = rangePart.split("-").map(Number);
+                        if (isNaN(rMin) || isNaN(rMax) || rMin < min || rMax > max || rMin > rMax) {
+                            throw new OperationError(`Invalid range '${rangePart}' in ${fieldName} field`);
+                        }
+                        rangeMin = rMin;
+                        rangeMax = rMax;
+                    } else {
+                        const val = parseInt(rangePart, 10);
+                        if (isNaN(val) || val < min || val > max) {
+                            throw new OperationError(`Invalid value '${rangePart}' in ${fieldName} field`);
+                        }
+                        rangeMin = val;
+                        rangeMax = max;
+                    }
+                }
+
+                for (let i = rangeMin; i <= rangeMax; i += step) {
+                    values.add(i);
+                }
+            } else if (part.includes("-")) {
+                const [rMin, rMax] = part.split("-").map(Number);
+                if (isNaN(rMin) || isNaN(rMax) || rMin < min || rMax > max || rMin > rMax) {
+                    throw new OperationError(`Invalid range '${part}' in ${fieldName} field`);
+                }
+                for (let i = rMin; i <= rMax; i++) {
+                    values.add(i);
+                }
+            } else if (part === "*") {
+                for (let i = min; i <= max; i++) {
+                    values.add(i);
+                }
+            } else {
+                const val = parseInt(part, 10);
+                if (isNaN(val) || val < min || val > max) {
+                    throw new OperationError(`Invalid value '${part}' in ${fieldName} field`);
+                }
+                values.add(val);
+            }
+        }
+
+        if (values.size === 0) {
+            throw new OperationError(`No valid values in ${fieldName} field`);
+        }
+
+        return values;
+    }
+
+    /**
+     * Joins a list of strings with commas and "and" for the final item.
+     */
+    joinList(items) {
+        if (items.length === 0) return "";
+        if (items.length === 1) return items[0];
+        if (items.length === 2) return items[0] + " and " + items[1];
+        return items.slice(0, -1).join(", ") + " and " + items[items.length - 1];
+    }
+
+    /**
+     * Builds the human-readable description from parsed fields.
+     */
+    buildDescription(minute, hour, dom, month, dow, minPart, hourPart, domPart, monthPart, dowPart) {
+        const parts = [];
+
+        // Minute
+        if (minute.size === 60) {
+            parts.push("Every minute");
+        } else {
+            const minStr = this.describeRange(minute, 0, 59);
+            parts.push(`At minute ${minStr}`);
+        }
+
+        // Hour
+        if (hour.size === 24) {
+            if (minute.size < 60) parts.push("past every hour");
+        } else if (hourPart !== "*") {
+            if (minute.size < 60) {
+                parts.push(`past hour ${this.describeRange(hour, 0, 23)}`);
+            } else {
+                parts.push(`past hour ${this.describeRange(hour, 0, 23)}`);
+            }
+        }
+
+        // Day of month
+        if (domPart !== "*") {
+            if (dom.size === 1) {
+                const val = dom.values().next().value;
+                parts.push(`on day-of-month ${val}`);
+            } else {
+                parts.push(`on day-of-month ${this.describeRange(dom, 1, 31)}`);
+            }
+        }
+
+        // Month
+        if (monthPart !== "*") {
+            if (month.size === 1) {
+                const val = month.values().next().value;
+                parts.push(`in ${MONTHS[val]}`);
+            } else if (this.isStepField(monthPart)) {
+                const step = parseInt(monthPart.split("/")[1], 10);
+                parts.push(`in every ${this.ordinal(step)} month`);
+            } else {
+                const monthNames = [...month].sort((a, b) => a - b).map(m => MONTHS[m]);
+                parts.push(`in ${this.joinList(monthNames)}`);
+            }
+        }
+
+        // Day of week
+        if (dowPart !== "*") {
+            if (dow.size === 1) {
+                const val = dow.values().next().value;
+                parts.push(`on ${DAYS[val]}`);
+            } else if (this.isStepField(dowPart)) {
+                const step = parseInt(dowPart.split("/")[1], 10);
+                parts.push(`every ${this.ordinal(step)} day of the week`);
+            } else {
+                const dayNames = [...dow].sort((a, b) => a - b).map(d => DAYS[d]);
+                parts.push(`on ${this.joinList(dayNames)}`);
+            }
+        }
+
+        return parts.join(" ") + ".";
+    }
+
+    /**
+     * Describes a set of values, using range notation where possible.
+     */
+    describeRange(values, min, max) {
+        if (values.size === (max - min + 1)) return "every " + min;
+        if (values.size === 1) return values.values().next().value.toString();
+
+        const sorted = [...values].sort((a, b) => a - b);
+        const ranges = [];
+        let start = sorted[0];
+        let end = sorted[0];
+
+        for (let i = 1; i < sorted.length; i++) {
+            if (sorted[i] === end + 1) {
+                end = sorted[i];
+            } else {
+                ranges.push(start === end ? `${start}` : `${start}-${end}`);
+                start = sorted[i];
+                end = sorted[i];
+            }
+        }
+        ranges.push(start === end ? `${start}` : `${start}-${end}`);
+
+        return this.joinList(ranges);
+    }
+
+    /**
+     * Returns the ordinal form of a number.
+     */
+    ordinal(n) {
+        const s = ["th", "st", "nd", "rd"];
+        const v = n % 100;
+        return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    }
+
+    /**
+     * Checks if a field uses step notation.
+     */
+    isStepField(field) {
+        return field.includes("/");
+    }
+}
+
+export default CronScheduleDecoder;

--- a/tests/operations/tests/CronScheduleDecoder.mjs
+++ b/tests/operations/tests/CronScheduleDecoder.mjs
@@ -119,4 +119,48 @@ TestRegister.addTests([
             },
         ],
     },
+    {
+        name: "Cron Schedule Decoder: invalid - trailing text after number",
+        input: "1foo * * * *",
+        expectedOutput: "Invalid value '1foo' in minute field",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: invalid - extra slash in step",
+        input: "*/2/3 * * * *",
+        expectedOutput: "Invalid step expression '*/2/3' in minute field",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: invalid - extra dash in range",
+        input: "1-2-3 * * * *",
+        expectedOutput: "Invalid range '1-2-3' in minute field",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: invalid - trailing text in step value",
+        input: "*/2x * * * *",
+        expectedOutput: "Invalid step value '2x' in minute field",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
 ]);

--- a/tests/operations/tests/CronScheduleDecoder.mjs
+++ b/tests/operations/tests/CronScheduleDecoder.mjs
@@ -1,0 +1,122 @@
+/**
+ * Cron Schedule Decoder tests.
+ *
+ * @author mmustafasenoglu
+ *
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        name: "Cron Schedule Decoder: every minute",
+        input: "* * * * *",
+        expectedOutput: "Every minute.",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: every day at midnight",
+        input: "0 0 * * *",
+        expectedOutput: "At minute 0 past hour 0.",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: issue example",
+        input: "0 0,12 1 */2 *",
+        expectedOutput: "At minute 0 past hour 0 and 12 on day-of-month 1 in every 2nd month.",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: weekdays at 9:30",
+        input: "30 9 * * 1-5",
+        expectedOutput: "At minute 30 past hour 9 on Monday, Tuesday, Wednesday, Thursday and Friday.",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: every 15 minutes",
+        input: "*/15 * * * *",
+        expectedOutput: "At minute 0, 15, 30 and 45 past every hour.",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: specific months",
+        input: "0 12 1 3,6,9,12 *",
+        expectedOutput: "At minute 0 past hour 12 on day-of-month 1 in March, June, September and December.",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: single day of week",
+        input: "0 0 * * 0",
+        expectedOutput: "At minute 0 past hour 0 on Sunday.",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: range in minutes",
+        input: "0-10 8 * * *",
+        expectedOutput: "At minute 0-10 past hour 8.",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: invalid - too few fields",
+        input: "* * *",
+        expectedOutput: "Invalid cron expression: expected 5 fields, got 3. Format: minute hour day-of-month month day-of-week",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+    {
+        name: "Cron Schedule Decoder: invalid - letter in field",
+        input: "a * * * *",
+        expectedOutput: "Invalid value 'a' in minute field",
+        recipeConfig: [
+            {
+                op: "Cron Schedule Decoder",
+                args: [],
+            },
+        ],
+    },
+]);


### PR DESCRIPTION
Closes #406

Adds a new **Cron Schedule Decoder** operation that converts standard 5-field cron expressions into human-readable descriptions.

## Changes
- `src/core/operations/CronScheduleDecoder.mjs`: New operation that parses cron expressions and outputs plain English
- `src/core/config/Categories.json`: Registered under Date / Time category
- `tests/operations/tests/CronScheduleDecoder.mjs`: 10 test cases covering wildcards, ranges, lists, steps, and error handling

## Supported operators
| Operator | Meaning | Example |
|----------|---------|---------|
| `*` | Any value | `* * * * *` → Every minute |
| `-` | Range | `0-10 * * * *` → At minute 0-10 |
| `,` | List | `0,30 * * * *` → At minute 0 and 30 |
| `/` | Step | `*/15 * * * *` → At minute 0, 15, 30 and 45 |

## Validation
- All 279 Node API tests passing
- All 2319 operation tests passing (including 10 new Cron Schedule Decoder tests)
- No external dependencies added (vanilla JS, per CyberChef design principles)