### PR TITLE
Add fixed-width integer packing and unpacking

### DIFF
--- a/src/core/config/Categories.json
+++ b/src/core/config/Categories.json
@@ -14,6 +14,8 @@
             "From Charcode",
             "To Decimal",
             "From Decimal",
+            "Pack Integers",
+            "Unpack Integers",
             "To Float",
             "From Float",
             "To Binary",

--- a/src/core/lib/IntegerPacking.mjs
+++ b/src/core/lib/IntegerPacking.mjs
@@ -1,0 +1,19 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import OperationError from "../errors/OperationError.mjs";
+
+/**
+ * Parse a supported integer width, including a custom editable option.
+ * @param {string} size
+ * @returns {number} The number of bytes in each integer.
+ */
+export function integerByteWidth(size) {
+    const bits = Number(size);
+    if (!/^\d+$/.test(String(size)) || !Number.isInteger(bits) || bits < 8 || bits > 4096 || bits % 8 !== 0) {
+        throw new OperationError("Size in bits must be a multiple of 8 from 8 to 4096.");
+    }
+    return bits / 8;
+}

--- a/src/core/operations/PackIntegers.mjs
+++ b/src/core/operations/PackIntegers.mjs
@@ -1,0 +1,67 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import { parseBigInt } from "../lib/BigIntUtils.mjs";
+import { toHex } from "../lib/Hex.mjs";
+import { integerByteWidth } from "../lib/IntegerPacking.mjs";
+
+/**
+ * Pack fixed-width integers without losing large-integer precision.
+ */
+class PackIntegers extends Operation {
+    /**
+     * PackIntegers constructor.
+     */
+    constructor() {
+        super();
+        this.name = "Pack Integers";
+        this.module = "Default";
+        this.description = "Packs decimal or 0x-prefixed hexadecimal integers into fixed-width binary words. Negative decimal values use two's complement; positive values may use the full unsigned range. Values outside that range are rejected rather than truncated.<br><br>Size must be a multiple of 8 from 8 to 4096 bits. Custom separators are literal strings; surrounding whitespace on each number is ignored. An empty separator treats the input as one integer. Raw output preserves binary bytes. Packed data is limited to 64 MiB. Use Unpack Integers for the inverse operation.";
+        this.inputType = "string";
+        this.outputType = "ArrayBuffer";
+        this.args = [
+            {name: "Size in bits", type: "editableOptionShort", value: ["8", "16", "32", "64"], defaultIndex: 2},
+            {name: "Separator", type: "binaryShortString", value: ","},
+            {name: "Output format", type: "option", value: ["Raw", "Hex"]},
+            {name: "Endianness", type: "option", value: ["Big endian", "Little endian"]}
+        ];
+    }
+
+    /**
+     * @param {string} input
+     * @param {Object[]} args
+     * @returns {ArrayBuffer|string}
+     */
+    run(input, args) {
+        const [size, separator, format, endian] = args,
+            width = integerByteWidth(size),
+            tokens = input.trim() === "" ? [] : separator === "" ? [input] : input.split(separator);
+        if (tokens.length * width > 64 * 1024 * 1024) {
+            throw new OperationError("Packed output must not exceed 64 MiB.");
+        }
+        const bytes = new Uint8Array(tokens.length * width),
+            modulus = 1n << BigInt(width * 8),
+            minimum = -(modulus >> 1n);
+        for (let index = 0; index < tokens.length; index++) {
+            let value = parseBigInt(tokens[index], `Integer at position ${index + 1}`);
+            if (value < minimum || value >= modulus) {
+                throw new OperationError(`Integer at position ${index + 1} does not fit in ${width * 8} bits.`);
+            }
+            if (value < 0n) value += modulus;
+            for (let offset = 0; offset < width; offset++) {
+                const target = endian === "Little endian" ? offset : width - offset - 1;
+                bytes[index * width + target] = Number(value & 255n);
+                value >>= 8n;
+            }
+        }
+        this.outputType = format === "Hex" ? "string" : "ArrayBuffer";
+        this.presentType = this.outputType;
+        return format === "Hex" ? toHex(bytes, " ") : bytes.buffer;
+    }
+}
+
+export default PackIntegers;

--- a/src/core/operations/UnpackIntegers.mjs
+++ b/src/core/operations/UnpackIntegers.mjs
@@ -1,0 +1,70 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import Operation from "../Operation.mjs";
+import OperationError from "../errors/OperationError.mjs";
+import Utils from "../Utils.mjs";
+import { fromHex } from "../lib/Hex.mjs";
+import { integerByteWidth } from "../lib/IntegerPacking.mjs";
+
+/**
+ * Unpack fixed-width binary words to exact decimal integers.
+ */
+class UnpackIntegers extends Operation {
+    /**
+     * UnpackIntegers constructor.
+     */
+    constructor() {
+        super();
+        this.name = "Unpack Integers";
+        this.module = "Default";
+        this.description = "Unpacks fixed-width binary words into decimal integers without loss of precision. Enable Signed to interpret two's-complement values. Size must be a multiple of 8 from 8 to 4096 bits. Input must contain complete words.<br><br>Hex input accepts hexadecimal byte pairs with optional whitespace. Raw input uses the bytes directly. The output separator is a literal string. Use Pack Integers for the inverse operation.";
+        this.inputType = "ArrayBuffer";
+        this.outputType = "string";
+        this.args = [
+            {name: "Size in bits", type: "editableOptionShort", value: ["8", "16", "32", "64"], defaultIndex: 2},
+            {name: "Signed", type: "boolean", value: false},
+            {name: "Separator", type: "binaryShortString", value: ", "},
+            {name: "Input format", type: "option", value: ["Raw", "Hex"]},
+            {name: "Endianness", type: "option", value: ["Big endian", "Little endian"]}
+        ];
+    }
+
+    /**
+     * @param {ArrayBuffer} input
+     * @param {Object[]} args
+     * @returns {string}
+     */
+    run(input, args) {
+        const [size, signed, separator, format, endian] = args,
+            width = integerByteWidth(size);
+        let bytes = new Uint8Array(input);
+        if (format === "Hex") {
+            const hex = Utils.arrayBufferToStr(input, false).replace(/\s+/g, "");
+            if (!/^(?:[0-9a-f]{2})*$/i.test(hex)) {
+                throw new OperationError("Hex input must contain complete hexadecimal byte pairs separated only by whitespace.");
+            }
+            bytes = new Uint8Array(fromHex(hex));
+        }
+        if (bytes.length % width !== 0) {
+            throw new OperationError(`Input length must be a multiple of ${width} bytes.`);
+        }
+        const output = [],
+            modulus = 1n << BigInt(width * 8),
+            signBit = modulus >> 1n;
+        for (let start = 0; start < bytes.length; start += width) {
+            let value = 0n;
+            for (let offset = 0; offset < width; offset++) {
+                const source = endian === "Little endian" ? width - offset - 1 : offset;
+                value = (value << 8n) | BigInt(bytes[start + source]);
+            }
+            if (signed && value >= signBit) value -= modulus;
+            output.push(value.toString());
+        }
+        return output.join(separator);
+    }
+}
+
+export default UnpackIntegers;

--- a/tests/browser/04_integer_packing.js
+++ b/tests/browser/04_integer_packing.js
@@ -1,0 +1,56 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+const utils = require("./browserUtils.js");
+
+/**
+ * Load a fresh page to avoid input-worker messages from a previous recipe.
+ * @param {Browser} browser
+ * @param {Object[]} recipe
+ * @param {string} input
+ * @param {string} expected
+ * @param {string} marker
+ */
+function checkRecipe(browser, recipe, input, expected, marker=expected) {
+    browser.url("about:blank")
+        .url(browser.launchUrl + "#recipe=" + encodeURIComponent(JSON.stringify(recipe)))
+        .useCss()
+        .waitForElementNotPresent("#preloader", 10000)
+        .waitForElementPresent("#rec-list li.operation", 10000)
+        .execute(() => {
+            const automatic = document.getElementById("auto-bake");
+            if (automatic && automatic.checked) document.getElementById("auto-bake-label").click();
+        })
+        .click("#input-text .cm-content")
+        .sendKeys("#input-text .cm-content", input);
+    browser.expect.element("#input-text .cm-content").text.to.equal(input).before(10000);
+    utils.bake(browser);
+    browser.expect.element("#output-text .cm-content").text.to.contain(marker).before(10000);
+    utils.expectOutput(browser, expected);
+}
+
+module.exports = {
+    "Packing matches the requested byte sequence": browser => {
+        checkRecipe(browser, [{op: "Pack Integers", args: ["32", ",", "Hex", "Big endian"]}],
+            "19022842, 1234567", "01 22 43 fa 00 12 d6 87");
+    },
+
+    "Raw bytes retain signed 64-bit precision": browser => {
+        const input = "-9223372036854775808, 9223372036854775807";
+        checkRecipe(browser, [
+            {op: "Pack Integers", args: ["64", ",", "Raw", "Little endian"]},
+            {op: "Unpack Integers", args: ["64", true, ", ", "Raw", "Little endian"]}
+        ], input, input);
+    },
+
+    "An incomplete word reports its byte width": browser => {
+        checkRecipe(browser, [
+            {op: "From Hex", args: ["Auto"]},
+            {op: "Unpack Integers", args: ["32", false, ", ", "Raw", "Big endian"]}
+        ], "ff", "Input length must be a multiple of 4 bytes.");
+    },
+
+    after: browser => browser.end()
+};

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -24,6 +24,7 @@ import "./tests/Dish.mjs";
 import "./tests/Operation.mjs";
 import "./tests/NodeDish.mjs";
 import "./tests/Utils.mjs";
+import "./tests/IntegerPacking.mjs";
 import "./tests/Categories.mjs";
 import "./tests/ToHTMLEntity.mjs";
 import "./tests/lib/BigIntUtils.mjs";

--- a/tests/node/tests/IntegerPacking.mjs
+++ b/tests/node/tests/IntegerPacking.mjs
@@ -1,0 +1,59 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import assert from "assert";
+import TestRegister from "../../lib/TestRegister.mjs";
+import it from "../assertionHandler.mjs";
+import PackIntegers from "../../../src/core/operations/PackIntegers.mjs";
+import UnpackIntegers from "../../../src/core/operations/UnpackIntegers.mjs";
+import chef from "../../../src/node/index.mjs";
+
+TestRegister.addApiTests([
+    ...["Big endian", "Little endian"].map(endian =>
+        it(`Integer packing: 64-bit bytes agree with DataView in ${endian}`, () => {
+            const values = [0n, 1n, 255n, 65536n, 9007199254740993n, (1n << 63n) - 1n, 1n << 63n, (1n << 64n) - 1n];
+            const expected = new ArrayBuffer(values.length * 8);
+            const view = new DataView(expected);
+            values.forEach((value, index) => view.setBigUint64(index * 8, value, endian === "Little endian"));
+            const actual = new PackIntegers().run(values.join(","), ["64", ",", "Raw", endian]);
+            assert.deepStrictEqual(new Uint8Array(actual), new Uint8Array(expected));
+            assert.strictEqual(new UnpackIntegers().run(expected, ["64", false, ",", "Raw", endian]), values.join(","));
+        })),
+    ...[8, 24, 128, 4096].map(bits =>
+        it(`Integer packing: exact ${bits}-bit signed and unsigned boundaries`, () => {
+            const minimum = -(1n << BigInt(bits - 1));
+            const maximum = (1n << BigInt(bits)) - 1n;
+            const pack = new PackIntegers(), unpack = new UnpackIntegers();
+            for (const endian of ["Big endian", "Little endian"]) {
+                const packed = pack.run(`${minimum},-1,0,1`, [String(bits), ",", "Raw", endian]);
+                assert.strictEqual(unpack.run(packed, [String(bits), true, ",", "Raw", endian]), `${minimum},-1,0,1`);
+                const unsigned = pack.run(maximum.toString(), [String(bits), ",", "Raw", endian]);
+                assert.deepStrictEqual([...new Uint8Array(unsigned)], Array(bits / 8).fill(255));
+                assert.strictEqual(unpack.run(unsigned, [String(bits), false, ",", "Raw", endian]), maximum.toString());
+            }
+            assert.throws(() => pack.run((minimum - 1n).toString(), [String(bits), ",", "Raw", "Big endian"]), {type: "OperationError"});
+            assert.throws(() => pack.run((maximum + 1n).toString(), [String(bits), ",", "Raw", "Big endian"]), {type: "OperationError"});
+        })),
+    it("Integer packing: an operation can switch output format between runs", () => {
+        const pack = new PackIntegers();
+        assert.strictEqual(pack.run("255", ["8", ",", "Hex", "Big endian"]), "ff");
+        assert.strictEqual(pack.outputType, "string");
+        assert.strictEqual(pack.presentType, "string");
+        assert.deepStrictEqual(new Uint8Array(pack.run("255", ["8", ",", "Raw", "Big endian"])), new Uint8Array([255]));
+        assert.strictEqual(pack.outputType, "ArrayBuffer");
+        assert.strictEqual(pack.presentType, "ArrayBuffer");
+    }),
+    it("Integer packing: Node recipe retains binary values above 127", async () => {
+        const result = await chef.bake("0,255,128", [
+            {op: "Pack Integers", args: ["8", ",", "Raw", "Big endian"]},
+            {op: "Unpack Integers", args: ["8", false, ",", "Raw", "Big endian"]}
+        ]);
+        assert.strictEqual(result.toString(), "0,255,128");
+    }),
+    it("Integer packing: oversized outputs are rejected before allocation", () => {
+        const input = Array(131073).fill("0").join(",");
+        assert.throws(() => new PackIntegers().run(input, ["4096", ",", "Raw", "Big endian"]), /must not exceed 64 MiB/);
+    })
+]);

--- a/tests/operations/tests/PackIntegers.mjs
+++ b/tests/operations/tests/PackIntegers.mjs
@@ -1,0 +1,400 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        "name": "Pack Integers: issue example",
+        "input": "19022842, 1234567",
+        "expectedOutput": "01 22 43 fa 00 12 d6 87",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "32",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: little endian",
+        "input": "19022842, 1234567",
+        "expectedOutput": "fa 43 22 01 87 d6 12 00",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "32",
+                    ",",
+                    "Hex",
+                    "Little endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: signed bounds",
+        "input": "-128,-1,0,127,255",
+        "expectedOutput": "80 ff 00 7f ff",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: unsigned 64-bit precision",
+        "input": "18446744073709551615,9007199254740993",
+        "expectedOutput": "ff ff ff ff ff ff ff ff 00 20 00 00 00 00 00 01",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "64",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: custom 24-bit width",
+        "input": "16777215,-8388608",
+        "expectedOutput": "ff ff ff 80 00 00",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "24",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: literal separator",
+        "input": "1||2",
+        "expectedOutput": "00 01 00 02",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "16",
+                    "||",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: hex input integers",
+        "input": "0x012243fa, 0x12d687",
+        "expectedOutput": "01 22 43 fa 00 12 d6 87",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "32",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: empty",
+        "input": "",
+        "expectedOutput": "",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "32",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: zero bytes preserved",
+        "input": "0,255",
+        "expectedOutput": "00 ff",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Raw",
+                    "Big endian"
+                ]
+            },
+            {
+                "op": "To Hex",
+                "args": [
+                    "Space",
+                    0
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid size 0",
+        "input": "1",
+        "expectedOutput": "Size in bits must be a multiple of 8 from 8 to 4096.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "0",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid size 7",
+        "input": "1",
+        "expectedOutput": "Size in bits must be a multiple of 8 from 8 to 4096.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "7",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid size 12",
+        "input": "1",
+        "expectedOutput": "Size in bits must be a multiple of 8 from 8 to 4096.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "12",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid size 4097",
+        "input": "1",
+        "expectedOutput": "Size in bits must be a multiple of 8 from 8 to 4096.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "4097",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid size Infinity",
+        "input": "1",
+        "expectedOutput": "Size in bits must be a multiple of 8 from 8 to 4096.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "Infinity",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid size NaN",
+        "input": "1",
+        "expectedOutput": "Size in bits must be a multiple of 8 from 8 to 4096.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "NaN",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid size abc",
+        "input": "1",
+        "expectedOutput": "Size in bits must be a multiple of 8 from 8 to 4096.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "abc",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid size ",
+        "input": "1",
+        "expectedOutput": "Size in bits must be a multiple of 8 from 8 to 4096.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: overflow 256",
+        "input": "256",
+        "expectedOutput": "Integer at position 1 does not fit in 8 bits.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: overflow -129",
+        "input": "-129",
+        "expectedOutput": "Integer at position 1 does not fit in 8 bits.",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid integer 1.5",
+        "input": "1.5",
+        "expectedOutput": "Integer at position 1 must be decimal or hex (0x...)",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid integer 1e3",
+        "input": "1e3",
+        "expectedOutput": "Integer at position 1 must be decimal or hex (0x...)",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid integer 1x",
+        "input": "1x",
+        "expectedOutput": "Integer at position 1 must be decimal or hex (0x...)",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid integer ,1",
+        "input": ",1",
+        "expectedOutput": "Integer at position 1 must be decimal or hex (0x...)",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Pack Integers: invalid integer 1,",
+        "input": "1,",
+        "expectedOutput": "Integer at position 2 must be decimal or hex (0x...)",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "8",
+                    ",",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    }
+]);

--- a/tests/operations/tests/UnpackIntegers.mjs
+++ b/tests/operations/tests/UnpackIntegers.mjs
@@ -1,0 +1,239 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import TestRegister from "../../lib/TestRegister.mjs";
+
+TestRegister.addTests([
+    {
+        "name": "Unpack Integers: issue example",
+        "input": "01 22 43 fa 00 12 d6 87",
+        "expectedOutput": "19022842, 1234567",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "32",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: signed",
+        "input": "80 ff 00 7f",
+        "expectedOutput": "-128, -1, 0, 127",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "8",
+                    true,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: unsigned",
+        "input": "80 ff 00 7f",
+        "expectedOutput": "128, 255, 0, 127",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "8",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: little endian",
+        "input": "fa43220187d61200",
+        "expectedOutput": "19022842|1234567",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "32",
+                    false,
+                    "|",
+                    "Hex",
+                    "Little endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: signed 64-bit",
+        "input": "8000000000000000ffffffffffffffff7fffffffffffffff",
+        "expectedOutput": "-9223372036854775808, -1, 9223372036854775807",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "64",
+                    true,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: unsigned 64-bit",
+        "input": "ffffffffffffffff",
+        "expectedOutput": "18446744073709551615",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "64",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: empty",
+        "input": "",
+        "expectedOutput": "",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "32",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: incomplete word",
+        "input": "001122",
+        "expectedOutput": "Input length must be a multiple of 4 bytes.",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "32",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: invalid hex 0",
+        "input": "0",
+        "expectedOutput": "Hex input must contain complete hexadecimal byte pairs separated only by whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "8",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: invalid hex zz",
+        "input": "zz",
+        "expectedOutput": "Hex input must contain complete hexadecimal byte pairs separated only by whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "8",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: invalid hex 00-11",
+        "input": "00-11",
+        "expectedOutput": "Hex input must contain complete hexadecimal byte pairs separated only by whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "8",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: invalid hex 0x01",
+        "input": "0x01",
+        "expectedOutput": "Hex input must contain complete hexadecimal byte pairs separated only by whitespace.",
+        "recipeConfig": [
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "8",
+                    false,
+                    ", ",
+                    "Hex",
+                    "Big endian"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Unpack Integers: raw round trip",
+        "input": "-32768,32767,-1,0",
+        "expectedOutput": "-32768,32767,-1,0",
+        "recipeConfig": [
+            {
+                "op": "Pack Integers",
+                "args": [
+                    "16",
+                    ",",
+                    "Raw",
+                    "Little endian"
+                ]
+            },
+            {
+                "op": "Unpack Integers",
+                "args": [
+                    "16",
+                    true,
+                    ",",
+                    "Raw",
+                    "Little endian"
+                ]
+            }
+        ]
+    }
+]);


### PR DESCRIPTION
Fixes #2138.

Add Pack Integers and Unpack Integers with exact large-integer handling, signed decoding, custom byte-aligned widths, literal separators, both byte orders, and Raw/Hex formats. Reject overflow, malformed hexadecimal input and incomplete words. Keep output and presentation types consistent when changing formats.

Validation: 288 Node tests, 2346 operation tests and three production-browser tests passed. ESLint and the production build passed. No dependencies added.
