### PR TITLE
Ignore non-object postMessage payloads

### DIFF
--- a/src/web/waiters/InputWaiter.mjs
+++ b/src/web/waiters/InputWaiter.mjs
@@ -1686,9 +1686,10 @@ class InputWaiter {
      */
     handlePostMessage(e) {
         log.debug(e);
-        if ("data" in e && "id" in e.data && "value" in e.data) {
-            if (e.data.id === "setInput") {
-                this.setInput(e.data.value);
+        const data = e?.data;
+        if (data !== null && typeof data === "object" && "id" in data && "value" in data) {
+            if (data.id === "setInput") {
+                this.setInput(data.value);
             }
         }
     }

--- a/tests/browser/01_io.js
+++ b/tests/browser/01_io.js
@@ -100,6 +100,24 @@ module.exports = {
             .click("#auto-bake-label");
     },
 
+    "Non-object postMessages are ignored": browser => {
+        browser.execute(function() {
+            window.cyberChefPostMessageErrors = [];
+            window.cyberChefPostMessageErrorHandler = function(e) {
+                window.cyberChefPostMessageErrors.push(e.message);
+            };
+            window.addEventListener("error", window.cyberChefPostMessageErrorHandler);
+            window.postMessage('{"args":{"frameIndex":0}}', "*");
+        });
+        browser.pause(100);
+        browser.execute(function() {
+            window.removeEventListener("error", window.cyberChefPostMessageErrorHandler);
+            return window.cyberChefPostMessageErrors;
+        }, [], function(result) {
+            browser.assert.deepEqual(result.value, []);
+        });
+    },
+
     "CodeMirror has loaded correctly": browser => {
         /* Editor has initialised */
         browser


### PR DESCRIPTION
Fixes #2054.

Guard the input `postMessage` handler before inspecting message fields so string and other non-object payloads cannot throw during startup. Valid `setInput` messages continue to update the input as before.

Validation:
- targeted Chrome browser regression for a string `postMessage` payload
- 279 Node API tests passed
- 2,309 operation tests passed
- `npm run lint`
- `npm run build`
