### PR TITLE
Add line width option to To Base64

### DIFF
--- a/AI_MARKER
+++ b/AI_MARKER
@@ -1,0 +1,1 @@
+Prepared for manual review before pull request submission.

--- a/src/core/operations/ToBase64.mjs
+++ b/src/core/operations/ToBase64.mjs
@@ -20,7 +20,7 @@ class ToBase64 extends Operation {
 
         this.name = "To Base64";
         this.module = "Default";
-        this.description = "Base64 is a notation for encoding arbitrary byte data using a restricted set of symbols that can be conveniently used by humans and processed by computers.<br><br>This operation encodes raw data into an ASCII Base64 string.<br><br>e.g. <code>hello</code> becomes <code>aGVsbG8=</code>";
+        this.description = "Base64 is a notation for encoding arbitrary byte data using a restricted set of symbols that can be conveniently used by humans and processed by computers.<br><br>This operation encodes raw data into an ASCII Base64 string. Set Line width to a positive value to wrap the output; 0 leaves it unwrapped.<br><br>e.g. <code>hello</code> becomes <code>aGVsbG8=</code>";
         this.infoURL = "https://wikipedia.org/wiki/Base64";
         this.inputType = "ArrayBuffer";
         this.outputType = "string";
@@ -29,6 +29,11 @@ class ToBase64 extends Operation {
                 name: "Alphabet",
                 type: "editableOption",
                 value: ALPHABET_OPTIONS
+            },
+            {
+                name: "Line width",
+                type: "number",
+                value: 0
             }
         ];
     }
@@ -40,7 +45,18 @@ class ToBase64 extends Operation {
      */
     run(input, args) {
         const alphabet = args[0];
-        return toBase64(input, alphabet);
+        const lineWidth = Math.floor(args[1]);
+        const output = toBase64(input, alphabet);
+
+        if (!Number.isFinite(lineWidth) || lineWidth <= 0) {
+            return output;
+        }
+
+        const lines = [];
+        for (let i = 0; i < output.length; i += lineWidth) {
+            lines.push(output.slice(i, i + lineWidth));
+        }
+        return lines.join("\n");
     }
 
     /**

--- a/tests/operations/tests/Base64.mjs
+++ b/tests/operations/tests/Base64.mjs
@@ -51,6 +51,28 @@ TestRegister.addTests([
         ],
     },
     {
+        name: "To Base64: line width",
+        input: "Hello, World!",
+        expectedOutput: "SGVsbG8s\nIFdvcmxk\nIQ==",
+        recipeConfig: [
+            {
+                op: "To Base64",
+                args: ["A-Za-z0-9+/=", 8],
+            },
+        ],
+    },
+    {
+        name: "To Base64: zero line width leaves output unwrapped",
+        input: "Hello, World!",
+        expectedOutput: "SGVsbG8sIFdvcmxkIQ==",
+        recipeConfig: [
+            {
+                op: "To Base64",
+                args: ["A-Za-z0-9+/=", 0],
+            },
+        ],
+    },
+    {
         name: "To Base64: UTF-8",
         input: "ნუ პანიკას",
         expectedOutput: "4YOc4YOjIOGDnuGDkOGDnOGDmOGDmeGDkOGDoQ==",


### PR DESCRIPTION
**Description**
Adds an optional Line width argument to To Base64. A positive value wraps the encoded output at that width, while 0 or an omitted argument preserves the existing unwrapped output.

**Existing Issue**
Addresses #1965.

**Screenshots**
Not applicable.

**Test Coverage**
- Added wrapped-output and zero-width regression cases to the Base64 operation tests.
- Focused wrapped and legacy one-argument checks: passed.
- ESLint and `git diff --check`: passed.
- Full operation suite reached 2310/2311 passing; the only failure was the unrelated `Register: RC4 key` generated dependency/config issue.
