### PR TITLE
Preserve binary input for RSA encryption

### DIFF
--- a/src/core/operations/RSAEncrypt.mjs
+++ b/src/core/operations/RSAEncrypt.mjs
@@ -6,6 +6,7 @@
 
 import Operation from "../Operation.mjs";
 import OperationError from "../errors/OperationError.mjs";
+import Utils from "../Utils.mjs";
 import forge from "node-forge";
 import { MD_ALGORITHMS } from "../lib/RSA.mjs";
 
@@ -24,7 +25,7 @@ class RSAEncrypt extends Operation {
         this.module = "Ciphers";
         this.description = "Encrypt a message with a PEM encoded RSA public key.";
         this.infoURL = "https://wikipedia.org/wiki/RSA_(cryptosystem)";
-        this.inputType = "string";
+        this.inputType = "byteArray";
         this.outputType = "string";
         this.args = [
             {
@@ -58,7 +59,7 @@ class RSAEncrypt extends Operation {
     }
 
     /**
-     * @param {string} input
+     * @param {byteArray} input
      * @param {Object[]} args
      * @returns {string}
      */
@@ -71,8 +72,9 @@ class RSAEncrypt extends Operation {
         try {
             // Load public key
             const pubKey = forge.pki.publicKeyFromPem(pemKey);
-            // https://github.com/digitalbazaar/forge/issues/465#issuecomment-271097600
-            const plaintextBytes = forge.util.encodeUtf8(input);
+            // node-forge expects a byte string. Preserve CyberChef's input bytes so
+            // RAW encryption and non-UTF-8 character encodings are not re-encoded.
+            const plaintextBytes = Utils.byteArrayToChars(input);
             // Encrypt message
             const eMsg = pubKey.encrypt(plaintextBytes, scheme, {md: MD_ALGORITHMS[md].create()});
             return eMsg;

--- a/tests/operations/tests/RSA.mjs
+++ b/tests/operations/tests/RSA.mjs
@@ -347,4 +347,23 @@ TestRegister.addTests([
             }
         ]
     },
+    {
+        name: "RSA Encrypt: RAW preserves binary input bytes",
+        input: "46 4c 80 ff",
+        expectedOutput: "3d5e1be4e95457390edde6800a3b34a09cf88d519396824d3df26cca134922c0927cab3136470b42e3462d98fadd1575f436851e04f9300b5b0fc087db0a7d509d22cf38670565efc55902389a9ed87022f7219bcace197485cbe6631b43e064cb41217e8f076fedfb92fea38ec5ea237b149d517f3fac88d31f050730adf9fe62b9baf316153f0ff2b5eec8881c6b2f4338ce73467dee8a77ab77647a76495b113c5ccb144c3897827fde5e5cc6d98b38d6ff172b3c03002e6cca60c73ce47fe3d1249749fc96c4c26f0c289b8a4a6d1aa93ad310c29f60d549d5606b2d2d7997f96de7b0a3aadc04407bf3d517f09dc5de9393c56013a5a471520afdd16931",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["Auto"]
+            },
+            {
+                "op": "RSA Encrypt",
+                "args": [PEM_PUB_2048, "RAW", "SHA-1"]
+            },
+            {
+                "op": "To Hex",
+                "args": ["None", 0]
+            }
+        ]
+    },
 ]);


### PR DESCRIPTION
Fixes #2066.

Preserves the original input bytes in RSA Encrypt instead of converting the input to text and encoding it as UTF-8 before encryption.

This fixes RAW RSA encryption for binary and non-ASCII input while retaining the existing OAEP and PKCS#1 behaviour.

Validation:
- Added a regression test for raw bytes containing values above 0x7f.
- All 21 RSA operation tests passed.
- 279 Node API tests passed.
- 2,310 operation tests passed.
- `npm run lint` passed.
- `npm run build` passed.
