### PR TITLE
Restore versioned ZIP names for tagged releases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,7 +112,10 @@ module.exports = function (grunt) {
     const compileYear = grunt.template.today("UTC:yyyy"),
         compileTime = grunt.template.today("UTC:dd/mm/yyyy HH:MM:ss") + " UTC",
         pkg = grunt.file.readJSON("package.json"),
-        version = process.env.GITHUB_SHA || `v${pkg.version}`,
+        // Match the package release tag; retain commit IDs for development builds.
+        version = process.env.GITHUB_REF === `refs/tags/v${pkg.version}` ?
+            `v${pkg.version}` :
+            process.env.GITHUB_SHA || `v${pkg.version}`,
         downloadZipFilename = `CyberChef_${version}.zip`,
         webpackConfig = require("./webpack.config.js"),
         BUILD_CONSTANTS = {

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -24,6 +24,7 @@ import "./tests/Dish.mjs";
 import "./tests/Operation.mjs";
 import "./tests/NodeDish.mjs";
 import "./tests/Utils.mjs";
+import "./tests/BuildVersion.mjs";
 import "./tests/Categories.mjs";
 import "./tests/ToHTMLEntity.mjs";
 import "./tests/lib/BigIntUtils.mjs";

--- a/tests/node/tests/BuildVersion.mjs
+++ b/tests/node/tests/BuildVersion.mjs
@@ -1,0 +1,57 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import TestRegister from "../../lib/TestRegister.mjs";
+import it from "../assertionHandler.mjs";
+
+const root = fileURLToPath(new URL("../../../", import.meta.url));
+const sha = "1234567890abcdef1234567890abcdef12345678";
+const version = "11.4.0";
+const readConfiguration = `
+    const grunt = require("grunt");
+    const readJSON = grunt.file.readJSON;
+    grunt.file.readJSON = function (filename, ...args) {
+        const result = readJSON.call(this, filename, ...args);
+        return filename === "package.json" ? {...result, version: process.argv[1]} : result;
+    };
+    require("./Gruntfile.js")(grunt);
+    const html = grunt.config.getRaw("webpack.web.plugins")
+        .find(plugin => plugin.constructor.name === "HtmlWebpackPlugin").userOptions;
+    console.log(JSON.stringify({
+        archive: grunt.config.get("zip.standalone.dest"),
+        version: html.version,
+        download: html.downloadZipFilename,
+        standalone: grunt.config.get("copy.standalone.files")[0].dest
+    }));
+`;
+
+TestRegister.addApiTests([
+    ["release tag", version, {GITHUB_REF: `refs/tags/v${version}`, GITHUB_SHA: sha}, `v${version}`],
+    ["prerelease tag", "11.4.1-rc.1", {GITHUB_REF: "refs/tags/v11.4.1-rc.1", GITHUB_SHA: sha}, "v11.4.1-rc.1"],
+    ["branch build", version, {GITHUB_REF: "refs/heads/master", GITHUB_SHA: sha}, sha],
+    ["version-named branch", version, {GITHUB_REF: `refs/heads/v${version}`, GITHUB_SHA: sha}, sha],
+    ["pull request", version, {GITHUB_REF: "refs/pull/123/merge", GITHUB_SHA: sha}, sha],
+    ["unmatched tag", version, {GITHUB_REF: "refs/tags/v0.0.0", GITHUB_SHA: sha}, sha],
+    ["local build", version, {}, `v${version}`],
+    ["build without commit metadata", version, {GITHUB_REF: "refs/heads/master"}, `v${version}`]
+].map(([name, packageVersion, environment, expected]) => it(`Build version: ${name}`, () => {
+    const result = spawnSync(process.execPath, ["--no-warnings", "--eval", readConfiguration, packageVersion], {
+        cwd: root,
+        env: {...process.env, GITHUB_SHA: "", GITHUB_REF: "", ...environment},
+        encoding: "utf8",
+        timeout: 10000
+    });
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+        archive: `build/prod/CyberChef_${expected}.zip`,
+        version: expected,
+        download: `CyberChef_${expected}.zip`,
+        standalone: `build/prod/CyberChef_v${packageVersion}.html`
+    });
+})));


### PR DESCRIPTION
Fixes #2640.

Use `v<package.version>` when `GITHUB_REF` is the matching release tag. This restores versioned release ZIP names and the displayed application version. Branch and pull-request builds retain their commit IDs; local builds keep their existing package-version fallback. Unmatched tags also retain the commit ID.

Adds eight regression cases against the actual Grunt configuration, covering releases, prereleases, branches, pull requests, unmatched tags and missing metadata. They check archive names, download links and displayed versions. The release and prerelease cases fail before the fix.

Validation:
- All 287 Node API tests and 2,309 operation tests passed.
- ESLint passed.
- A production build with simulated matching release metadata produced `CyberChef_v11.4.0.zip`. Verified its standalone HTML entry, both rendered version strings, download link and SHA-256 digest.

No dependencies changed. The full browser suite and Docker builds were not run.
