### PR TITLE
Reset x86 disassembly address between recipes

### DIFF
--- a/src/core/operations/DisassembleX86.mjs
+++ b/src/core/operations/DisassembleX86.mjs
@@ -152,9 +152,11 @@ class DisassembleX86 extends Operation {
                 break;
         }
 
+        // Short offsets leave address bits from previous runs in the disassembler.
+        // Set the full 64-bit address so every recipe starts at its requested offset.
         disassemble.SetBasePosition(
             parseHexAddress(codeSegment, "Code Segment (CS)", 4) + ":" +
-            parseHexAddress(offset, "Offset (IP)")
+            parseHexAddress(offset, "Offset (IP)", 16)
         );
         disassemble.setShowInstructionHex(showInstructionHex);
         disassemble.setShowInstructionPos(showInstructionPos);

--- a/tests/browser/04_disassemble.js
+++ b/tests/browser/04_disassemble.js
@@ -1,0 +1,50 @@
+/**
+ * Regression tests for disassembly address changes in a running worker.
+ *
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+const utils = require("./browserUtils.js");
+
+module.exports = {
+    before: browser => {
+        browser
+            .resizeWindow(1280, 800)
+            .url(browser.launchUrl)
+            .useCss()
+            .waitForElementNotPresent("#preloader", 10000)
+            .click("#auto-bake-label");
+    },
+
+    "Reset disassembly address between bakes": browser => {
+        utils.loadRecipe(browser, "Disassemble x86", "FFE0",
+            ["64", "Full x86 architecture", "16", "1234567812345678", false, true]);
+        browser.waitForElementVisible("#stale-indicator", 5000)
+            .waitForElementNotVisible("#snackbar-container", 6000);
+        utils.bake(browser);
+        browser.assert.textContains("#output-text .cm-content", "1234567812345678 JMP RAX");
+
+        browser.execute(() => {
+            window.disassemblyTestWorker = window.app.manager.worker.chefWorkers[0].worker;
+        });
+        utils.loadRecipe(browser, "Disassemble x86", "FFE0",
+            ["64", "Full x86 architecture", "16", "0", false, true]);
+        browser.waitForElementVisible("#stale-indicator", 5000)
+            .waitForElementNotVisible("#snackbar-container", 6000);
+        utils.bake(browser);
+        browser.assert.textContains("#output-text .cm-content", "0000000000000000 JMP RAX");
+
+        browser.execute(() => {
+            const sameWorker = window.disassemblyTestWorker ===
+                window.app.manager.worker.chefWorkers[0].worker;
+            delete window.disassemblyTestWorker;
+            return sameWorker;
+        }, [], ({value}) => {
+            browser.assert.strictEqual(value, true, "The same worker handles both recipes");
+        });
+    },
+
+    after: browser => {
+        browser.end();
+    }
+};

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -29,6 +29,7 @@ import "./tests/ToHTMLEntity.mjs";
 import "./tests/lib/BigIntUtils.mjs";
 import "./tests/lib/ChartsProtocolPrototypePollution.mjs";
 import "./tests/ParseQRCode.mjs";
+import "./tests/DisassembleX86.mjs";
 
 const testStatus = {
     allTestsPassing: true,

--- a/tests/node/tests/DisassembleX86.mjs
+++ b/tests/node/tests/DisassembleX86.mjs
@@ -1,0 +1,51 @@
+/**
+ * Disassemble x86 address reset tests.
+ *
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+import assert from "assert";
+import chef from "../../../src/node/index.mjs";
+import TestRegister from "../../lib/TestRegister.mjs";
+import it from "../assertionHandler.mjs";
+
+/**
+ * Run a new recipe against the shared disassembler.
+ *
+ * @param {string} mode
+ * @param {string} offset
+ * @param {string} [input="FFE0"]
+ * @returns {Promise<string>}
+ */
+async function disassemble(mode, offset, input = "FFE0") {
+    const result = await chef.bake(input, [{
+        op: "Disassemble x86",
+        args: [mode, "Full x86 architecture", "16", offset, false, true]
+    }]);
+    return result.toString();
+}
+
+TestRegister.addApiTests([
+    it("Disassemble x86: clear low address bits between 64-bit recipes", async () => {
+        assert.match(await disassemble("64", "00000000FFFFFFFF"), /^00000000FFFFFFFF JMP RAX/);
+        assert.match(await disassemble("64", "0"), /^0000000000000000 JMP RAX/);
+    }),
+    it("Disassemble x86: clear high address bits between 64-bit recipes", async () => {
+        assert.match(await disassemble("64", "1234567800000010"), /^1234567800000010 JMP RAX/);
+        assert.match(await disassemble("64", "10000"), /^0000000000010000 JMP RAX/);
+    }),
+    it("Disassemble x86: clear low address bits between 32-bit recipes", async () => {
+        assert.match(await disassemble("32", "12345678"), /^12345678 JMP EAX/);
+        assert.match(await disassemble("32", "1"), /^00000001 JMP EAX/);
+    }),
+    it("Disassemble x86: reset address when switching bit modes", async () => {
+        await disassemble("64", "1234567812345678");
+        assert.match(await disassemble("16", "1234", "90"), /^0016:1234 NOP/);
+        assert.match(await disassemble("64", "0x10", "90"), /^0000000000000010 NOP/);
+    }),
+    it("Disassemble x86: preserve carry inside a recipe and reset on the next", async () => {
+        assert.strictEqual(await disassemble("64", "00000000FFFFFFFF", "9090"),
+            "00000000FFFFFFFF NOP\r\n0000000100000000 NOP\r\n");
+        assert.match(await disassemble("64", "0", "90"), /^0000000000000000 NOP/);
+    }),
+]);


### PR DESCRIPTION
**Description**

Pad the hexadecimal instruction offset to its full width before passing it to the disassembler. This clears address bits left by earlier recipes without changing the vendored decoder or the accepted address formats.

**Existing Issue**

Fixes #2107.

**Test Coverage**

- Five repeated-run regressions cover 32/64-bit offsets, switching bit modes and address carry. All five fail before the fix.
- `npm test`: 284 Node API tests and 2,309 operation tests passed.
- Browser regression passed against the production build in Chrome 152, confirming both recipes use the same worker.
- `npm run lint` and `npm run build` passed.
