### PR TITLE
Restore lazy worker modules in standalone builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,20 @@ With these principles in mind, any changes or additions to CyberChef should keep
  - Standalone
  - Efficient
  - As small as possible
+
+## Testing standalone module loading
+
+The production ZIP can be extracted and opened through its versioned HTML file without a
+web server. Its `local-modules` directory contains source-string wrappers for the compiled
+operation modules. The document loads these on demand with classic script elements, then
+passes the source to the requesting worker. The worker executes a temporary blob URL and
+revokes it after loading. Hosted builds continue to import the normal `modules` files.
+
+Run `tests/browser/04_worker_modules.js` against both a hosted production build and the
+extracted HTML file by setting Nightwatch's `launch_url` to the corresponding HTTP or
+`file:` URL. Use normal browser security settings. The tests exercise certificate parsing
+and compression through the worker. The Node tests in `WorkerModules.mjs` cover shared
+loads, rejected module names, failures, retries and blob cleanup.
+
+These checks cover operation-module loading. Operations that load additional external
+assets may have separate offline requirements.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,8 +32,17 @@ module.exports = function (grunt) {
         "Creates a production-ready build. Use the --msg flag to add a compile message.",
         [
             "eslint", "clean:prod", "clean:config", "exec:generateConfig", "findModules", "webpack:web",
-            "copy:standalone", "zip:standalone", "clean:standalone", "calcDownloadHash", "chmod"
+            "copy:standalone", "standaloneModules", "zip:standalone", "clean:standalone", "calcDownloadHash", "chmod"
         ]);
+
+    grunt.registerTask("standaloneModules", "Package module source for local workers.", function () {
+        grunt.file.expand("build/prod/modules/*.js").forEach(file => {
+            const name = path.basename(file, ".js");
+            const source = grunt.file.read(file);
+            grunt.file.write(`build/prod/local-modules/${name}.js`,
+                `globalThis.CyberChefModuleSources[${JSON.stringify(name)}] = ${JSON.stringify(source)};\n`);
+        });
+    });
 
     grunt.registerTask("node",
         "Compiles CyberChef into a single NodeJS module.",
@@ -217,7 +226,7 @@ module.exports = function (grunt) {
             node: ["build/node/*"],
             config: ["src/core/config/OperationConfig.json", "src/core/config/modules/*", "src/code/operations/index.mjs"],
             nodeConfig: ["src/node/index.mjs", "src/node/config/OperationConfig.json"],
-            standalone: ["build/prod/CyberChef*.html"]
+            standalone: ["build/prod/CyberChef*.html", "build/prod/local-modules"]
         },
         eslint: {
             configs: ["*.{js,mjs}"],

--- a/src/core/ChefWorker.js
+++ b/src/core/ChefWorker.js
@@ -10,6 +10,7 @@ import Chef from "./Chef.mjs";
 import OperationConfig from "./config/OperationConfig.json" with { type: "json" };
 import OpModules from "./config/modules/OpModules.mjs";
 import loglevelMessagePrefix from "loglevel-message-prefix";
+import { createWorkerModuleLoader } from "./lib/WorkerModuleLoader.mjs";
 
 
 // Set up Chef instance
@@ -96,10 +97,9 @@ self.addEventListener("message", function(e) {
  * @param {Object} data
  */
 async function bake(data) {
-    // Ensure the relevant modules are loaded
-    self.loadRequiredModules(data.recipeConfig);
     try {
         self.inputNum = data.inputNum === undefined ? -1 : data.inputNum;
+        await self.loadRequiredModules(data.recipeConfig);
         const response = await self.chef.bake(
             data.input,          // The user's input
             data.recipeConfig,   // The configuration of the recipe
@@ -206,18 +206,7 @@ async function calculateHighlights(recipeConfig, direction, pos) {
  *
  * @param {Object} recipeConfig
  */
-self.loadRequiredModules = function(recipeConfig) {
-    recipeConfig.forEach(op => {
-        const module = self.OperationConfig[op.op].module;
-
-        if (!(module in OpModules)) {
-            log.info(`Loading ${module} module`);
-            self.sendStatusMessage(`Loading ${module} module`);
-            self.importScripts(`${self.docURL}/modules/${module}.js`); // lgtm [js/client-side-unvalidated-url-redirection]
-            self.sendStatusMessage("");
-        }
-    });
-};
+self.loadRequiredModules = createWorkerModuleLoader(self, OpModules, OperationConfig);
 
 
 /**

--- a/src/core/lib/Magic.mjs
+++ b/src/core/lib/Magic.mjs
@@ -372,7 +372,7 @@ class Magic {
         const dish = new Dish();
         dish.set(input, Dish.ARRAY_BUFFER);
 
-        if (isWorkerEnvironment()) self.loadRequiredModules(recipeConfig);
+        if (isWorkerEnvironment()) await self.loadRequiredModules(recipeConfig);
 
         const recipe = new Recipe(recipeConfig);
         try {

--- a/src/core/lib/WorkerModuleLoader.mjs
+++ b/src/core/lib/WorkerModuleLoader.mjs
@@ -1,0 +1,68 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+/**
+ * Create a module loader for a classic worker. Local builds receive bundled source
+ * from the document because blob workers cannot import file URLs directly.
+ * @param {WorkerGlobalScope} worker
+ * @param {Object} modules
+ * @param {Object} operationConfig
+ * @returns {Function}
+ */
+export function createWorkerModuleLoader(worker, modules, operationConfig) {
+    const pending = new Map(), loading = new Map();
+    worker.addEventListener("message", ({data}) => {
+        if (data.action !== "moduleSource" || !pending.has(data.data.module)) return;
+        const request = pending.get(data.data.module);
+        pending.delete(data.data.module);
+        if (data.data.error) request.reject(new Error(data.data.error));
+        else request.resolve(data.data.source);
+    });
+
+    /**
+     * Load one module, sharing an in-flight request between simultaneous recipes.
+     * @param {string} name
+     * @returns {Promise}
+     */
+    async function load(name) {
+        if (Object.hasOwn(modules, name)) return;
+        if (loading.has(name)) return loading.get(name);
+        const promise = (async () => {
+            worker.sendStatusMessage(`Loading ${name} module`);
+            try {
+                if (worker.docURL.startsWith("file:")) {
+                    const source = await new Promise((resolve, reject) => {
+                        pending.set(name, {resolve, reject});
+                        worker.postMessage({action: "loadModule", data: {module: name}});
+                    });
+                    const url = worker.URL.createObjectURL(new worker.Blob([source], {type: "text/javascript"}));
+                    try {
+                        worker.importScripts(url);
+                    } finally {
+                        worker.URL.revokeObjectURL(url);
+                    }
+                } else {
+                    worker.importScripts(`${worker.docURL}/modules/${name}.js`);
+                }
+                if (!Object.hasOwn(modules, name)) throw new Error(`Module ${name} did not load.`);
+            } finally {
+                worker.sendStatusMessage("");
+            }
+        })();
+        loading.set(name, promise);
+        try {
+            await promise;
+        } finally {
+            loading.delete(name);
+        }
+    }
+
+    return async recipeConfig => {
+        for (const operation of recipeConfig) {
+            if (!Object.hasOwn(operationConfig, operation.op)) throw new Error(`Unknown operation: ${operation.op}`);
+            await load(operationConfig[operation.op].module);
+        }
+    };
+}

--- a/src/web/LocalModuleLoader.mjs
+++ b/src/web/LocalModuleLoader.mjs
@@ -1,0 +1,68 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import OperationConfig from "../core/config/OperationConfig.json" with { type: "json" };
+
+const MODULE_NAMES = new Set(Object.values(OperationConfig).map(operation => operation.module));
+let localLoader;
+
+/**
+ * Load trusted standalone module source through a classic script element.
+ * The generated files only publish source strings; operations still run in workers.
+ */
+export class LocalModuleLoader {
+    /**
+     * @param {Document} page
+     */
+    constructor(page) {
+        this.page = page;
+        this.cache = new Map();
+        this.sources = page.defaultView.CyberChefModuleSources ||= Object.create(null);
+    }
+
+    /**
+     * @param {string} name
+     * @returns {Promise<string>}
+     */
+    async load(name) {
+        if (this.page.location.protocol !== "file:" || !MODULE_NAMES.has(name) || !/^[A-Za-z0-9]+$/.test(name)) {
+            throw new Error("Invalid local module request.");
+        }
+        if (!this.cache.has(name)) {
+            const promise = new Promise((resolve, reject) => {
+                const script = this.page.createElement("script");
+                const finish = error => {
+                    clearTimeout(timer);
+                    script.remove();
+                    const source = this.sources[name];
+                    delete this.sources[name];
+                    if (error || typeof source !== "string") reject(new Error(`Unable to load local ${name} module.`));
+                    else resolve(source);
+                };
+                const timer = setTimeout(() => finish(true), 30000);
+                script.onload = () => finish(false);
+                script.onerror = () => finish(true);
+                script.src = new URL(`local-modules/${name}.js`, this.page.location.href).href;
+                this.page.head.appendChild(script);
+            });
+            this.cache.set(name, promise);
+            promise.catch(() => this.cache.delete(name));
+        }
+        return this.cache.get(name);
+    }
+}
+
+/**
+ * Reply only to the worker that requested a module, including load failures.
+ * @param {Worker} worker
+ * @param {string} name
+ */
+export function replyWithLocalModule(worker, name) {
+    localLoader ||= new LocalModuleLoader(document);
+    localLoader.load(name).then(
+        source => worker.postMessage({action: "moduleSource", data: {module: name, source}}),
+        error => worker.postMessage({action: "moduleSource", data: {module: name, error: error.message}})
+    );
+}

--- a/src/web/waiters/BackgroundWorkerWaiter.mjs
+++ b/src/web/waiters/BackgroundWorkerWaiter.mjs
@@ -4,6 +4,7 @@
  * @license Apache-2.0
  */
 
+import { replyWithLocalModule } from "../LocalModuleLoader.mjs";
 import ChefWorker from "worker-loader?inline=no-fallback!../../core/ChefWorker.js";
 
 /**
@@ -63,6 +64,9 @@ class BackgroundWorkerWaiter {
         log.debug(`Receiving '${r.action}' from BGChefWorker`);
 
         switch (r.action) {
+            case "loadModule":
+                replyWithLocalModule(e.target, r.data.module);
+                break;
             case "bakeComplete":
             case "bakeError":
                 if (typeof r.data.id !== "undefined") {

--- a/src/web/waiters/WorkerWaiter.mjs
+++ b/src/web/waiters/WorkerWaiter.mjs
@@ -5,6 +5,7 @@
  * @license Apache-2.0
  */
 
+import { replyWithLocalModule } from "../LocalModuleLoader.mjs";
 import ChefWorker from "worker-loader?inline=no-fallback!../../core/ChefWorker.js";
 import DishWorker from "worker-loader?inline=no-fallback!../workers/DishWorker.mjs";
 import { debounce } from "../../core/Utils.mjs";
@@ -195,6 +196,9 @@ class WorkerWaiter {
         const currentWorker = this.getChefWorker(inputNum);
 
         switch (r.action) {
+            case "loadModule":
+                replyWithLocalModule(e.target, r.data.module);
+                break;
             case "bakeComplete":
                 log.debug(`Bake ${inputNum} complete.`);
                 this.manager.timing.recordTime("bakeComplete", inputNum);

--- a/tests/browser/04_worker_modules.js
+++ b/tests/browser/04_worker_modules.js
@@ -1,0 +1,51 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+const utils = require("./browserUtils.js");
+
+// Certificate fixture shared with the Public Key from Certificate operation tests.
+const certificate = `-----BEGIN CERTIFICATE-----
+MIIBfTCCASegAwIBAgIUeisK5Nwss2DGg5PCs4uSxxXyyNkwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIUlNBIHRlc3QwHhcNMjExMTE5MTcyMDI2WhcNMzExMTE3
+MTcyMDI2WjATMREwDwYDVQQDDAhSU0EgdGVzdDBcMA0GCSqGSIb3DQEBAQUAA0sA
+MEgCQQDyq9A6emHSLczn5Omu5muy+AReC53pTGCrW6Bi65OoobahT2RUSzXCYuvB
+757fLLTKz+dLeo6sFkNhIzHZI+n7AgMBAAGjUzBRMB0GA1UdDgQWBBRO+jvkqq5p
+pnQgwMMnRoun6e7eiTAfBgNVHSMEGDAWgBRO+jvkqq5ppnQgwMMnRoun6e7eiTAP
+BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA0EAR/5HAZM5qBhU/ezDUIFx
+gmUGoFbIb5kJD41YCnaSdrgWglh4He4melSs42G/oxBBjuCJ0bUpqWnLl+lJkv1z
+IA==
+-----END CERTIFICATE-----`;
+
+/**
+ * @param {Browser} browser
+ * @param {Array} recipe
+ * @param {string} input
+ * @param {string} expected
+ */
+function checkRecipe(browser, recipe, input, expected) {
+    browser.url("about:blank").url(browser.launchUrl + "#recipe=" + encodeURIComponent(JSON.stringify(recipe)))
+        .waitForElementNotPresent("#preloader", 10000)
+        .waitForElementPresent("#rec-list li.operation")
+        .sendKeys("#input-text .cm-content", input);
+    utils.bake(browser);
+    browser.expect.element("#output-text .cm-content").text.to.contain(expected).before(15000);
+}
+
+module.exports = {
+    before: browser => browser.resizeWindow(1280, 800),
+
+    "Parse a certificate from a lazy-loaded module": browser => {
+        checkRecipe(browser, [{op: "Parse X.509 certificate", args: ["PEM"]}], certificate,
+            "Serial number:");
+    },
+
+    "Load a compression module and run successive operations": browser => {
+        checkRecipe(browser, [{op: "Gzip", args: []}, {op: "Gunzip", args: []}], "module loading test",
+            "module loading test");
+        utils.expectOutput(browser, "module loading test");
+    },
+
+    after: browser => browser.end()
+};

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -24,6 +24,7 @@ import "./tests/Dish.mjs";
 import "./tests/Operation.mjs";
 import "./tests/NodeDish.mjs";
 import "./tests/Utils.mjs";
+import "./tests/WorkerModules.mjs";
 import "./tests/Categories.mjs";
 import "./tests/ToHTMLEntity.mjs";
 import "./tests/lib/BigIntUtils.mjs";

--- a/tests/node/tests/WorkerModules.mjs
+++ b/tests/node/tests/WorkerModules.mjs
@@ -1,0 +1,141 @@
+/**
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+import assert from "assert";
+import TestRegister from "../../lib/TestRegister.mjs";
+import it from "../assertionHandler.mjs";
+import { LocalModuleLoader } from "../../../src/web/LocalModuleLoader.mjs";
+import { createWorkerModuleLoader } from "../../../src/core/lib/WorkerModuleLoader.mjs";
+
+/**
+ * @returns {Object}
+ */
+function documentFixture() {
+    const scripts = [];
+    const page = {
+        location: {protocol: "file:", href: "file:///offline/CyberChef.html#recipe=test"},
+        defaultView: {},
+        createElement: () => ({remove() {
+            this.removed = true;
+        }}),
+        head: {appendChild: script => scripts.push(script)}
+    };
+    return {page, scripts, loader: new LocalModuleLoader(page)};
+}
+
+/**
+ * @param {string} protocol
+ * @returns {Object}
+ */
+function workerFixture(protocol="file:") {
+    const modules = {}, messages = [], imports = [], revoked = [], statuses = [];
+    const listeners = [];
+    const worker = {
+        docURL: protocol + "///offline",
+        addEventListener: (event, listener) => listeners.push(listener),
+        postMessage: message => messages.push(message),
+        sendStatusMessage: message => statuses.push(message),
+        Blob,
+        URL: {createObjectURL: () => "blob:module", revokeObjectURL: url => revoked.push(url)},
+        importScripts: url => {
+            imports.push(url); modules.PublicKey = {};
+        }
+    };
+    return {
+        worker, modules, messages, imports, revoked, statuses,
+        reply: data => listeners.forEach(listener => listener({data: {action: "moduleSource", data}})),
+        load: createWorkerModuleLoader(worker, modules, {Certificate: {module: "PublicKey"}})
+    };
+}
+
+TestRegister.addApiTests([
+    it("Local modules: share script loads and remove transient source", async () => {
+        const {page, scripts, loader} = documentFixture();
+        const first = loader.load("PublicKey"), second = loader.load("PublicKey");
+        assert.strictEqual(scripts.length, 1);
+        assert.strictEqual(scripts[0].src, "file:///offline/local-modules/PublicKey.js");
+        page.defaultView.CyberChefModuleSources.PublicKey = "trusted bundled source";
+        scripts[0].onload();
+        assert.deepStrictEqual(await Promise.all([first, second]), ["trusted bundled source", "trusted bundled source"]);
+        assert.strictEqual(await loader.load("PublicKey"), "trusted bundled source");
+        assert.strictEqual(scripts.length, 1);
+        assert.strictEqual(scripts[0].removed, true);
+        assert.strictEqual(page.defaultView.CyberChefModuleSources.PublicKey, undefined);
+    }),
+    it("Local modules: reject unknown names and remote document requests", async () => {
+        const {page, scripts, loader} = documentFixture();
+        for (const name of ["../PublicKey", "__proto__", "constructor", "https://example.com/code", "Unknown"]) {
+            await assert.rejects(loader.load(name), /Invalid local module request/);
+        }
+        page.location.protocol = "https:";
+        await assert.rejects(loader.load("PublicKey"), /Invalid local module request/);
+        assert.strictEqual(scripts.length, 0);
+    }),
+    it("Local modules: failed files can be retried", async () => {
+        const {page, scripts, loader} = documentFixture();
+        const failed = assert.rejects(loader.load("PublicKey"), /Unable to load local PublicKey/);
+        scripts[0].onerror();
+        await failed;
+        const success = loader.load("PublicKey");
+        page.defaultView.CyberChefModuleSources.PublicKey = "source";
+        scripts[1].onload();
+        assert.strictEqual(await success, "source");
+    }),
+    it("Local modules: reject a script without its source payload", async () => {
+        const {scripts, loader} = documentFixture();
+        const failed = assert.rejects(loader.load("PublicKey"), /Unable to load local/);
+        scripts[0].onload();
+        await failed;
+    }),
+    it("Worker modules: hosted builds retain direct imports", async () => {
+        const fixture = workerFixture("https:");
+        await fixture.load([{op: "Certificate"}]);
+        await fixture.load([{op: "Certificate"}]);
+        assert.deepStrictEqual(fixture.imports, ["https:///offline/modules/PublicKey.js"]);
+        assert.deepStrictEqual(fixture.messages, []);
+    }),
+    it("Worker modules: await source, share requests and revoke blobs", async () => {
+        const fixture = workerFixture();
+        const first = fixture.load([{op: "Certificate"}]), second = fixture.load([{op: "Certificate"}]);
+        assert.deepStrictEqual(fixture.imports, []);
+        assert.strictEqual(fixture.messages.length, 1);
+        fixture.reply({module: "PublicKey", source: "source"});
+        await Promise.all([first, second]);
+        assert.deepStrictEqual(fixture.imports, ["blob:module"]);
+        assert.deepStrictEqual(fixture.revoked, ["blob:module"]);
+        assert.strictEqual(fixture.statuses.at(-1), "");
+    }),
+    it("Worker modules: forward failures and permit retry", async () => {
+        const fixture = workerFixture();
+        const failed = assert.rejects(fixture.load([{op: "Certificate"}]), /Unavailable/);
+        fixture.reply({module: "PublicKey", error: "Unavailable"});
+        await failed;
+        const success = fixture.load([{op: "Certificate"}]);
+        fixture.reply({module: "PublicKey", source: "source"});
+        await success;
+        assert.strictEqual(fixture.messages.length, 2);
+    }),
+    it("Worker modules: release blobs after an import failure", async () => {
+        const fixture = workerFixture();
+        fixture.worker.importScripts = () => {
+            throw new Error("Invalid bundle");
+        };
+        const failed = assert.rejects(fixture.load([{op: "Certificate"}]), /Invalid bundle/);
+        fixture.reply({module: "PublicKey", source: "source"});
+        await failed;
+        assert.deepStrictEqual(fixture.revoked, ["blob:module"]);
+        assert.strictEqual(fixture.statuses.at(-1), "");
+    }),
+    it("Worker modules: require successful registration", async () => {
+        const fixture = workerFixture("https:");
+        fixture.worker.importScripts = () => undefined;
+        await assert.rejects(fixture.load([{op: "Certificate"}]), /did not load/);
+    }),
+    it("Worker modules: reject unknown operations before requesting code", async () => {
+        const fixture = workerFixture();
+        await assert.rejects(fixture.load([{op: "constructor"}]), /Unknown operation/);
+        assert.deepStrictEqual(fixture.messages, []);
+    })
+]);


### PR DESCRIPTION
**Description**

Restores lazy-loaded operations when an extracted production ZIP is opened directly with `file:`. The baseline reproduced a blank certificate result and a blocked `importScripts(file:///.../modules/PublicKey.js)` call in Chrome 152.

The standalone ZIP now includes source-string wrappers for the existing compiled modules. The document loads a requested wrapper through a classic script element and returns its source to that worker, which imports a temporary blob URL. Foreground and background workers share cached source; module names are restricted to the operation configuration. Hosted imports remain unchanged and the wrapper files are removed from hosted build output.

Module loading is awaited before baking, including Magic's nested recipes. Failed loads reach the existing error output, and blob URLs are released after use. No new dependencies or relaxed browser security settings are required.

**Existing Issue**

Fixes #2785.

**Test Coverage**

- `npm run lint` and `npm test`: 289 Node API tests and 2,309 operation tests passed, including 10 new loader tests.
- `npm run build`: production build and ZIP generation passed.
- Two Chrome browser tests passed against both the hosted build and extracted `file:` HTML. They exercise certificate parsing and a compression round trip.
- The original file-mode certificate reproduction fails on the unchanged build and succeeds with this change. Removing the extracted PublicKey wrapper produces a readable error rather than a stuck load.
- Every wrapper was evaluated in an isolated Node VM and verified to publish source identical to its compiled module. Hosted output contains no `local-modules` directory.

Node 24 and Chrome 152 were used locally. Operations with additional external assets may have separate offline requirements; this change covers operation-module loading.

**Documentation**

Added standalone loading and browser-test instructions to CONTRIBUTING.md. No intended visual changes.
