### PR TITLE
Make RSA encryption and decryption binary-safe

### DIFF
--- a/src/core/operations/RSADecrypt.mjs
+++ b/src/core/operations/RSADecrypt.mjs
@@ -8,6 +8,7 @@ import Operation from "../Operation.mjs";
 import OperationError from "../errors/OperationError.mjs";
 import forge from "node-forge";
 import { MD_ALGORITHMS } from "../lib/RSA.mjs";
+import Utils from "../Utils.mjs";
 
 /**
  * RSA Decrypt operation
@@ -24,8 +25,8 @@ class RSADecrypt extends Operation {
         this.module = "Ciphers";
         this.description = "Decrypt an RSA encrypted message with a PEM encoded private key.";
         this.infoURL = "https://wikipedia.org/wiki/RSA_(cryptosystem)";
-        this.inputType = "string";
-        this.outputType = "string";
+        this.inputType = "byteArray";
+        this.outputType = "byteArray";
         this.args = [
             {
                 name: "RSA Private Key (PEM)",
@@ -63,9 +64,9 @@ class RSADecrypt extends Operation {
     }
 
     /**
-     * @param {string} input
+     * @param {byteArray} input
      * @param {Object[]} args
-     * @returns {string}
+     * @returns {byteArray}
      */
     run(input, args) {
         const [pemKey, password, scheme, md] = args;
@@ -74,8 +75,9 @@ class RSADecrypt extends Operation {
         }
         try {
             const privKey = forge.pki.decryptRsaPrivateKey(pemKey, password);
-            const dMsg = privKey.decrypt(input, scheme, {md: MD_ALGORITHMS[md].create()});
-            return forge.util.decodeUtf8(dMsg);
+            const encrypted = Utils.byteArrayToChars(input);
+            const dMsg = privKey.decrypt(encrypted, scheme, {md: MD_ALGORITHMS[md].create()});
+            return Utils.strToByteArray(dMsg);
         } catch (err) {
             throw new OperationError(err);
         }

--- a/src/core/operations/RSAEncrypt.mjs
+++ b/src/core/operations/RSAEncrypt.mjs
@@ -8,6 +8,7 @@ import Operation from "../Operation.mjs";
 import OperationError from "../errors/OperationError.mjs";
 import forge from "node-forge";
 import { MD_ALGORITHMS } from "../lib/RSA.mjs";
+import Utils from "../Utils.mjs";
 
 /**
  * RSA Encrypt operation
@@ -25,7 +26,7 @@ class RSAEncrypt extends Operation {
         this.description = "Encrypt a message with a PEM encoded RSA public key.";
         this.infoURL = "https://wikipedia.org/wiki/RSA_(cryptosystem)";
         this.inputType = "string";
-        this.outputType = "string";
+        this.outputType = "byteArray";
         this.args = [
             {
                 name: "RSA Public Key (PEM)",
@@ -75,7 +76,7 @@ class RSAEncrypt extends Operation {
             const plaintextBytes = forge.util.encodeUtf8(input);
             // Encrypt message
             const eMsg = pubKey.encrypt(plaintextBytes, scheme, {md: MD_ALGORITHMS[md].create()});
-            return eMsg;
+            return Utils.strToByteArray(eMsg);
         } catch (err) {
             if (err.message === "RSAES-OAEP input message length is too long.") {
                 throw new OperationError(`RSAES-OAEP input message length (${err.length}) is longer than the maximum allowed length (${err.maxLength}).`);

--- a/tests/operations/tests/RSA.mjs
+++ b/tests/operations/tests/RSA.mjs
@@ -48,6 +48,25 @@ DwIDAQAB
 
 TestRegister.addTests([
     {
+        name: "RSA Decrypt: binary OAEP/SHA-256 from hex",
+        input: "8ebbe3e4c6315eb6791b674e969d560a7600697b268e08c92a75c2ddb37792b5e1aaa0bc011c15167e50c1af8ca7842e2025761d93e77860a26ee912ebba2f35e9a7ab183a64357bdd96c06032992b709b80cb601a23d80f282369a1c171f277a92e7ea62b6f5892633ea51fe64d720fe879402ce48065e8ea0ae280236aa32ceae5dcb60585a219b6af236b2afe868fdedb6c8d3674745c303f256c23f25d0a40e322e59bb7dfb0e010d8a83ac8c24f1df31282a3f100fb5d264ace4b17b6b4d763dfbde71b2f68258d7906e4c30346d249dd60f991e3766e0cfdd6aa0b544f71c2a65621b0436cca57ac6d5af12aae07e1346d289539475336a4f4b047f0e2",
+        expectedOutput: "f89766d163f006af7d37beeee64ae9e2b071abb64fe2e2fb36e8e49ee7b5b061",
+        recipeConfig: [
+            {
+                "op": "From Hex",
+                "args": ["Auto"]
+            },
+            {
+                "op": "RSA Decrypt",
+                "args": [PEM_PRIV_2048, "", "RSA-OAEP", "SHA-256"]
+            },
+            {
+                "op": "To Hex",
+                "args": ["None", 0]
+            }
+        ]
+    },
+    {
         name: "RSA Encrypt/Decrypt: RSA-OAEP/SHA-1, nothing",
         input: "",
         expectedOutput: "",


### PR DESCRIPTION
**Description**
Makes RSA Encrypt and RSA Decrypt binary-safe by representing encrypted and decrypted data as byte arrays. This allows `From Hex -> RSA Decrypt` to handle arbitrary RSA-OAEP ciphertext and decrypted binary keys without UTF-8 coercion.

**Existing Issue**
Addresses #2436.

**Screenshots**
Not applicable.

**Test Coverage**
- Added a binary RSA-OAEP/SHA-256 `From Hex -> RSA Decrypt -> To Hex` regression.
- 2310/2310 operation tests pass.
- ESLint passes for the changed operation and test files.
- `git diff --check` passes.
