### PR TITLE
Fix webpack path matching on Windows

### DIFF
--- a/AI_MARKER
+++ b/AI_MARKER
@@ -1,0 +1,1 @@
+Prepared for manual review before pull request submission.

--- a/tests/node/index.mjs
+++ b/tests/node/index.mjs
@@ -29,6 +29,7 @@ import "./tests/ToHTMLEntity.mjs";
 import "./tests/lib/BigIntUtils.mjs";
 import "./tests/lib/ChartsProtocolPrototypePollution.mjs";
 import "./tests/ParseQRCode.mjs";
+import "./tests/WebpackConfig.mjs";
 
 const testStatus = {
     allTestsPassing: true,

--- a/tests/node/tests/WebpackConfig.mjs
+++ b/tests/node/tests/WebpackConfig.mjs
@@ -1,0 +1,20 @@
+import TestRegister from "../../lib/TestRegister.mjs";
+import it from "../assertionHandler.mjs";
+import assert from "assert";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const webpackConfig = require("../../../webpack.config.js");
+
+TestRegister.addApiTests([
+    it("Webpack: Babel exclusion handles Windows node_modules paths", () => {
+        const javascriptRule = webpackConfig.module.rules.find(rule =>
+            rule.loader === "babel-loader"
+        );
+
+        assert(javascriptRule.exclude.test("C:\\repo\\node_modules\\lodash\\index.js"));
+        assert(!javascriptRule.exclude.test("C:\\repo\\node_modules\\crypto-api\\index.js"));
+        assert(!javascriptRule.exclude.test("C:\\repo\\node_modules\\bootstrap\\index.js"));
+        assert(javascriptRule.exclude.test("/repo/node_modules/lodash/index.js"));
+    }),
+]);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,7 +142,7 @@ module.exports = {
         rules: [
             {
                 test: /\.m?js$/,
-                exclude: /node_modules\/(?!crypto-api|bootstrap)/,
+                exclude: /node_modules[\\/](?!crypto-api|bootstrap)/,
                 options: {
                     configFile: path.resolve(__dirname, "babel.config.js"),
                     cacheDirectory: true,


### PR DESCRIPTION
**Description**
Makes the Babel `node_modules` exclusion match both POSIX and Windows path separators, so third-party modules are excluded correctly on Windows while `crypto-api` and `bootstrap` remain transpiled. Adds regression coverage for Windows and POSIX module paths.

**Existing Issue**
Addresses part of #2415.

**Screenshots**
Not applicable.

**Test Coverage**
- Focused webpack path assertions: passed.
- `npx eslint webpack.config.js tests/node/index.mjs tests/node/tests/WebpackConfig.mjs`: passed.
- `git diff --check`: passed.
