### PR TITLE
Expose build version at /version.txt

### DIFF
--- a/AI_MARKER
+++ b/AI_MARKER
@@ -1,0 +1,1 @@
+Prepared with AI assistance in accordance with the repository contribution policy.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
         "Creates a production-ready build. Use the --msg flag to add a compile message.",
         [
             "eslint", "clean:prod", "clean:config", "exec:generateConfig", "findModules", "webpack:web",
-            "copy:standalone", "zip:standalone", "clean:standalone", "calcDownloadHash", "chmod"
+            "writeVersionEndpoint", "copy:standalone", "zip:standalone", "clean:standalone", "calcDownloadHash", "chmod"
         ]);
 
     grunt.registerTask("node",
@@ -73,6 +73,12 @@ module.exports = function (grunt) {
                     main: "./src/web/index.js"
                 }, moduleEntryPoints));
         });
+
+    grunt.registerTask("writeVersionEndpoint", "Write the package version for static deployments", function () {
+        grunt.file.mkdir("build/prod");
+        grunt.file.write("build/prod/version.txt", `${pkg.version}\n`);
+    });
+
 
     grunt.registerTask("calcDownloadHash", "Compute download hash", function () {
         const done = this.async();


### PR DESCRIPTION
**Description**
Adds a static `/version.txt` resource to production builds, generated directly from the `package.json` version. This gives deployment and monitoring scripts a simple endpoint for checking the running CyberChef version, and the file is included in release archives.

**Existing Issue**
Addresses #2070.

**Screenshots**
Not applicable.

**Test Coverage**
- `grunt writeVersionEndpoint`: passed and produced the current package version.
- `eslint Gruntfile.js`: passed.
- `git diff --check`: passed.
