### PR TITLE
Clarify Radix-64 alphabet label

### DIFF
--- a/AI_MARKER
+++ b/AI_MARKER
@@ -1,0 +1,1 @@
+Prepared for manual review before pull request submission.

--- a/src/core/lib/Base64.mjs
+++ b/src/core/lib/Base64.mjs
@@ -170,7 +170,7 @@ export const ALPHABET_OPTIONS = [
     {name: "XML: A-Za-z0-9_.", value: "A-Za-z0-9_."},
     {name: "y64: A-Za-z0-9._-", value: "A-Za-z0-9._-"},
     {name: "z64: 0-9a-zA-Z+/=", value: "0-9a-zA-Z+/="},
-    {name: "Radix-64 (RFC 4880): 0-9A-Za-z+/=", value: "0-9A-Za-z+/="},
+    {name: "Radix-64: 0-9A-Za-z+/=", value: "0-9A-Za-z+/="},
     {name: "Uuencoding: [space]-_", value: " -_"},
     {name: "Xxencoding: +-0-9A-Za-z", value: "+\\-0-9A-Za-z"},
     {name: "BinHex: !-,-0-689@A-NP-VX-Z[`a-fh-mp-r", value: "!-,-0-689@A-NP-VX-Z[`a-fh-mp-r"},


### PR DESCRIPTION
**Description**
Removes the RFC 4880 attribution from the plain Radix-64 alphabet option. RFC 4880 ASCII armor includes additional OpenPGP framing and CRC-24 behavior, while this option only selects the Base64-compatible alphabet.

**Existing Issue**
Addresses #1893.

**Screenshots**
Not applicable.

**Test Coverage**
- `npx eslint src/core/lib/Base64.mjs`: passed.
- `git diff --check`: passed.
