### PR TITLE
Skip UTF-7 encoding in default Magic brute force

### DIFF
--- a/src/core/lib/Magic.mjs
+++ b/src/core/lib/Magic.mjs
@@ -137,9 +137,10 @@ class Magic {
     /**
      * Generate various simple brute-forced encodings of the data (trucated to 100 bytes).
      *
+     * @param {boolean} [extLang=false] - Whether extensive language support is enabled.
      * @returns {Object[]} - The encoded data and an operation config to generate it.
      */
-    async bruteForce() {
+    async bruteForce(extLang=false) {
         const sample = new Uint8Array(this.inputBuffer).slice(0, 100);
         const results = [];
 
@@ -173,6 +174,10 @@ class Magic {
          */
         const testEnc = async op => {
             for (let i = 0; i < encodings.length; i++) {
+                if (!extLang && op === "Encode text" && encodings[i] === "UTF-7 (65000)") {
+                    continue;
+                }
+
                 const conf = {
                     op: op,
                     args: [encodings[i]]
@@ -301,7 +306,7 @@ class Magic {
 
         if (intensive) {
             // Run brute forcing of various types on the data and create a new branch for each option
-            const bfEncodings = await this.bruteForce();
+            const bfEncodings = await this.bruteForce(extLang);
 
             await Promise.all(bfEncodings.map(async enc => {
                 const magic = new Magic(enc.data, this.opCriteria, undefined),

--- a/tests/operations/tests/Magic.mjs
+++ b/tests/operations/tests/Magic.mjs
@@ -154,6 +154,28 @@ TestRegister.addTests([
         ]
     },
     {
+        name: "Magic: intensive mode excludes UTF-7 encode by default",
+        input: "\xff\xfe\xfd\xfc",
+        unexpectedMatch: /Encode_text\('UTF-7 \(65000\)'\)/,
+        recipeConfig: [
+            {
+                op: "Magic",
+                args: [1, true, false]
+            }
+        ]
+    },
+    {
+        name: "Magic: extensive language support allows UTF-7 encode",
+        input: "\xff\xfe\xfd\xfc",
+        expectedMatch: /Encode_text\('UTF-7 \(65000\)'\)/,
+        recipeConfig: [
+            {
+                op: "Magic",
+                args: [1, true, true]
+            }
+        ]
+    },
+    {
         name: "Magic: invalid zero A1Z26 values do not match",
         input: "0,0",
         unexpectedMatch: /A1Z26 Cipher Decode/,


### PR DESCRIPTION
**Description**
Stops intensive Magic from trying `Encode text` with UTF-7 by default, avoiding the reported false positives. UTF-7 encoding remains available when extensive language support is enabled.

**Existing Issue**
Fixes #2001.

**Screenshots**
N/A.

**Test Coverage**
Added regressions for both default and extensive-language modes. Full validation: 279 Node API tests and 2,311 operation tests passed; lint and production build passed.
