### PR TITLE
Centralise contributor guidance in CONTRIBUTING.md

### DIFF
--- a/AI_MARKER
+++ b/AI_MARKER
@@ -1,0 +1,1 @@
+Prepared for manual review before pull request submission.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,35 @@
 # Contributing
 
-Take a look through the [Wiki pages](https://github.com/gchq/CyberChef/wiki) for guides on [compiling CyberChef](https://github.com/gchq/CyberChef/wiki/Getting-started) and [adding new operations](https://github.com/gchq/CyberChef/wiki/Adding-a-new-operation).
+This file is the source of truth for contributing to CyberChef.
 
-There are lots of opportunities to contribute to CyberChef. If you want ideas, take a look at any [Issues](https://github.com/gchq/CyberChef/issues) tagged with '[help wanted](https://github.com/gchq/CyberChef/labels/help%20wanted)'.
+There are lots of opportunities to contribute to CyberChef. If you want ideas, take a look at [issues tagged `help wanted`](https://github.com/gchq/CyberChef/labels/help%20wanted).
+
+## Development setup
+
+CyberChef requires Node.js 24 or 26. From the repository root:
+
+```bash
+npm install
+npm start
+```
+
+Useful development commands are:
+
+```bash
+npm run build
+npm run lint
+npm run lint:grammar
+npm test
+npm run testui
+```
+
+To scaffold a new operation, run:
+
+```bash
+npm run newop
+```
+
+New operations should include tests under `tests/operations/tests/` and a category entry in `src/core/config/Categories.json`.
 
 Before your contributions can be accepted, you must:
 
@@ -13,6 +40,14 @@ Before your contributions can be accepted, you must:
  - Submit a pull request.
 
 Please note that we will ***reject*** pull requests from the master branch of your fork owing to the mess it makes of our own working repositories and the extra work entailed.
+
+## Testing
+
+Bug fixes should include a regression test that fails before the fix and passes afterwards. New functionality should include tests for normal use and relevant edge cases.
+
+- Operation and Node API tests: `npm test`
+- Browser UI tests: `npm run testui`
+- Browser UI tests against the development server: `npm run testuidev`
 
 ## Coding conventions
 

--- a/README.md
+++ b/README.md
@@ -180,12 +180,7 @@ Please see the [CyberChef security policy](./SECURITY.md).
 
 ## Contributing
 
-Contributing a new operation to CyberChef is super easy! The quickstart script will walk you through the process. If you can write basic JavaScript, you can write a CyberChef operation.
-
-An installation walkthrough, how-to guides for adding new operations and themes, descriptions of the repository structure, available data types and coding conventions can all be found in the ["Contributing" wiki page](https://github.com/gchq/CyberChef/wiki/Contributing).
-
- - Push your changes to your fork.
- - Submit a pull request. If you are doing this for the first time, you will be prompted to sign the [GCHQ Contributor Licence Agreement](https://cla-assistant.io/gchq/CyberChef) via the CLA assistant on the pull request. This will also ask whether you are happy for GCHQ to contact you about a token of thanks for your contribution, or about job opportunities at GCHQ.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the current development setup, test commands, coding conventions, pull request requirements and guidance for adding operations.
 
 
 ## Licencing


### PR DESCRIPTION
**Description**
Makes `CONTRIBUTING.md` the in-repository source of truth for contributor guidance. It adds the supported development setup, common build/lint/test commands, operation scaffolding and testing expectations, then replaces the duplicated README guidance with a single link to `CONTRIBUTING.md`.

**Existing Issue**
Addresses #2337.

**Screenshots**
Not applicable.

**Test Coverage**
- Documentation-only change.
- `git diff --check`: passed.