### PR TITLE
Add HTTP health check for Docker deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,6 @@ FROM nginxinc/nginx-unprivileged:stable-alpine@sha256:9b87ad3dd9f431c733f19dfb27
 LABEL maintainer="GCHQ <oss@gchq.gov.uk>"
 
 COPY --from=builder /app/build/prod /usr/share/nginx/html/
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl --fail --silent --show-error --max-time 5 --noproxy '*' --output /dev/null http://127.0.0.1:8080/ || exit 1

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ docker run -it -p 8080:8080 ghcr.io/gchq/cyberchef:latest
 
 Just like before, navigate to `http://localhost:8080` in your browser.
 
+The image includes an HTTP health check against `http://127.0.0.1:8080/` inside the
+container. View its status with `docker inspect --format '{{.State.Health.Status}}'
+<container>`. It checks that nginx serves the page; it does not run recipes or
+restart an unhealthy container automatically. Deployments that change nginx's
+internal port or path should override the check with `--health-cmd` or disable it
+with `--no-healthcheck`.
+
+To test a locally built image, run `bash tests/docker/healthcheck.sh cyberchef`.
+The test uses an isolated container to check healthy, unhealthy and recovered
+states, without publishing ports or accessing the external network.
+
+
 This image is built and published through our [GitHub Workflows](.github/workflows/releases.yml).
 
 ### From source

--- a/tests/docker/healthcheck.sh
+++ b/tests/docker/healthcheck.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2026 Crown Copyright
+# Licensed under the Apache License, Version 2.0.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <built-cyberchef-image>" >&2
+    exit 1
+fi
+
+container=""
+cleanup() {
+    if [ -n "$container" ]; then
+        docker rm -f "$container" >/dev/null
+    fi
+}
+trap cleanup EXIT
+
+# No published ports or external network are needed. Proxy settings must not
+# redirect the local probe, even when inherited from a deployment environment.
+container=$(docker run -d --network none \
+    --health-interval=1s --health-timeout=10s \
+    --health-start-period=1s --health-retries=1 \
+    -e http_proxy=http://127.0.0.1:1 -e HTTP_PROXY=http://127.0.0.1:1 \
+    -e ALL_PROXY=http://127.0.0.1:1 -e NO_PROXY= -e no_proxy= "$1")
+
+wait_for_health() {
+    local expected="$1"
+    local actual
+    for ((attempt = 0; attempt < 30; attempt++)); do
+        actual=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' "$container")
+        if [ "$actual" = "$expected" ]; then
+            echo "Health status: $actual"
+            return
+        fi
+        if [ "$actual" = missing ]; then
+            echo "The image has no health check." >&2
+            return 1
+        fi
+        sleep 1
+    done
+    docker inspect --format '{{json .State.Health}}' "$container" >&2
+    echo "Expected health status: $expected" >&2
+    return 1
+}
+
+wait_for_health healthy
+# Force an HTTP error without stopping the container or nginx.
+docker exec --user 0 "$container" mv /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.saved
+wait_for_health unhealthy
+docker exec --user 0 "$container" mv /usr/share/nginx/html/index.html.saved /usr/share/nginx/html/index.html
+wait_for_health healthy


### PR DESCRIPTION
Fixes #2469.

Add a bounded HTTP health check against nginx on `127.0.0.1:8080`. Use the curl already present in the pinned runtime image, discard the response body, and bypass proxy settings. No packages or privileges are added.

Add a container regression script and document checking, overriding and disabling the probe. The script checks healthy, HTTP-failure and recovered states with external networking disabled and invalid proxy settings. It fails against the unchanged image because no health check exists.

Validation: production website build, ESLint and ShellCheck passed. The runtime stage, built from the pinned nginx base and those production assets, passed all three health-state checks as user 101. The complete multi-stage Docker build and multi-platform runs were not repeated.
