### PR TITLE
Add optional JSON output to Parse URI

### DIFF
--- a/src/core/operations/ParseURI.mjs
+++ b/src/core/operations/ParseURI.mjs
@@ -20,11 +20,17 @@ class ParseURI extends Operation {
 
         this.name = "Parse URI";
         this.module = "URL";
-        this.description = "Pretty prints complicated Uniform Resource Identifier (URI) strings for ease of reading. Particularly useful for Uniform Resource Locators (URLs) with a lot of arguments.";
+        this.description = "Pretty prints complicated Uniform Resource Identifier (URI) strings for ease of reading. Particularly useful for Uniform Resource Locators (URLs) with a lot of arguments.<br><br>Enable Output as JSON for structured output. Query parameter values are arrays, preserving repeated parameters and empty values.";
         this.infoURL = "https://wikipedia.org/wiki/Uniform_Resource_Identifier";
         this.inputType = "string";
         this.outputType = "string";
-        this.args = [];
+        this.args = [
+            {
+                name: "Output as JSON",
+                type: "boolean",
+                value: false
+            }
+        ];
     }
 
     /**
@@ -34,6 +40,26 @@ class ParseURI extends Operation {
      */
     run(input, args) {
         const uri = url.parse(input, false);
+
+        if (args[0]) {
+            const result = {};
+            for (const [key, value] of [
+                ["Protocol", uri.protocol], ["Auth", uri.auth], ["Hostname", uri.hostname],
+                ["Port", uri.port], ["Path name", uri.pathname]
+            ]) {
+                if (value) result[key] = value;
+            }
+            if (uri.query) {
+                const parameters = Object.create(null);
+                for (const [key, value] of new URLSearchParams(uri.query)) {
+                    if (!Object.prototype.hasOwnProperty.call(parameters, key)) parameters[key] = [];
+                    parameters[key].push(value);
+                }
+                result.Arguments = parameters;
+            }
+            if (uri.hash) result.Hash = uri.hash;
+            return JSON.stringify(result, null, 4);
+        }
 
         let output = "";
 

--- a/tests/browser/04_uri_json.js
+++ b/tests/browser/04_uri_json.js
@@ -1,0 +1,54 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+const utils = require("./browserUtils.js");
+
+/**
+ * Load a fresh page to avoid input-worker messages from a previous recipe.
+ * @param {Browser} browser
+ * @param {Object[]} recipe
+ * @param {string} input
+ * @param {string} expected
+ * @param {string} marker
+ */
+function checkRecipe(browser, recipe, input, expected, marker=expected) {
+    browser.url("about:blank")
+        .url(browser.launchUrl + "#recipe=" + encodeURIComponent(JSON.stringify(recipe)))
+        .useCss()
+        .waitForElementNotPresent("#preloader", 10000)
+        .waitForElementPresent("#rec-list li.operation", 10000)
+        .execute(() => {
+            const automatic = document.getElementById("auto-bake");
+            if (automatic && automatic.checked) document.getElementById("auto-bake-label").click();
+        })
+        .click("#input-text .cm-content")
+        .sendKeys("#input-text .cm-content", input);
+    browser.expect.element("#input-text .cm-content").text.to.equal(input).before(10000);
+    utils.bake(browser);
+    browser.expect.element("#output-text .cm-content").text.to.contain(marker).before(10000);
+    utils.expectOutput(browser, expected);
+}
+
+module.exports = {
+    "JSON preserves repeated query parameters": browser => {
+        checkRecipe(browser, [{op: "Parse URI", args: [true]}],
+            "https://example.com/?q=one&q=two", JSON.stringify({
+                Protocol: "https:", Hostname: "example.com", "Path name": "/",
+                Arguments: {q: ["one", "two"]}
+            }, null, 4), '"two"');
+    },
+
+    "Default output remains text": browser => {
+        checkRecipe(browser, [{op: "Parse URI", args: []}], "/path?q=test",
+            "Path name:\t/path\nArguments:\n\tq = test\n", "q = test");
+    },
+
+    "JSON query values retain literal markup": browser => {
+        checkRecipe(browser, [{op: "Parse URI", args: [true]}], "/?q=%3Cscript%3E",
+            JSON.stringify({"Path name": "/", Arguments: {q: ["<script>"]}}, null, 4), "<script>");
+    },
+
+    after: browser => browser.end()
+};

--- a/tests/operations/tests/ParseURI.mjs
+++ b/tests/operations/tests/ParseURI.mjs
@@ -1,0 +1,137 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        "name": "Parse URI: default text",
+        "input": "https://example.com/path?q=test",
+        "expectedOutput": "Protocol:\thttps:\nHostname:\texample.com\nPath name:\t/path\nArguments:\n\tq = test\n",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": []
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: text repeated parameters",
+        "input": "https://example.com/?q=one&q=two",
+        "expectedOutput": "Protocol:\thttps:\nHostname:\texample.com\nPath name:\t/\nArguments:\n\tq = one,two\n",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    false
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: all URI parts",
+        "input": "https://user:pass@example.com:8443/path?q=one#section",
+        "expectedOutput": "{\n    \"Protocol\": \"https:\",\n    \"Auth\": \"user:pass\",\n    \"Hostname\": \"example.com\",\n    \"Port\": \"8443\",\n    \"Path name\": \"/path\",\n    \"Arguments\": {\n        \"q\": [\n            \"one\"\n        ]\n    },\n    \"Hash\": \"#section\"\n}",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    true
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: repeated parameters",
+        "input": "https://example.com/?q=one&q=two&x=3",
+        "expectedOutput": "{\n    \"Protocol\": \"https:\",\n    \"Hostname\": \"example.com\",\n    \"Path name\": \"/\",\n    \"Arguments\": {\n        \"q\": [\n            \"one\",\n            \"two\"\n        ],\n        \"x\": [\n            \"3\"\n        ]\n    }\n}",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    true
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: empty and escaped values",
+        "input": "/search?empty=&flag&q=a+b&q=%26%3D&%E2%9C%93=%F0%9F%99%82",
+        "expectedOutput": "{\n    \"Path name\": \"/search\",\n    \"Arguments\": {\n        \"empty\": [\n            \"\"\n        ],\n        \"flag\": [\n            \"\"\n        ],\n        \"q\": [\n            \"a b\",\n            \"&=\"\n        ],\n        \"✓\": [\n            \"🙂\"\n        ]\n    }\n}",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    true
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: prototype keys",
+        "input": "/?__proto__=a&constructor=b&toString=c&__proto__=d",
+        "expectedOutput": "{\n    \"Path name\": \"/\",\n    \"Arguments\": {\n        \"__proto__\": [\n            \"a\",\n            \"d\"\n        ],\n        \"constructor\": [\n            \"b\"\n        ],\n        \"toString\": [\n            \"c\"\n        ]\n    }\n}",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    true
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: relative URI",
+        "input": "/path#hash",
+        "expectedOutput": "{\n    \"Path name\": \"/path\",\n    \"Hash\": \"#hash\"\n}",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    true
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: empty URI",
+        "input": "",
+        "expectedOutput": "{}",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    true
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: queryless URL",
+        "input": "https://example.com",
+        "expectedOutput": "{\n    \"Protocol\": \"https:\",\n    \"Hostname\": \"example.com\",\n    \"Path name\": \"/\"\n}",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    true
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Parse URI: invalid percent escape",
+        "input": "/?q=%zz",
+        "expectedOutput": "{\n    \"Path name\": \"/\",\n    \"Arguments\": {\n        \"q\": [\n            \"%zz\"\n        ]\n    }\n}",
+        "recipeConfig": [
+            {
+                "op": "Parse URI",
+                "args": [
+                    true
+                ]
+            }
+        ]
+    }
+]);


### PR DESCRIPTION
Fixes #1756.

Add an opt-in JSON output while retaining the existing text output by default. Query parameters are arrays, preserving repeated values, empty values and literal prototype-named keys.

Validation: 279 Node tests, 2319 operation tests and three production-browser tests passed. ESLint and the production build passed. No dependencies added.
