### PR TITLE
Mention Merge in Fork operation description

### DIFF
--- a/AI_MARKER
+++ b/AI_MARKER
@@ -1,0 +1,1 @@
+Prepared for manual review before pull request submission.

--- a/src/core/operations/Fork.mjs
+++ b/src/core/operations/Fork.mjs
@@ -22,7 +22,7 @@ class Fork extends Operation {
         this.name = "Fork";
         this.flowControl = true;
         this.module = "Default";
-        this.description = "Split the input data up based on the specified delimiter and run all subsequent operations on each branch separately.<br><br>For example, to decode multiple Base64 strings, enter them all on separate lines then add the 'Fork' and 'From Base64' operations to the recipe. Each string will be decoded separately.";
+        this.description = "Split the input data up based on the specified delimiter and run all subsequent operations on each branch separately. Use the 'Merge' operation to explicitly end a fork and continue with the combined output.<br><br>For example, to decode multiple Base64 strings, enter them all on separate lines then add the 'Fork' and 'From Base64' operations to the recipe. Each string will be decoded separately.";
         this.inputType = "string";
         this.outputType = "string";
         this.args = [


### PR DESCRIPTION
**Description**
Mentions the Merge operation in Fork's description so the paired flow-control operations are discoverable in both directions through the operation help/search text.

**Existing Issue**
Addresses #2069.

**Screenshots**
Not applicable.

**Test Coverage**
- Documentation/metadata-only change.
- `npx eslint src/core/operations/Fork.mjs`: passed.
- `git diff --check`: passed.
