### PR TITLE
Isolate failing Magic detector patterns

### DIFF
--- a/src/core/lib/Magic.mjs
+++ b/src/core/lib/Magic.mjs
@@ -45,10 +45,15 @@ class Magic {
                 (inputEntropy < check.entropyRange[0] ||
                 inputEntropy > check.entropyRange[1]))
                 return;
-            // If the input doesn't match the pattern, move on
-            if (check.pattern &&
-                !check.pattern.test(this.inputStr))
-                return;
+            // If the input doesn't match the pattern, move on. Some regex engines can
+            // throw on pathological inputs, so isolate each detector from the rest of Magic.
+            if (check.pattern) {
+                try {
+                    if (!check.pattern.test(this.inputStr)) return;
+                } catch (err) {
+                    return;
+                }
+            }
 
             matches.push(check);
         });

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -27,6 +27,7 @@ import "./tests/Utils.mjs";
 import "./tests/Categories.mjs";
 import "./tests/ToHTMLEntity.mjs";
 import "./tests/lib/BigIntUtils.mjs";
+import "./tests/lib/Magic.mjs";
 import "./tests/lib/ChartsProtocolPrototypePollution.mjs";
 import "./tests/ParseQRCode.mjs";
 

--- a/tests/node/tests/lib/Magic.mjs
+++ b/tests/node/tests/lib/Magic.mjs
@@ -1,0 +1,27 @@
+import TestRegister from "../../../lib/TestRegister.mjs";
+import Magic from "../../../../src/core/lib/Magic.mjs";
+import it from "../../assertionHandler.mjs";
+import assert from "assert";
+
+TestRegister.addApiTests([
+    it("Magic: detector regex failures do not abort matching", () => {
+        const input = new TextEncoder().encode("test").buffer;
+        const criteria = [
+            {
+                op: "Failing detector",
+                pattern: {
+                    test: () => {
+                        throw new RangeError("Maximum call stack size exceeded");
+                    }
+                }
+            },
+            {
+                op: "Matching detector",
+                pattern: /test/
+            }
+        ];
+
+        const matches = new Magic(input, criteria).findMatchingInputOps();
+        assert.deepStrictEqual(matches.map(match => match.op), ["Matching detector"]);
+    })
+]);


### PR DESCRIPTION
**Description**
Isolates detector regex failures during Magic matching. If a browser regex engine throws on a pathological input, that detector is skipped and the remaining Magic checks continue instead of aborting the operation.

**Existing Issue**
Fixes #2698.

**Screenshots**
N/A.

**Test Coverage**
Added a regression confirming a failing detector does not prevent subsequent detectors from matching. Full validation: 280 Node API tests and 2,309 operation tests passed; lint and production build passed.
