### PR TITLE
Allow operations to be added by touch

### DIFF
--- a/src/web/waiters/OperationsWaiter.mjs
+++ b/src/web/waiters/OperationsWaiter.mjs
@@ -26,6 +26,7 @@ class OperationsWaiter {
 
         this.options = {};
         this.removeIntent = false;
+        this.operationPointerStart = null;
     }
 
     /**
@@ -185,6 +186,9 @@ class OperationsWaiter {
      */
     opListCreate(e) {
         this.manager.recipe.createSortableSeedList(e.target);
+        e.target.addEventListener("pointerdown", this.operationPointerDown.bind(this));
+        e.target.addEventListener("pointerup", this.operationPointerUp.bind(this));
+        e.target.addEventListener("pointercancel", this.operationPointerCancel.bind(this));
 
         // Populate ops total
         document.querySelector("#operations .title .op-count").innerText = Object.keys(this.app.operations).length;
@@ -220,6 +224,49 @@ class OperationsWaiter {
                     }
                 }, 50);
             });
+    }
+
+
+    /**
+     * Records the start of a touch interaction with an operation.
+     *
+     * @param {PointerEvent} e
+     */
+    operationPointerDown(e) {
+        if (e.pointerType !== "touch") return;
+        const operation = e.target.closest("li.operation");
+        if (!operation || !e.currentTarget.contains(operation)) return;
+        this.operationPointerStart = {
+            pointerId: e.pointerId,
+            x: e.clientX,
+            y: e.clientY,
+            operation
+        };
+    }
+
+
+    /**
+     * Adds an operation when a touch interaction is a tap rather than a drag.
+     *
+     * @param {PointerEvent} e
+     */
+    operationPointerUp(e) {
+        const start = this.operationPointerStart;
+        this.operationPointerStart = null;
+        if (!start || e.pointerType !== "touch" || e.pointerId !== start.pointerId) return;
+
+        const operation = e.target.closest("li.operation");
+        if (operation !== start.operation || this.manager.recipe.dragInProgress) return;
+
+        const maxTapMovement = 10;
+        if (Math.hypot(e.clientX - start.x, e.clientY - start.y) > maxTapMovement) return;
+        this.manager.recipe.addOperation(operation.textContent);
+    }
+
+
+    /** Clear a cancelled touch interaction. */
+    operationPointerCancel() {
+        this.operationPointerStart = null;
     }
 
 

--- a/tests/browser/04_touch_operations.js
+++ b/tests/browser/04_touch_operations.js
@@ -1,0 +1,52 @@
+/**
+ * Regression tests for touch interaction with operations.
+ *
+ * @copyright Crown Copyright 2026
+ * @license Apache-2.0
+ */
+
+module.exports = {
+    before: browser => {
+        browser
+            .resizeWindow(480, 800)
+            .url(browser.launchUrl)
+            .useCss()
+            .waitForElementNotPresent("#preloader", 10000);
+    },
+
+    "Touch tap adds an operation without changing mouse clicks": browser => {
+        browser.execute(() => {
+            const operation = Array.from(document.querySelectorAll(".op-list li.operation"))
+                .find(el => el.textContent === "A1Z26 Cipher Decode");
+            const event = (type, pointerType, x, y) => new PointerEvent(type, {
+                bubbles: true,
+                pointerId: 7,
+                pointerType,
+                clientX: x,
+                clientY: y
+            });
+
+            operation.dispatchEvent(event("pointerdown", "touch", 10, 10));
+            operation.dispatchEvent(event("pointerup", "touch", 10, 10));
+            const afterTap = document.querySelectorAll("#rec-list li.operation").length;
+
+            operation.dispatchEvent(event("pointerdown", "mouse", 10, 10));
+            operation.dispatchEvent(event("pointerup", "mouse", 10, 10));
+            const afterMouse = document.querySelectorAll("#rec-list li.operation").length;
+
+            operation.dispatchEvent(event("pointerdown", "touch", 10, 10));
+            operation.dispatchEvent(event("pointerup", "touch", 30, 30));
+            const afterMove = document.querySelectorAll("#rec-list li.operation").length;
+            const recipeName = document.querySelector("#rec-list .op-title")?.textContent;
+
+            return {afterTap, afterMouse, afterMove, recipeName};
+        }, [], ({value}) => {
+            browser.expect(value.afterTap).to.equal(1);
+            browser.expect(value.afterMouse).to.equal(1);
+            browser.expect(value.afterMove).to.equal(1);
+            browser.expect(value.recipeName).to.equal("A1Z26 Cipher Decode");
+        });
+    },
+
+    after: browser => browser.end()
+};


### PR DESCRIPTION
Fixes #2456.

Adds touch-tap support to the operations list so mobile and touch-device users can add an operation without requiring drag-and-drop.

A short touch adds exactly one operation. Touch movement is treated as a drag, and normal mouse clicks remain unchanged to avoid duplicate additions.

Validation:
- Browser regression test passed in Chrome 152, covering tap, movement and mouse-click behaviour.
- 279 Node API tests passed.
- 2,309 operation tests passed.
- `npm run lint` passed.
- `npm run build` passed.
