### PR TITLE
Fix malformed percent escapes in recipe links

### DIFF
--- a/src/core/Utils.mjs
+++ b/src/core/Utils.mjs
@@ -1184,6 +1184,7 @@ class Utils {
 
     /**
      * Parses URI parameters into a JSON object.
+     * Malformed percent escapes remain literal; invalid UTF-8 uses replacement characters.
      *
      * @param {string} paramStr - The serialised query or hash section of a URI
      * @returns {object}
@@ -1210,7 +1211,7 @@ class Utils {
             if (param.length !== 2) {
                 result[params[i]] = true;
             } else {
-                result[param[0]] = decodeURIComponent(param[1].replace(/\+/g, " "));
+                result[param[0]] = new URLSearchParams("value=" + param[1]).get("value");
             }
         }
 

--- a/tests/browser/03_recipe_load.js
+++ b/tests/browser/03_recipe_load.js
@@ -42,6 +42,36 @@ module.exports = {
         });
     },
 
+    "Invalid percent delimiter reaches operation validation": browser => {
+        browser
+            .url("about:blank")
+            .url(browser.launchUrl + "#recipe=To_Hex('%',0)&input=aGVsbG8")
+            .waitForElementNotPresent("#preloader", 10000)
+            .waitForElementPresent("#rec-list li.operation", 10000);
+        utils.bake(browser);
+        utils.expectOutput(browser, "Delimiter cannot be empty.");
+    },
+
+    "Query links decode valid escapes beside literal percent signs": browser => {
+        browser
+            .url("about:blank")
+            .url(browser.launchUrl + "?recipe=To_Hex('Per%63ent',0)&input=aGVsbG8&note=100%")
+            .waitForElementNotPresent("#preloader", 10000)
+            .waitForElementPresent("#rec-list li.operation", 10000);
+        utils.bake(browser);
+        utils.expectOutput(browser, "%68%65%6c%6c%6f");
+    },
+
+    "Percent signs remain usable in free-text recipe arguments": browser => {
+        browser
+            .url("about:blank")
+            .url(browser.launchUrl + "#recipe=Find_/_Replace({'option':'Simple%20string','string':'%'},'percent',true,false,true,false)&input=NTAl")
+            .waitForElementNotPresent("#preloader", 10000)
+            .waitForElementPresent("#rec-list li.operation", 10000);
+        utils.bake(browser);
+        utils.expectOutput(browser, "50percent");
+    },
+
     after: browser => {
         browser.end();
     }

--- a/tests/node/tests/Utils.mjs
+++ b/tests/node/tests/Utils.mjs
@@ -4,6 +4,22 @@ import it from "../assertionHandler.mjs";
 import assert from "assert";
 
 TestRegister.addApiTests([
+    ...[
+        ["literal percent", "#recipe=To_Hex('%',0)", {recipe: "To_Hex('%',0)"}],
+        ["short escape", "?value=%2", {value: "%2"}],
+        ["non-hex escape", "value=%GG", {value: "%GG"}],
+        ["mixed escapes", "value=50%25%20off%", {value: "50% off%"}],
+        ["invalid UTF-8", "value=%FF", {value: "\uFFFD"}],
+        ["truncated UTF-8", "value=%E0%A4", {value: "\uFFFD"}],
+        ["encoded percent", "value=%2525", {value: "%25"}],
+        ["Unicode", "value=%F0%9F%98%80", {value: "\u{1F600}"}],
+        ["plus and separators", "value=a+b%2Bc%26d%3De", {value: "a b+c&d=e"}],
+        ["flags and duplicates", "?flag&value=first&value=second&empty=", {flag: true, value: "second", empty: ""}],
+        ["empty parameters", "", {}]
+    ].map(([name, input, expected]) => it(`Utils: URI parameters handle ${name}`, () => {
+        assert.deepStrictEqual(Utils.parseURIParams(input), expected);
+    })),
+
     it("Utils: should parse six backslashes correctly", () => {
         assert.equal(Utils.parseEscapedChars("\\\\\\\\\\\\"), "\\\\\\");
     }),


### PR DESCRIPTION
Fixes #2422.

Decode URI parameter values with the platform form parser so malformed percent escapes cannot abort application startup. Preserve existing parameter names, flags and duplicate-key handling. Valid escapes are decoded once, literal percent signs remain intact, and invalid UTF-8 uses replacement characters.

Adds 11 Node parameter cases and three browser regressions covering the reported URL, mixed encoded/literal percent signs, and free-text recipe arguments. The reported invalid To Hex delimiter now reaches normal operation validation instead of preventing the app from loading.

Validation:
- Six new Node cases fail on the original code; the reported browser URL also fails to load its recipe before the fix.
- All 290 Node API tests and 2,309 operation tests pass.
- All four recipe-loading browser tests pass in headless Chrome 152 (27 assertions).
- Production build and ESLint pass. No dependencies added.

The complete browser suite was not run.
