### PR TITLE
Fix escaped binary defaults in Node recipes

### DIFF
--- a/src/node/NodeRecipe.mjs
+++ b/src/node/NodeRecipe.mjs
@@ -6,6 +6,7 @@
 
 import {operations} from "./index.mjs";
 import { sanitise } from "./apiUtils.mjs";
+import Ingredient from "../core/Ingredient.mjs";
 
 /**
  * Similar to core/Recipe, Recipe controls a list of operations and
@@ -95,7 +96,12 @@ class NodeRecipe {
                 Object.prototype.hasOwnProperty.call(curr, "args")) {
                 prev = await curr.op(prev, curr.args);
             } else {
-                prev = await curr(prev);
+                const binaryDefaults = Object.fromEntries(
+                    Object.entries(curr.args)
+                        .filter(([, arg]) => arg.type === "binaryString" || arg.type === "binaryShortString")
+                        .map(([name, arg]) => [name, Ingredient.prepare(arg.value, arg.type)])
+                );
+                prev = await curr(prev, Object.keys(binaryDefaults).length ? binaryDefaults : null);
             }
         }
         return prev;

--- a/tests/node/tests/nodeApi.mjs
+++ b/tests/node/tests/nodeApi.mjs
@@ -288,6 +288,16 @@ TestRegister.addApiTests([
         assert.strictEqual(result.toString(), "73 6f 6d 65 20 69 6e 70 75 74");
     }),
 
+    it("chef.bake: applies escaped binary string defaults when args are omitted", async () => {
+        const result = await chef.bake("mess with the best, die rest like the rest", {
+            op: chef.toTable,
+        });
+        assert.strictEqual(result.toString(),
+            "+--------------------+-------------------------+\n" +
+            "| mess with the best |  die rest like the rest |\n" +
+            "+--------------------+-------------------------+\n");
+    }),
+
     it("chef.bake: should take single JSON object describing op and args ARRAY", async () => {
         const result = await chef.bake("some input", {
             op: chef.toHex,


### PR DESCRIPTION
**Description**
Fix Node recipe execution when an operation omits arguments and has escaped `binaryString`/`binaryShortString` defaults. Those defaults now receive the same ingredient preparation as the browser path, preventing values such as `\r\n` from being treated as literal `r`/`n` delimiters. This addresses the root cause reported in gchq/CyberChef-server#85.

**Test Coverage**
Added a `chef.bake` regression for `To Table` with omitted args. Node API tests: 280/280 pass. `npm run lint` passes.