### PR TITLE
Add literal multi-character substitution with number-word presets

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -162,6 +162,7 @@
             "Cetacean Cipher Encode",
             "Cetacean Cipher Decode",
             "Substitute",
+            "Multi-character Substitution",
             "Derive PBKDF2 key",
             "Derive EVP key",
             "Derive HKDF key",

--- a/src/core/operations/MulticharacterSubstitution.mjs
+++ b/src/core/operations/MulticharacterSubstitution.mjs
@@ -1,0 +1,89 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import Utils from "../Utils.mjs";
+
+const NUMBER_WORDS = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"];
+
+/**
+ * Multi-character Substitution operation.
+ */
+class MulticharacterSubstitution extends Operation {
+    /**
+     * MulticharacterSubstitution constructor.
+     */
+    constructor() {
+        super();
+        this.name = "Multi-character Substitution";
+        this.module = "Default";
+        this.description = "Replaces literal strings in a single, case-sensitive pass. At each position the longest matching key wins. Replacements are not processed again and unmatched text is preserved.<br><br>The number-word presets convert full English number words or their first two or three letters to digits. For example, <code>thsetwfinize</code> becomes <code>372590</code> with the two-letter preset.<br><br>Custom dictionaries are JSON objects such as <code>{&quot;foo&quot;:&quot;bar&quot;,&quot;remove&quot;:&quot;&quot;}</code>. Keys must be non-empty and values must be strings. Regular-expression and replacement syntax are treated literally. Custom JSON is limited to 65536 characters and 4096 mappings.";
+        this.inputType = "string";
+        this.outputType = "string";
+        this.args = [
+            {
+                name: "Dictionary",
+                type: "option",
+                value: ["Number words", "Two-letter number words", "Three-letter number words", "Custom"]
+            },
+            {
+                name: "Custom dictionary",
+                type: "text",
+                value: "{}"
+            }
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const [preset, custom] = args;
+        let entries;
+        if (preset === "Custom") {
+            if (custom.length > 65536) {
+                throw new OperationError("Custom dictionary must be at most 65536 characters.");
+            }
+            let parsed;
+            try {
+                parsed = JSON.parse(custom);
+            } catch {
+                throw new OperationError("Custom dictionary must be a JSON object mapping non-empty strings to strings.");
+            }
+            if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+                throw new OperationError("Custom dictionary must be a JSON object mapping non-empty strings to strings.");
+            }
+            entries = Object.entries(parsed);
+            if (entries.some(([key, value]) => key.length === 0 || typeof value !== "string")) {
+                throw new OperationError("Custom dictionary must be a JSON object mapping non-empty strings to strings.");
+            }
+            if (entries.length > 4096) {
+                throw new OperationError("Custom dictionary must contain at most 4096 mappings.");
+            }
+        } else {
+            const lengths = new Map([
+                ["Number words", undefined],
+                ["Two-letter number words", 2],
+                ["Three-letter number words", 3]
+            ]);
+            if (!lengths.has(preset)) {
+                throw new OperationError("Unknown dictionary preset.");
+            }
+            entries = NUMBER_WORDS.map((word, digit) => [word.slice(0, lengths.get(preset)), String(digit)]);
+        }
+        if (entries.length === 0) return input;
+        const dictionary = new Map(entries);
+        const pattern = [...dictionary.keys()]
+            .sort((a, b) => b.length - a.length)
+            .map(key => Utils.escapeRegex(key))
+            .join("|");
+        return input.replace(new RegExp(pattern, "g"), match => dictionary.get(match));
+    }
+}
+
+export default MulticharacterSubstitution;

--- a/tests/browser/04_multicharacter_substitution.js
+++ b/tests/browser/04_multicharacter_substitution.js
@@ -1,0 +1,38 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+const utils = require("./browserUtils.js");
+
+module.exports = {
+    before: browser => {
+        browser.resizeWindow(1280, 800)
+            .url(browser.launchUrl)
+            .useCss()
+            .waitForElementNotPresent("#preloader", 10000)
+            .click("#auto-bake-label");
+    },
+
+    "Number-word preset": browser => {
+        utils.loadRecipe(browser, "Multi-character Substitution", "thsetwfinize",
+            ["Two-letter number words", "{}"]);
+        utils.bake(browser);
+        utils.expectOutput(browser, "372590");
+    },
+
+    "Custom longest match is non-cascading": browser => {
+        utils.loadRecipe(browser, "Multi-character Substitution", "ababa",
+            ["Custom", '{"ab":"Y","aba":"X","X":"wrong"}']);
+        utils.bake(browser);
+        utils.expectOutput(browser, "Xba");
+    },
+
+    "Invalid dictionary is shown in the output": browser => {
+        utils.loadRecipe(browser, "Multi-character Substitution", "one", ["Custom", "{"]);
+        utils.bake(browser);
+        utils.expectOutput(browser, "Custom dictionary must be a JSON object mapping non-empty strings to strings.");
+    },
+
+    after: browser => browser.end()
+};

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -24,6 +24,7 @@ import "./tests/Dish.mjs";
 import "./tests/Operation.mjs";
 import "./tests/NodeDish.mjs";
 import "./tests/Utils.mjs";
+import "./tests/MulticharacterSubstitution.mjs";
 import "./tests/Categories.mjs";
 import "./tests/ToHTMLEntity.mjs";
 import "./tests/lib/BigIntUtils.mjs";

--- a/tests/node/tests/MulticharacterSubstitution.mjs
+++ b/tests/node/tests/MulticharacterSubstitution.mjs
@@ -1,0 +1,24 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import assert from "assert";
+import TestRegister from "../../lib/TestRegister.mjs";
+import it from "../assertionHandler.mjs";
+import MulticharacterSubstitution from "../../../src/core/operations/MulticharacterSubstitution.mjs";
+
+TestRegister.addApiTests([
+    it("Multi-character substitution: excessive mappings are rejected", () => {
+        const dictionary = JSON.stringify(Object.fromEntries(Array.from({length: 4097}, (_, i) => [String(i), ""])));
+        assert.throws(() => new MulticharacterSubstitution().run("x", ["Custom", dictionary]), /at most 4096 mappings/);
+    }),
+    it("Multi-character substitution: metacharacters remain literal", () => {
+        const dictionary = {"a-b": "dash", "/": "$&", "\\": "backslash", ".*": "star"};
+        assert.strictEqual(new MulticharacterSubstitution().run("a-b / \\ .*", ["Custom", JSON.stringify(dictionary)]),
+            "dash $& backslash star");
+    }),
+    it("Multi-character substitution: unknown preset is rejected", () => {
+        assert.throws(() => new MulticharacterSubstitution().run("x", ["unknown", "{}"]), {type: "OperationError"});
+    })
+]);

--- a/tests/operations/tests/MulticharacterSubstitution.mjs
+++ b/tests/operations/tests/MulticharacterSubstitution.mjs
@@ -1,0 +1,373 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        "name": "Multi-character Substitution: number words",
+        "input": "threeseventwofiveninezero",
+        "expectedOutput": "372590",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Number words",
+                    "{}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: two letters",
+        "input": "thsetwfinize",
+        "expectedOutput": "372590",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Two-letter number words",
+                    "{}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: three letters",
+        "input": "thrsevtwofivninzer",
+        "expectedOutput": "372590",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Three-letter number words",
+                    "{}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: all numbers",
+        "input": "zero one two three four five six seven eight nine",
+        "expectedOutput": "0 1 2 3 4 5 6 7 8 9",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Number words",
+                    "{}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: longest match",
+        "input": "ababa",
+        "expectedOutput": "Xba",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"ab\":\"Y\",\"aba\":\"X\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: non-cascading",
+        "input": "abc",
+        "expectedOutput": "bcX",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"a\":\"b\",\"b\":\"c\",\"c\":\"X\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: literal punctuation",
+        "input": "[a].* (b) [a]",
+        "expectedOutput": "X Y X",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"[a]\":\"X\",\"(b)\":\"Y\",\".*\":\"\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: replacement syntax stays literal",
+        "input": "a",
+        "expectedOutput": "$$ $& $1",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"a\":\"$$ $& $1\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: empty replacement",
+        "input": "bananas",
+        "expectedOutput": "bs",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"anana\":\"\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: empty input",
+        "input": "",
+        "expectedOutput": "",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"one\":\"1\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: empty dictionary",
+        "input": "unchanged",
+        "expectedOutput": "unchanged",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: case sensitive",
+        "input": "ONE one",
+        "expectedOutput": "ONE 1",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Number words",
+                    "{}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: Unicode",
+        "input": "🙂🙂é",
+        "expectedOutput": "AB",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"🙂🙂\":\"A\",\"é\":\"B\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: prototype keys",
+        "input": "__proto__ constructor toString",
+        "expectedOutput": "ABC",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"__proto__\":\"A\",\" constructor \":\"B\",\"toString\":\"C\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: newlines and tabs",
+        "input": "one\ntwo\tthree",
+        "expectedOutput": "1\n2\t3",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Number words",
+                    "{}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: preset ignores custom dictionary",
+        "input": "one",
+        "expectedOutput": "1",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Number words",
+                    "{"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid dictionary {",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid dictionary null",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "null"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid dictionary []",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "[]"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid dictionary \"text\"",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "\"text\""
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid dictionary 12",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "12"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid mapping {\"\":\"x\"}",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"\":\"x\"}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid mapping {\"x\":1}",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"x\":1}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid mapping {\"x\":null}",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"x\":null}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: invalid mapping {\"x\":{}}",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be a JSON object mapping non-empty strings to strings.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    "{\"x\":{}}"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Multi-character Substitution: bounded dictionary",
+        "input": "x",
+        "expectedOutput": "Custom dictionary must be at most 65536 characters.",
+        "recipeConfig": [
+            {
+                "op": "Multi-character Substitution",
+                "args": [
+                    "Custom",
+                    " ".repeat(65537)
+                ]
+            }
+        ]
+    }
+]);


### PR DESCRIPTION
Fixes #2452.

Add Multi-character Substitution with full, two-letter and three-letter English number-word presets, plus custom JSON mappings. Replacement is literal, case-sensitive and performed in one pass, choosing the longest matching key. Unmatched text is preserved and replacement text is not processed again.

Use escaped patterns and a Map so regex syntax, replacement tokens and prototype-like keys remain literal. Validate dictionary types and non-empty keys, with limits of 65,536 JSON characters and 4,096 mappings. No new dependencies.

Validation: 282 Node tests and 2,335 operation tests passed, including 29 new cases covering the reported examples, overlapping keys, non-cascading replacements, Unicode, punctuation, empty values and malformed dictionaries. Three headless Chrome tests passed for preset selection, custom mappings and visible validation errors. ESLint and the production build passed.
